### PR TITLE
Add packet capture and a pcap writer

### DIFF
--- a/sampledb.vcxproj
+++ b/sampledb.vcxproj
@@ -62,6 +62,7 @@
     <DCompile Include="src\manager\instance.d" />
     <DCompile Include="src\manager\log.d" />
     <DCompile Include="src\manager\package.d" />
+    <DCompile Include="src\manager\pcap.d" />
     <DCompile Include="src\manager\plugin.d" />
     <DCompile Include="src\manager\sampler.d" />
     <DCompile Include="src\manager\subscriber.d" />

--- a/sampledb.vcxproj.filters
+++ b/sampledb.vcxproj.filters
@@ -507,6 +507,9 @@
     <DCompile Include="src\urt\system.d">
       <Filter>src\urt</Filter>
     </DCompile>
+    <DCompile Include="src\manager\pcap.d">
+      <Filter>src\manager</Filter>
+    </DCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include=".gitignore" />

--- a/src/manager/pcap.d
+++ b/src/manager/pcap.d
@@ -1,0 +1,383 @@
+module manager.pcap;
+
+import urt.array;
+import urt.file;
+import urt.lifetime;
+import urt.log;
+import urt.map;
+import urt.string;
+import urt.system;
+import urt.time;
+import urt.util : alignUp, swap;
+
+import manager.plugin;
+import manager.console;
+
+import router.iface;
+
+nothrow @nogc:
+
+
+enum LinkType : ushort
+{
+    ETHERNET = 1, // IEEE 802.3 Ethernet
+    RAW = 101, // Raw IP; the packet begins with an IPv4 or IPv6 header, with the version field of the header indicating whether it's an IPv4 or IPv6 header
+    IPV4 = 228, // Raw IPv4; the packet begins with an IPv4 header
+    IPV6 = 229, // Raw IPv6; the packet begins with an IPv6 header
+    IEEE802_11 = 105, // IEEE 802.11 wireless LAN
+    IEEE802_11_RADIOTAP = 127, // Radiotap link-layer information followed by an 802.11 header
+    IEEE802_15_4_WITHFCS = 195, // IEEE 802.15.4 Low-Rate Wireless Networks, with each packet having the FCS at the end of the frame
+    IEEE802_15_4_NONASK_PHY = 215, // IEEE 802.15.4 Low-Rate Wireless Networks, with each packet having the FCS at the end of the frame, and with the PHY-level data for the O-QPSK, BPSK, GFSK, MSK, and RCC DSS BPSK PHYs (4 octets of 0 as preamble, one octet of SFD, one octet of frame length + reserved bit) preceding the MAC-layer data (starting with the frame control field)
+    IEEE802_15_4_NOFCS = 230, // IEEE 802.15.4 Low-Rate Wireless Network, without the FCS at the end of the frame
+    IEEE802_15_4_TAP = 283, // IEEE 802.15.4 Low-Rate Wireless Networks, with a pseudo-header (https://github.com/jkcko/ieee802.15.4-tap/blob/master/IEEE%20802.15.4%20TAP%20Link%20Type%20Specification.pdf) containing TLVs with metadata preceding the 802.15.4 header
+    CAN20B = 190, // Controller Area Network (CAN) v. 2.0B
+    CAN_SOCKETCAN = 227, // CAN (Controller Area Network) frames, with a pseudo-header (https://www.tcpdump.org/linktypes/LINKTYPE_CAN_SOCKETCAN.html) followed by the frame payload
+    I2C_LINUX = 209, // Linux I2C packets (https://www.tcpdump.org/linktypes/LINKTYPE_I2C_LINUX.html)
+    LORATAP = 270 // LoRaTap pseudo-header (https://github.com/eriknl/LoRaTap/blob/master/README.md), followed by the payload, which is typically the PHYPayload from the LoRaWan specification
+}
+
+struct PcapInterface
+{
+nothrow @nogc:
+
+    bool openFile(const char[] filename, bool overwrite = false)
+    {
+        if (pcapFile.is_open)
+            return false;
+
+        // open file
+        Result r = pcapFile.open(filename, overwrite ? FileOpenMode.WriteTruncate : FileOpenMode.WriteAppend, FileOpenFlags.Sequential);
+        if (r != Result.Success)
+            return false;
+
+        startOffset = pcapFile.get_pos();
+
+        // write section header...
+        auto buffer = Array!ubyte(Reserve, 256);
+
+        SectionHeaderBlock shb;
+        buffer ~= shb.asBytes;
+
+        SystemInfo sysInfo = getSysInfo();
+        buffer.writeOption(2, sysInfo.processor); // shb_hardware
+        buffer.writeOption(3, sysInfo.osName); // shb_os
+        buffer.writeOption(4, "ENMS"); // shb_userappl
+        buffer.writeOption(0, null);
+
+        buffer.writeBlockLen();
+        write(buffer[]);
+
+        return true;
+    }
+
+    bool openRemote(const char[] remotehost)
+    {
+        return false;
+    }
+
+    void close()
+    {
+        // update section header length
+        ulong endOffset = pcapFile.get_pos();
+        pcapFile.set_pos(startOffset + SectionHeaderBlock.sectionLength.offsetof);
+        size_t written;
+        pcapFile.write((endOffset - startOffset).asBytes, written);
+        assert(written == 8);
+
+        // close file
+        pcapFile.close();
+    }
+
+    bool enable(bool enable)
+        => enabled.swap(enable);
+
+    void setBufferParams(Duration maxTime = 0.seconds, size_t maxBytes = 0)
+    {
+        maxBufferTime = maxTime;
+        maxBufferBytes = maxBytes;
+    }
+
+    void subscribeInterface(BaseInterface iface)
+    {
+        auto filter = PacketFilter(direction: cast(PacketDirection)(PacketDirection.Incoming | PacketDirection.Outgoing));
+
+        iface.subscribe(&packetHandler, filter);
+    }
+
+    void flush()
+    {
+        lastUpdate = getTime();
+
+        foreach (ref InterfacePacketBuffer ib; packetBuffers)
+        {
+            if (ib.packetBuffer.empty)
+                continue;
+
+            write(ib.packetBuffer[]);
+            ib.packetBuffer.clear();
+        }
+    }
+
+    void write(const void[] data)
+    {
+        // TODO: should we actually just bail? maybe something more particular?
+        if (!pcapFile.is_open)
+            return;
+
+        size_t written;
+        pcapFile.write(data, written);
+        assert(written == data.length, "Write length wrong! ... what to do?");
+        // TODO: what to do? try again?
+    }
+
+    void update()
+    {
+        if (getTime() - lastUpdate < maxBufferTime)
+            return;
+        flush();
+    }
+
+private:
+
+    String name;
+    Map!(BaseInterface, InterfacePacketBuffer) packetBuffers;
+
+    ulong startOffset;
+    MonoTime lastUpdate;
+
+    File pcapFile;
+
+    uint nextInterfaceIndex = 0;
+    bool enabled = true;
+
+    Duration maxBufferTime;
+    size_t maxBufferBytes;
+
+    struct InterfacePacketBuffer
+    {
+        BaseInterface iface;
+        int index = -1;
+        ushort linkType;
+
+        Array!ubyte packetBuffer;
+    }
+
+    void packetHandler(ref const Packet p, BaseInterface i, PacketDirection dir, void*)
+    {
+        writePacket(p, i, dir);
+    }
+
+    void writePacket(ref const Packet p, BaseInterface i, PacketDirection dir)
+    {
+        import router.iface.zigbee;
+
+        if (!enabled)
+            return;
+
+        InterfacePacketBuffer* ib = packetBuffers.get(i);
+        if (!ib)
+        {
+            ib = packetBuffers.insert(i, InterfacePacketBuffer(i, nextInterfaceIndex++, i.pcapType()));
+
+            // write IDB header...
+            auto buffer = Array!ubyte(Reserve, 256);
+
+            InterfaceDescriptionBlock idb;
+            idb.linkType = ib.linkType;
+            buffer ~= idb.asBytes;
+            buffer.writeOption(2, i.name[]); // if_name
+            if (auto z = cast(ZigbeeInterface)i)
+                buffer.writeOption(7, z.eui[]); // if_EUIaddr
+            else
+                buffer.writeOption(6, i.mac.b[]); // if_MACaddr
+            ubyte ts = 9; // 6 = microseconds, 9 = nanoseconds
+            buffer.writeOption(9, (&ts)[0..1]); // if_tsresol
+            buffer.writeOption(0, null);
+            buffer.writeBlockLen();
+
+            write(buffer[]);
+            buffer.clear();
+        }
+
+        size_t packetOffset = ib.packetBuffer.length;
+        ulong timestamp = unixTimeNs(p.creationTime);
+
+        // write packet block...
+        EnhancedPacketBlock epb;
+        epb.interfaceID = ib.index;
+        epb.timestampHigh = timestamp >> 32;
+        epb.timestampLow = cast(uint)timestamp;
+//        epb.capturedLength = cast(uint)p.data.length; // write it later
+//        epb.originalLength = cast(uint)p.data.length;
+        ib.packetBuffer ~= epb.asBytes;
+        size_t capturedLengthOffset = ib.packetBuffer.length - 8;
+
+        uint packetLen;
+        i.pcapWrite(p, dir, (const void[] packetData) {
+            packetLen += cast(uint)packetData.length;
+            ib.packetBuffer ~= cast(const ubyte[])packetData;
+        });
+        ib.packetBuffer.alignBlock();
+
+        // write capture length...
+        ib.packetBuffer[][capturedLengthOffset .. capturedLengthOffset + 4] = packetLen.asBytes;
+        ib.packetBuffer[][capturedLengthOffset + 4 .. capturedLengthOffset + 8] = packetLen.asBytes;
+
+        // write packet flags:
+        uint flags = (dir == PacketDirection.Incoming) ? 1 : 2; // 01 = inbound, 10 = outbound
+
+        // 2-4 Reception type (000 = not specified, 001 = unicast, 010 = multicast, 011 = broadcast, 100 = promiscuous)
+        if (p.dst.isBroadcast)
+            flags |= 3 << 2;
+        else if (p.dst.isMulticast)
+            flags |= 2 << 2;
+        else
+            flags |= 1 << 2;
+        ib.packetBuffer.writeOption(2, flags.asBytes); // epb_flags
+
+        // epb_dropcount
+        // epb_packetid
+
+        ib.packetBuffer.writeOption(0, null);
+        ib.packetBuffer.writeBlockLen(packetOffset);
+
+        if (ib.packetBuffer.length > maxBufferBytes)
+            flush();
+    }
+}
+
+struct PcapServer
+{
+    // TODO: host a pcap server that other devices can remote in to
+    // forward the pcap stream to a PcapInterface...
+
+    // this is for tiny devices with no storage to log packet captures to a central device
+}
+
+
+class PcapModule : Plugin
+{
+    mixin RegisterModule!"manager.pcap";
+
+    class Instance : Plugin.Instance
+    {
+        mixin DeclareInstance;
+    nothrow @nogc:
+
+        Array!(PcapInterface*) interfaces;
+
+        PcapInterface* findInterface(const(char)[] name)
+        {
+            foreach (PcapInterface* pcap; interfaces)
+                if (pcap.name == name)
+                    return pcap;
+            return null;
+        }
+
+        override void init()
+        {
+            app.console.registerCommand!add("/tools/pcap", this);
+        }
+
+        override void postUpdate()
+        {
+            foreach (PcapInterface* pcap; interfaces)
+                pcap.update();
+        }
+
+        import urt.meta.nullable;
+
+        // /tools/pcap/add command
+        void add(Session session, const(char)[] name, const(char)[] file)
+        {
+            if (name.empty)
+            {
+                session.writeLine("PCAP interface must have a name");
+                return;
+            }
+            foreach (PcapInterface* pcap; interfaces)
+            {
+                if (pcap.name == name)
+                {
+                    session.writeLine("PCAP interface '", name, "' already exists");
+                    return;
+                }
+            }
+            String n = name.makeString(app.allocator);
+
+            PcapInterface* pcap = app.allocator.allocT!PcapInterface();
+            pcap.name = n.move;
+
+            if (!pcap.openFile(file))
+            {
+                writeInfo("Couldn't open PCAP file '", file, "'");
+                app.allocator.freeT(pcap);
+                return;
+            }
+
+            interfaces ~= pcap;
+
+            writeInfo("Create PCAP interface '", name, "' to file: ", file);
+        }
+    }
+}
+
+
+private:
+
+struct SectionHeaderBlock
+{
+    uint type = 0x0A0D0D0A;
+    uint blockLength = 0;
+    uint byteOrderMagic = 0x1A2B3C4D;
+    ushort majorVersion = 1;
+    ushort minorVersion = 0;
+    ulong sectionLength = -1;
+}
+static assert(SectionHeaderBlock.sizeof == 24);
+
+struct InterfaceDescriptionBlock
+{
+    uint type = 0x00000001;
+    uint blockLength = 0;
+    ushort linkType;
+    ushort reserved = 0;
+    uint snapLength = 0;
+}
+static assert(InterfaceDescriptionBlock.sizeof == 16);
+
+struct EnhancedPacketBlock
+{
+    uint type = 0x00000006;
+    uint blockLength = 0;
+    uint interfaceID;
+    uint timestampHigh;
+    uint timestampLow;
+    uint capturedLength;
+    uint originalLength;
+}
+static assert(EnhancedPacketBlock.sizeof == 28);
+
+ubyte[T.sizeof] asBytes(T)(auto ref const T data)
+    => *cast(ubyte[T.sizeof]*)&data;
+
+void writeOption(ref Array!ubyte buffer, ushort option, const void[] data)
+{
+    buffer ~= option.asBytes;
+    buffer ~= (cast(ushort)data.length).asBytes;
+    buffer ~= cast(ubyte[])data;
+    buffer.alignBlock();
+}
+
+void writeBlockLen(ref Array!ubyte buffer, size_t startOffset = 0)
+{
+    uint len = cast(uint)((buffer.length - startOffset) + 4);
+    buffer ~= len.asBytes;
+    buffer[][startOffset + 4 .. startOffset + 8] = len.asBytes; // TODO: what is wrong with array indexing?
+    assert(buffer.length - startOffset == len);
+}
+
+void alignBlock(ref Array!ubyte buffer)
+{
+    buffer.resize(buffer.length.alignUp!4);
+}

--- a/src/protocol/modbus/package.d
+++ b/src/protocol/modbus/package.d
@@ -336,13 +336,13 @@ nothrow @nogc:
         return state;
     }
 
-    void responseHandler(ref const ModbusPDU request, ref ModbusPDU response, MonoTime requestTime, MonoTime responseTime)
+    void responseHandler(ref const ModbusPDU request, ref ModbusPDU response, SysTime requestTime, SysTime responseTime)
     {
         session.writeLine("Response from ", slave[], " in ", (responseTime - requestTime).as!"msecs", "ms: ", toHexString(response.data[1..$], 2, 4, "_ "));
         state = CommandCompletionState.Finished;
     }
 
-    void errorHandler(ModbusErrorType errorType, ref const ModbusPDU request, MonoTime requestTime)
+    void errorHandler(ModbusErrorType errorType, ref const ModbusPDU request, SysTime requestTime)
     {
         Duration reqDuration = getTime() - requestTime;
         if (errorType == ModbusErrorType.Timeout)

--- a/src/protocol/modbus/sampler.d
+++ b/src/protocol/modbus/sampler.d
@@ -170,10 +170,10 @@ private:
         ubyte type;
         ubyte flags; // 1 - in-flight, 2 - constant-sampled, 4 - ...
         ushort sampleTimeMs;
-        MonoTime lastUpdate;
+        SysTime lastUpdate;
     }
 
-    void responseHandler(ref const ModbusPDU request, ref ModbusPDU response, MonoTime requestTime, MonoTime responseTime)
+    void responseHandler(ref const ModbusPDU request, ref ModbusPDU response, SysTime requestTime, SysTime responseTime)
     {
         ubyte kind = request.functionCode == FunctionCode.ReadHoldingRegisters ? 4 :
                      request.functionCode == FunctionCode.ReadInputRegisters ? 3 :
@@ -349,7 +349,7 @@ private:
         }
     }
 
-    void errorHandler(ModbusErrorType errorType, ref const ModbusPDU request, MonoTime requestTime)
+    void errorHandler(ModbusErrorType errorType, ref const ModbusPDU request, SysTime requestTime)
     {
         ubyte kind = request.functionCode == FunctionCode.ReadHoldingRegisters ? 4 :
                      request.functionCode == FunctionCode.ReadInputRegisters ? 3 :
@@ -377,7 +377,7 @@ private:
         }
     }
 
-    void snoopHandler(ref const MACAddress server, ref const ModbusPDU request, ref ModbusPDU response, MonoTime requestTime, MonoTime responseTime)
+    void snoopHandler(ref const MACAddress server, ref const ModbusPDU request, ref ModbusPDU response, SysTime requestTime, SysTime responseTime)
     {
         // check it's a response from the server we're interested in
         if (server != this.server)

--- a/src/protocol/tesla/master.d
+++ b/src/protocol/tesla/master.d
@@ -324,7 +324,7 @@ nothrow @nogc:
         iface.send(c.mac, message[], EtherType.ENMS, ENMS_SubType.TeslaTWC);
     }
 
-    void incomingPacket(ref const Packet p, BaseInterface iface, void* userData) nothrow @nogc
+    void incomingPacket(ref const Packet p, BaseInterface iface, PacketDirection dir, void* userData) nothrow @nogc
     {
         TWCMessage msg;
         if (parseTWCMessage(cast(ubyte[])p.data, msg))

--- a/src/protocol/zigbee/client.d
+++ b/src/protocol/zigbee/client.d
@@ -29,7 +29,7 @@ nothrow @nogc:
     }
 
 private:
-    void incomingPacket(ref const Packet p, BaseInterface iface, void* userData) nothrow @nogc
+    void incomingPacket(ref const Packet p, BaseInterface iface, PacketDirection dir, void* userData) nothrow @nogc
     {
     }
 }

--- a/src/protocol/zigbee/coordinator.d
+++ b/src/protocol/zigbee/coordinator.d
@@ -29,7 +29,7 @@ nothrow @nogc:
     }
 
 private:
-    void incomingPacket(ref const Packet p, BaseInterface iface, void* userData) nothrow @nogc
+    void incomingPacket(ref const Packet p, BaseInterface iface, PacketDirection dir, void* userData) nothrow @nogc
     {
     }
 }

--- a/src/router/iface/packet.d
+++ b/src/router/iface/packet.d
@@ -59,7 +59,7 @@ nothrow @nogc:
         return r;
     }
 
-    MonoTime creationTime; // time received, or time of call to send
+    SysTime creationTime; // time received, or time of call to send
     MACAddress src;
     MACAddress dst;
     uint vlan;

--- a/src/router/stream/package.d
+++ b/src/router/stream/package.d
@@ -37,7 +37,7 @@ enum StreamOptions
 
 struct StreamStatus
 {
-    MonoTime linkStatusChangeTime;
+    SysTime linkStatusChangeTime;
     bool linkStatus;
     int linkDowns;
     ulong sendBytes;

--- a/src/router/stream/tcp.d
+++ b/src/router/stream/tcp.d
@@ -36,7 +36,7 @@ nothrow @nogc:
             assert(0);
         }
         remote = addrInfo.address;
-        status.linkStatusChangeTime = getTime();
+        status.linkStatusChangeTime = getSysTime();
         update();
     }
 
@@ -45,13 +45,13 @@ nothrow @nogc:
         super(name.move, "tcp-client", options);
 
         remote = address;
-        status.linkStatusChangeTime = getTime();
+        status.linkStatusChangeTime = getSysTime();
         update();
     }
 
     override bool connect()
     {
-        lastRetry = MonoTime();
+        lastRetry = SysTime();
         update();
         return true;
     }
@@ -200,7 +200,7 @@ nothrow @nogc:
             return;
         }
 
-        MonoTime now = getTime();
+        SysTime now = getSysTime();
 
         // if the socket is invalid, we'll attempt to initiate a connection...
         if (socket == Socket.invalid)
@@ -297,7 +297,7 @@ nothrow @nogc:
         socket = Socket.invalid;
         live = false;
         status.linkStatus = false;
-        status.linkStatusChangeTime = getTime();
+        status.linkStatusChangeTime = getSysTime();
         ++status.linkDowns;
 
         writeWarning("TCP stream '", name, "' link down.");
@@ -308,7 +308,7 @@ nothrow @nogc:
 //private:
     InetAddress remote;
     Socket socket;
-    MonoTime lastRetry;
+    SysTime lastRetry;
 //    TCPServer reverseConnectServer;
 
     bool keepEnable = false;

--- a/src/router/tesla/twc.d
+++ b/src/router/tesla/twc.d
@@ -375,8 +375,6 @@ class TeslaWallConnector
 
 	void poll()
 	{
-		MonoTime now = getTime();
-
 		ubyte[1024] buffer = void;
 		ptrdiff_t bytes = stream.read(buffer);
 		if (bytes == Socket.ERROR)

--- a/src/urt/array.d
+++ b/src/urt/array.d
@@ -575,6 +575,9 @@ nothrow @nogc:
 
     void resize(size_t count)
     {
+        if (count == _length)
+            return;
+
         if (count < _length)
         {
             static if (is(T == class) || is(T == interface))

--- a/src/urt/endian.d
+++ b/src/urt/endian.d
@@ -158,13 +158,13 @@ alias bigEndianToNative(T) = endianToNative!(T, false);
 alias littleEndianToNative(T) = endianToNative!(T, true);
 
 
-pragma(inline, true) ubyte[1] nativeToEndian(bool little, T)(T u8)
+pragma(inline, true) ubyte[1] nativeToEndian(bool little, T)(const T u8)
     if (is(T == ubyte) || is(T == byte) || is(T == bool))
 {
     return (cast(ubyte*)&u8)[0..1];
 }
 
-ubyte[2] nativeToEndian(bool little, T)(T u16)
+ubyte[2] nativeToEndian(bool little, T)(const T u16)
     if (is(T == ushort) || is(T == short) || is(T == wchar))
 {
     static if (SupportUnalignedLoadStore && IsLittleEndian == little)
@@ -189,7 +189,7 @@ ubyte[2] nativeToEndian(bool little, T)(T u16)
     }
 }
 
-ubyte[4] nativeToEndian(bool little, T)(T u32)
+ubyte[4] nativeToEndian(bool little, T)(const T u32)
     if (is(T == uint) || is(T == int) || is(T == dchar) || is(T == float))
 {
     static if (SupportUnalignedLoadStore && IsLittleEndian == little)
@@ -218,7 +218,7 @@ ubyte[4] nativeToEndian(bool little, T)(T u32)
     }
 }
 
-ubyte[8] nativeToEndian(bool little, T)(T u64)
+ubyte[8] nativeToEndian(bool little, T)(const T u64)
     if (is(T == ulong) || is(T == long) || is(T == double))
 {
     static if (SupportUnalignedLoadStore && IsLittleEndian == little)
@@ -247,13 +247,13 @@ ubyte[8] nativeToEndian(bool little, T)(T u64)
     }
 }
 
-ubyte[T.sizeof] nativeToEndian(bool little, T)(T data)
+ubyte[T.sizeof] nativeToEndian(bool little, T)(const T data)
     if (isEnum!T)
 {
     return nativeToEndian!little(cast(enumType!T)data);
 }
 
-ubyte[T.sizeof] nativeToEndian(bool little, T)(auto ref T data)
+ubyte[T.sizeof] nativeToEndian(bool little, T)(auto ref const T data)
     if (is(T == U[N], U, size_t N))
 {
     static assert(is(T == U[N], U, size_t N) && !is(U == class) && !is(U == interface) && !is(U == V*, V), T.stringof ~ " is not POD");
@@ -271,7 +271,7 @@ ubyte[T.sizeof] nativeToEndian(bool little, T)(auto ref T data)
     return buffer;
 }
 
-ubyte[T.sizeof] nativeToEndian(bool little, T)(auto ref T data)
+ubyte[T.sizeof] nativeToEndian(bool little, T)(auto ref const T data)
     if (is(T == struct))
 {
     // assert that T is POD
@@ -290,24 +290,24 @@ ubyte[T.sizeof] nativeToEndian(bool little, T)(auto ref T data)
     return buffer;
 }
 
-ubyte[T.sizeof] nativeToEndian(bool little, T)(auto ref T data)
+ubyte[T.sizeof] nativeToEndian(bool little, T)(auto ref const T data)
     if (is(T == U[], U) || is(T == U*, U) || is(T == class) || is(T == interface))
 {
     static assert(false, "Invalid call for " ~ T.stringof);
 }
 
-ubyte[T.sizeof] nativeToBigEndian(T)(auto ref T data)
+ubyte[T.sizeof] nativeToBigEndian(T)(auto ref const T data)
     => nativeToEndian!false(data);
-ubyte[T.sizeof] nativeToLittleEndian(T)(auto ref T data)
+ubyte[T.sizeof] nativeToLittleEndian(T)(auto ref const T data)
     => nativeToEndian!true(data);
 
 
-void storeBigEndian(T)(T* target, T val)
+void storeBigEndian(T)(T* target, const T val)
     if (isSomeInt!T || is(T == float))
 {
     (cast(ubyte*)target)[0..T.sizeof] = nativeToBigEndian(val);
 }
-void storeLittleEndian(T)(T* target, T val)
+void storeLittleEndian(T)(T* target, const T val)
     if (isSomeInt!T || is(T == float))
 {
     (cast(ubyte*)target)[0..T.sizeof] = nativeToLittleEndian(val);

--- a/src/urt/file.d
+++ b/src/urt/file.d
@@ -5,6 +5,8 @@ import urt.result;
 import urt.string.uni;
 import urt.time;
 
+public import urt.result;
+
 alias SystemTime = void;
 
 version(Windows)

--- a/src/urt/time.d
+++ b/src/urt/time.d
@@ -38,10 +38,10 @@ nothrow @nogc:
             return MonoTime(ticks - bootFileTime);
     }
 
-    bool opEquals(MonoTime b) const pure
+    bool opEquals(Time!clock b) const pure
         => ticks == b.ticks;
 
-    int opCmp(MonoTime b) const pure
+    int opCmp(Time!clock b) const pure
         => ticks < b.ticks ? -1 : ticks > b.ticks ? 1 : 0;
 
     Duration opBinary(string op, Clock c)(Time!c rhs) const pure if (op == "-")
@@ -365,6 +365,14 @@ Duration appTime(MonoTime t)
     => t - startTime;
 Duration appTime(SysTime t)
     => cast(MonoTime)t - startTime;
+
+ulong unixTimeNs(SysTime t)
+{
+    version (Windows)
+        return (t.ticks - 116444736000000000UL) * 100UL;
+    else
+        static assert(false, "TODO");
+}
 
 Duration abs(Duration d) pure
     => Duration(d.ticks < 0 ? -d.ticks : d.ticks);

--- a/src/urt/util.d
+++ b/src/urt/util.d
@@ -69,16 +69,35 @@ T nextPowerOf2(T)(T x)
 	return cast(T)(x + 1);
 }
 
+T alignDown(size_t alignment, T)(T value)
+    if (isSomeInt!T || is(T == U*, U))
+{
+    return cast(T)(cast(size_t)value & ~(alignment - 1));
+}
+
 T alignDown(T)(T value, size_t alignment)
 	if (isSomeInt!T || is(T == U*, U))
 {
 	return cast(T)(cast(size_t)value & ~(alignment - 1));
 }
 
+T alignUp(size_t alignment, T)(T value)
+    if (isSomeInt!T || is(T == U*, U))
+{
+    return cast(T)((cast(size_t)value + (alignment - 1)) & ~(alignment - 1));
+}
+
 T alignUp(T)(T value, size_t alignment)
 	if (isSomeInt!T || is(T == U*, U))
 {
 	return cast(T)((cast(size_t)value + (alignment - 1)) & ~(alignment - 1));
+}
+
+bool isAligned(size_t alignment, T)(T value)
+    if (isSomeInt!T || is(T == U*, U))
+{
+    static assert(T.sizeof > size_t.sizeof, "TODO");
+    return (cast(size_t)value & (alignment - 1)) == 0;
 }
 
 bool isAligned(T)(T value, size_t alignment)


### PR DESCRIPTION
DEPENDS ON:
- [x] #23
- [x] #52 
- [x] #59

This started as a nice contained pcap file writer, ...but then it kinda exploded!

I need a couple of extra utils, and a couple of general fixes.
But most annoying-ly, when writing out the packets to file, I realised that the pcap expects packet timestamps in a common time base... and then I realised I was using `MonoTime` (performance counter) for almost everything!
I need to use `SysTime` for real timestamps, and so I had to change timestamp keeping everywhere!

I also had to update the interface subscriber to also emit outgoing packets, not just incoming as it were...