### PR TITLE
HTTP state machine

### DIFF
--- a/conf/startup.conf
+++ b/conf/startup.conf
@@ -134,6 +134,7 @@ add name=goodwe_can stream=can.1 protocol=ebyte
 #------------------------------------------------------------------------------------------
 # Other runtime stuff
 
+/protocol/http/server add name=webserver port=8080
 /protocol/telnet/server add name=console port=23
 /protocol/mdns/server add name=mdns
 

--- a/src/protocol/http/client.d
+++ b/src/protocol/http/client.d
@@ -39,7 +39,7 @@ nothrow @nogc:
         this.parser = HTTPParser(&dispatchMessage);
     }
 
-    HTTPMessage* request(HTTPMethod method, const(char)[] resource, int delegate(ref const HTTPMessage) nothrow @nogc responseHandler, const void[] content = null, HTTPParam[] params = null, HTTPParam[] additionalHeaders = null, String username = null, String password = null)
+    HTTPMessage* request(HTTPMethod method, const(char)[] resource, HTTPMessageHandler responseHandler, const void[] content = null, HTTPParam[] params = null, HTTPParam[] additionalHeaders = null, String username = null, String password = null)
     {
         HTTPMessage* request = defaultAllocator().allocT!HTTPMessage();
         request.httpVersion = serverVersion;
@@ -51,7 +51,7 @@ nothrow @nogc:
         request.headers = additionalHeaders.move;
         request.queryParams = params.move;
         request.responseHandler = responseHandler;
-        request.requestTime = getTime();
+        request.requestTime = getSysTime();
 
         if (requests.length == 0) // OR CONCURRENT REQUESTS...
             sendRequest(*request);

--- a/src/protocol/http/server.d
+++ b/src/protocol/http/server.d
@@ -21,9 +21,11 @@ nothrow @nogc:
 class HTTPServer
 {
 nothrow @nogc:
-    const String name;
 
     alias RequestHandler = int delegate(ref const HTTPMessage, Stream stream) nothrow @nogc;
+
+    const String name;
+
     this(String name, BaseInterface , ushort port, RequestHandler requestHandler)
     {
         server = defaultAllocator().allocT!TCPServer(name.toString().makeString(defaultAllocator), port, &acceptConnection, null);


### PR DESCRIPTION
Convert the HTTP message parser logic to a more well-structured state machine, which is easier to follow.

Also added console commands to create a `HTTPClient`, and perform a HTTP request.