### PR TITLE
Fix write history crash

### DIFF
--- a/src/protocol/telnet/session.d
+++ b/src/protocol/telnet/session.d
@@ -294,7 +294,11 @@ private:
             return;
         }
 
-        size_t fileSize = m_historyFile.get_size();
+        ulong size = m_historyFile.get_size();
+
+        // TODO: maybe we should specify a "MAX_ALLOC" or something...
+        assert(size <= size_t.max, "File too large to read into memory");
+        size_t fileSize = cast(size_t)size;
 
         char[] mem = cast(char[])allocator.alloc(fileSize);
         if (mem == null)

--- a/src/urt/string/package.d
+++ b/src/urt/string/package.d
@@ -166,20 +166,28 @@ inout(char)[] takeLine(ref inout(char)[] s) pure nothrow @nogc
 	return t;
 }
 
-inout(char)[] split(char Separator)(ref inout(char)[] s)
+inout(char)[] split(char Separator, bool HandleQuotes = true)(ref inout(char)[] s)
 {
-	int inQuotes = 0;
+	static if (HandleQuotes)
+		int inQuotes = 0;
+	else
+		enum inQuotes = false;
+
 	size_t i = 0;
 	for (; i < s.length; ++i)
 	{
 		if (s[i] == Separator && !inQuotes)
 			break;
-		if (s[i] == '"' && !(inQuotes & 0x6))
-			inQuotes = 1 - inQuotes;
-		else if (s[i] == '\'' && !(inQuotes & 0x5))
-			inQuotes = 2 - inQuotes;
-		else if (s[i] == '`' && !(inQuotes & 0x3))
-			inQuotes = 4 - inQuotes;
+
+		static if (HandleQuotes)
+		{
+			if (s[i] == '"' && !(inQuotes & 0x6))
+				inQuotes = 1 - inQuotes;
+			else if (s[i] == '\'' && !(inQuotes & 0x5))
+				inQuotes = 2 - inQuotes;
+			else if (s[i] == '`' && !(inQuotes & 0x3))
+				inQuotes = 4 - inQuotes;
+		}
 	}
 	inout(char)[] t = s[0 .. i].trimBack;
 	s = i < s.length ? s[i+1 .. $].trimFront : null;


### PR DESCRIPTION
Fixed a crash where the file ended on a '\r' (checked the following byte for '\n' without checking the length).

Simplified the implementation using `split`, which splits strings on separators.
Had to tweak split with an option to skip the quotes check.