### PR TITLE
Map accepts compatible types for key comparisons.

### DIFF
--- a/src/urt/algorithm.d
+++ b/src/urt/algorithm.d
@@ -8,14 +8,14 @@ version = SmallSize;
 nothrow @nogc:
 
 
-int compare(T, U)(auto ref T a, auto ref U b)
+auto compare(T, U)(auto ref T a, auto ref U b)
 {
     static if (__traits(compiles, lvalueOf!T.opCmp(lvalueOf!U)))
         return a.opCmp(b);
     else static if (__traits(compiles, lvalueOf!U.opCmp(lvalueOf!T)))
         return -b.opCmp(a);
     else
-        return a < b ? -1 : a > b ? 1 : 0;
+        return a < b ? -1 : (a > b ? 1 : 0);
 }
 
 size_t binarySearch(alias pred = void, T, Cmp...)(T[] arr, auto ref Cmp cmpArgs)


### PR DESCRIPTION
Previously, the `Map` methods that accepted keys for lookup required arguments of `KeyType`, but it should be possible to lookup given any type which has a valid comparison with `KeyType`.
For example; If the key type is `String`, which allocates and owns the string, you don't want to allocate and copy a new `String` just for comparison; `Map` should accept a `const char[]` for comparison in this case.