### PR TITLE
Start migrating the app to a tick-less kernel

### DIFF
--- a/openwatt.vcxproj
+++ b/openwatt.vcxproj
@@ -1059,6 +1059,7 @@
     <DCompile Include="third_party\urt\src\urt\internal\stdc\errno.d" />
     <DCompile Include="third_party\urt\src\urt\internal\stdc\stdio.d" />
     <DCompile Include="third_party\urt\src\urt\internal\stdc\stdlib.d" />
+    <DCompile Include="third_party\urt\src\urt\internal\sys\freertos\package.d" />
     <DCompile Include="third_party\urt\src\urt\internal\sys\windows\basetsd.d" />
     <DCompile Include="third_party\urt\src\urt\internal\sys\windows\basetyps.d" />
     <DCompile Include="third_party\urt\src\urt\internal\sys\windows\ntdef.d" />
@@ -1124,6 +1125,14 @@
     <DCompile Include="third_party\urt\src\urt\string\string.d" />
     <DCompile Include="third_party\urt\src\urt\string\tailstring.d" />
     <DCompile Include="third_party\urt\src\urt\string\uni.d" />
+    <DCompile Include="third_party\urt\src\urt\sync\critical.d" />
+    <DCompile Include="third_party\urt\src\urt\sync\event.d" />
+    <DCompile Include="third_party\urt\src\urt\sync\mpmc.d" />
+    <DCompile Include="third_party\urt\src\urt\sync\mpsc.d" />
+    <DCompile Include="third_party\urt\src\urt\sync\mutex.d" />
+    <DCompile Include="third_party\urt\src\urt\sync\semaphore.d" />
+    <DCompile Include="third_party\urt\src\urt\sync\spinlock.d" />
+    <DCompile Include="third_party\urt\src\urt\sync\spsc.d" />
     <DCompile Include="third_party\urt\src\urt\system.d" />
     <DCompile Include="third_party\urt\src\urt\thread.d" />
     <DCompile Include="third_party\urt\src\urt\time.d" />

--- a/openwatt.vcxproj.filters
+++ b/openwatt.vcxproj.filters
@@ -205,6 +205,9 @@
     <Filter Include="third_party\urt\internal\sys">
       <UniqueIdentifier>{6aed1c5f-ebc2-4e3e-8b87-f6f39b96eb12}</UniqueIdentifier>
     </Filter>
+    <Filter Include="third_party\urt\internal\sys\freertos">
+      <UniqueIdentifier>{a8b9c0d1-e2f3-4a5b-9c8d-7e6f5d4c3b2a}</UniqueIdentifier>
+    </Filter>
     <Filter Include="third_party\urt\internal\sys\winows">
       <UniqueIdentifier>{51839fa1-68ac-4d92-b82c-33642d718550}</UniqueIdentifier>
     </Filter>
@@ -219,6 +222,9 @@
     </Filter>
     <Filter Include="third_party\urt\string">
       <UniqueIdentifier>{eb6617e4-792c-4476-90b3-977eba93f55f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="third_party\urt\sync">
+      <UniqueIdentifier>{d4e1f5a2-3b78-4c9e-8a1b-5f2e3d4c6b7a}</UniqueIdentifier>
     </Filter>
     <Filter Include="third_party\urt\si">
       <UniqueIdentifier>{af470b6a-000a-4e83-9502-2ea2ca5f3159}</UniqueIdentifier>
@@ -1026,6 +1032,30 @@
     <DCompile Include="third_party\urt\src\urt\string\uni.d">
       <Filter>third_party\urt\string</Filter>
     </DCompile>
+    <DCompile Include="third_party\urt\src\urt\sync\critical.d">
+      <Filter>third_party\urt\sync</Filter>
+    </DCompile>
+    <DCompile Include="third_party\urt\src\urt\sync\event.d">
+      <Filter>third_party\urt\sync</Filter>
+    </DCompile>
+    <DCompile Include="third_party\urt\src\urt\sync\mpmc.d">
+      <Filter>third_party\urt\sync</Filter>
+    </DCompile>
+    <DCompile Include="third_party\urt\src\urt\sync\mpsc.d">
+      <Filter>third_party\urt\sync</Filter>
+    </DCompile>
+    <DCompile Include="third_party\urt\src\urt\sync\mutex.d">
+      <Filter>third_party\urt\sync</Filter>
+    </DCompile>
+    <DCompile Include="third_party\urt\src\urt\sync\semaphore.d">
+      <Filter>third_party\urt\sync</Filter>
+    </DCompile>
+    <DCompile Include="third_party\urt\src\urt\sync\spinlock.d">
+      <Filter>third_party\urt\sync</Filter>
+    </DCompile>
+    <DCompile Include="third_party\urt\src\urt\sync\spsc.d">
+      <Filter>third_party\urt\sync</Filter>
+    </DCompile>
     <DCompile Include="third_party\urt\src\urt\si\package.d">
       <Filter>third_party\urt\si</Filter>
     </DCompile>
@@ -1202,6 +1232,9 @@
     </DCompile>
     <DCompile Include="third_party\urt\src\urt\internal\stdc\stdlib.d">
       <Filter>third_party\urt\internal\stdc</Filter>
+    </DCompile>
+    <DCompile Include="third_party\urt\src\urt\internal\sys\freertos\package.d">
+      <Filter>third_party\urt\internal\sys\freertos</Filter>
     </DCompile>
     <DCompile Include="third_party\urt\src\urt\internal\sys\windows\sspi.d">
       <Filter>third_party\urt\internal\sys\winows</Filter>

--- a/src/driver/baremetal/wifi.d
+++ b/src/driver/baremetal/wifi.d
@@ -6,7 +6,7 @@ static if (num_wifi > 0) {
 
 import urt.endian : loadBigEndian;
 import urt.result : Result;
-import urt.thread : SPSCRing;
+import urt.sync.spsc : SPSCRing;
 import urt.time : SysTime, getSysTime;
 
 import manager.base;

--- a/src/driver/windows/adapter_watcher.d
+++ b/src/driver/windows/adapter_watcher.d
@@ -7,7 +7,7 @@ import urt.atomic : atomicLoad, atomicStore, MemoryOrder;
 import urt.lifetime : move;
 import urt.string;
 import urt.system : sleep;
-import urt.thread : SPSCRing;
+import urt.sync.spsc : SPSCRing;
 import urt.time : msecs;
 
 import driver.windows.npcap;

--- a/src/main.d
+++ b/src/main.d
@@ -160,18 +160,19 @@ int main(string[] args)
 
     while (true)
     {
-        MonoTime start = getTime();
-        g_app.update();
+        // handle any expired timers (heartbeat-driven update() lives in here).
+        MonoTime next_deadline = g_app.process_due();
 
         version (ESP32_S3)
             ow_watchdog_feed();
 
         version (Embedded)
         {
-            if ((start - last_heartbeat).as!"seconds" >= 10)
+            MonoTime now = getTime();
+            if ((now - last_heartbeat).as!"seconds" >= 10)
             {
                 log_info("system", "Heartbeat");
-                last_heartbeat = start;
+                last_heartbeat = now;
             }
         }
 
@@ -208,12 +209,9 @@ int main(string[] args)
         if (session && session.is_attached())
             session.update();
 
-        Duration frame_time = getTime() - start;
-
-        long sleep_usecs = 1000_000 / g_app.update_rate_hz;
-        sleep_usecs -= frame_time.as!"usecs";
-        if (sleep_usecs > 20)
-            sleep(sleep_usecs.usecs);
+        // sleep until either the next timer deadline or an event fires.
+        g_app.wait_for_wake(next_deadline);
+        g_app.process_events();
     }
 
     shutdown_application();

--- a/src/manager/cron/job.d
+++ b/src/manager/cron/job.d
@@ -10,6 +10,7 @@ import urt.time;
 import urt.util : popcnt;
 import urt.variant;
 
+import manager;
 import manager.base;
 import manager.console;
 import manager.console.command;
@@ -157,65 +158,53 @@ protected:
                 break;
         }
 
+        _done_firing = false;
+        if (_schedule_type != ScheduleType.none)
+            schedule_fire(getTime());
+
+        if (_schedule_type == ScheduleType.tod || _schedule_type == ScheduleType.absolute)
+        {
+            g_app.subscribe_wallclock_change(&on_wallclock_change);
+            _wc_subscribed = true;
+        }
+
         writeInfo("CronJob '", name, "': Scheduled, next run at ", _next_run);
         return CompletionStatus.complete;
     }
 
     override CompletionStatus shutdown()
     {
+        if (_wc_subscribed)
+        {
+            g_app.unsubscribe_wallclock_change(&on_wallclock_change);
+            _wc_subscribed = false;
+        }
+        if (_fire_scheduled)
+        {
+            g_app.cancel(&on_fire);
+            _fire_scheduled = false;
+        }
+        if (_cleanup_scheduled)
+        {
+            g_app.cancel(&on_cleanup);
+            _cleanup_scheduled = false;
+        }
+
         foreach (ref cmd; _running_commands)
             cmd.command.request_cancel();
 
         update_running_commands();
 
         if (_running_commands.length > 0)
+        {
+            // commands still draining - keep cleanup scheduled until they
+            // finish; the state machine will re-enter shutdown() until we
+            // return complete
+            schedule_cleanup();
             return CompletionStatus.continue_;
+        }
 
         return CompletionStatus.complete;
-    }
-
-    override void update()
-    {
-        update_running_commands();
-
-        SysTime now = getSysTime();
-
-        if (now < _next_run)
-            return;
-
-        execute_command();
-
-        _last_run = now;
-        ++_run_count;
-
-        bool one_shot = false;
-        final switch (_schedule_type)
-        {
-            case ScheduleType.none:
-                one_shot = true;
-                break;
-            case ScheduleType.duration:
-                if (_repeat)
-                    _next_run = _next_run + _schedule;
-                else
-                    one_shot = true;
-                break;
-            case ScheduleType.tod:
-                if (_repeat)
-                    _next_run = next_occurrence(now, _at, _days_mask);
-                else
-                    one_shot = true;
-                break;
-            case ScheduleType.absolute:
-                one_shot = true;
-                break;
-        }
-
-        if (one_shot && _running_commands.length == 0)
-        {
-            writeInfo("CronJob '", name, "': One-shot job completed, disabling");
-            disabled = true;
-        }
     }
 
 private:
@@ -247,6 +236,115 @@ private:
     uint _run_count;
 
     Array!RunningCommand _running_commands;
+
+    bool _done_firing;
+    bool _fire_scheduled;
+    bool _cleanup_scheduled;
+    bool _wc_subscribed;
+
+    void schedule_fire(MonoTime anchor)
+    {
+        Duration until;
+        final switch (_schedule_type)
+        {
+            case ScheduleType.none:
+                return;
+            case ScheduleType.duration:
+                g_app.schedule(anchor + _schedule, &on_fire);
+                _fire_scheduled = true;
+                return;
+            case ScheduleType.tod:
+            case ScheduleType.absolute:
+                until = _next_run - getSysTime();
+                if (until < Duration.zero)
+                    until = Duration.zero;   // missed deadline -> fire immediately
+                break;
+        }
+        g_app.schedule(getTime() + until, &on_fire);
+        _fire_scheduled = true;
+    }
+
+    void on_wallclock_change()
+    {
+        if (_done_firing)
+            return;
+
+        if (_fire_scheduled)
+        {
+            g_app.cancel(&on_fire);
+            _fire_scheduled = false;
+        }
+
+        if (_schedule_type == ScheduleType.tod)
+            _next_run = next_occurrence(getSysTime(), _at, _days_mask);
+
+        schedule_fire(getTime());
+    }
+
+    void schedule_cleanup()
+    {
+        if (_cleanup_scheduled)
+            return;
+        g_app.schedule(getTime() + msecs(50), &on_cleanup);
+        _cleanup_scheduled = true;
+    }
+
+    void on_fire(MonoTime scheduled)
+    {
+        _fire_scheduled = false;
+
+        execute_command();
+
+        _last_run = getSysTime();
+        ++_run_count;
+
+        bool one_shot = false;
+        final switch (_schedule_type)
+        {
+            case ScheduleType.none:
+            case ScheduleType.absolute:
+                one_shot = true;
+                break;
+            case ScheduleType.duration:
+                one_shot = !_repeat;
+                if (!one_shot)
+                    _next_run = _next_run + _schedule;
+                break;
+            case ScheduleType.tod:
+                one_shot = !_repeat;
+                if (!one_shot)
+                    _next_run = next_occurrence(_last_run, _at, _days_mask);
+                break;
+        }
+
+        if (one_shot)
+            _done_firing = true;
+        else
+            schedule_fire(scheduled);
+
+        if (_running_commands.length > 0)
+            schedule_cleanup();
+        else if (_done_firing)
+            complete_one_shot();
+    }
+
+    void on_cleanup(MonoTime scheduled)
+    {
+        _cleanup_scheduled = false;
+
+        update_running_commands();
+
+        if (_running_commands.length > 0)
+            schedule_cleanup();
+        else if (_done_firing)
+            complete_one_shot();
+    }
+
+    void complete_one_shot()
+    {
+        writeInfo("CronJob '", name, "': One-shot job completed, disabling");
+        disabled = true;
+    }
 
     void update_running_commands()
     {

--- a/src/manager/cron/package.d
+++ b/src/manager/cron/package.d
@@ -24,6 +24,10 @@ nothrow @nogc:
         g_app.console.register_collection!CronJob();
     }
 
+    // Cron firing itself is timer-driven (CronJob.on_fire); this only
+    // exists to keep state-machine transitions (validate → startup →
+    // shutdown) ticking. Once BaseObject state changes become event-
+    // driven, this can go away too.
     override void update()
     {
         Collection!CronJob().update_all();

--- a/src/manager/package.d
+++ b/src/manager/package.d
@@ -9,6 +9,8 @@ import urt.meta.enuminfo : VoidEnumInfo;
 import urt.si.quantity;
 import urt.si.unit;
 import urt.string;
+import urt.sync.event;
+import urt.sync.mpsc;
 import urt.time;
 import urt.traits : is_enum, Unqual;
 import urt.variant;
@@ -38,6 +40,16 @@ enum AuthResult : ubyte
 alias AuthCallback = void delegate(AuthResult result, const(char)[] profile) nothrow @nogc;
 
 alias IntrinsicFunction = Variant function(Variant[] args) nothrow @nogc;
+
+alias TimerHandler      = void delegate(MonoTime scheduled) nothrow @nogc;
+alias EventHandler      = void delegate(MonoTime when) nothrow @nogc;
+alias WallclockHandler  = void delegate() nothrow @nogc;
+
+enum EventPriority : ubyte
+{
+    control,
+    bulk,
+}
 
 struct ElementLink
 {
@@ -195,6 +207,13 @@ nothrow @nogc:
         assert(!g_app, "Application already created!");
         g_app = this;
 
+        _wake_event.init();
+        _priority_events.init();
+        _bulk_events.init();
+
+        import urt.time : subscribe_clock_change;
+        subscribe_clock_change(&notify_wallclock_change);
+
         id_init();
         init_collections();
         init_elements();
@@ -246,10 +265,15 @@ nothrow @nogc:
             m.post_init();
 
         console.freeze();
+
+        schedule(getTime(), &heartbeat);
     }
 
     ~this()
     {
+        import urt.time : unsubscribe_clock_change;
+        unsubscribe_clock_change(&notify_wallclock_change);
+        _wake_event.destroy();
         g_app = null;
     }
 
@@ -348,6 +372,137 @@ nothrow @nogc:
     {
         assert(identifier[] !in intrinsic_functions, "Intrinsic function already registered!");
         intrinsic_functions.insert(identifier.move, func);
+    }
+
+    // MAIN THREAD ONLY; off-thread/ISR callers post a message to schedule a new event
+    void schedule(MonoTime when, TimerHandler handler)
+    {
+        _timer_when ~= when;
+        _timer_handler ~= handler;
+    }
+
+    uint cancel(TimerHandler handler, uint count = 1)
+    {
+        uint removed = 0;
+        foreach (i, h; _timer_handler)
+        {
+            if (h is handler)
+            {
+                _timer_remove(i);
+                if (++removed == count)
+                    return removed;
+            }
+        }
+        return removed;
+    }
+
+    MonoTime process_due()
+    {
+        MonoTime now = getTime();
+    again:
+        size_t next = size_t.max;
+        MonoTime next_when = MonoTime(ulong.max);
+        foreach (i, w; _timer_when)
+        {
+            if (w < next_when)
+            {
+                next = i;
+                next_when = w;
+            }
+        }
+        if (next == size_t.max)
+            return MonoTime(ulong.max);
+        if (next_when <= now)
+        {
+            MonoTime scheduled = next_when;
+            TimerHandler handler = _timer_handler[next];
+            _timer_remove(next);
+            handler(scheduled);
+            goto again;
+        }
+        return next_when;
+    }
+
+    void subscribe_wallclock_change(WallclockHandler h)
+    {
+        _wallclock_handlers ~= h;
+    }
+
+    void unsubscribe_wallclock_change(WallclockHandler h)
+    {
+        foreach (i, hh; _wallclock_handlers)
+        {
+            if (hh is h)
+            {
+                _wallclock_handlers.removeSwapLast(i);
+                return;
+            }
+        }
+    }
+
+    void notify_wallclock_change()
+    {
+        foreach (h; _wallclock_handlers)
+            h();
+    }
+
+    bool post_event(EventHandler handler, MonoTime when, EventPriority priority = EventPriority.control)
+    {
+        bool ok;
+        final switch (priority)
+        {
+            case EventPriority.control:
+                ok = _priority_events.enqueue(PendingEvent(handler, when));
+                break;
+            case EventPriority.bulk:
+                ok = _bulk_events.enqueue(PendingEvent(handler, when));
+                break;
+        }
+        if (!ok)
+            return false;
+        _wake_event.set();
+        return true;
+    }
+
+    void wait_for_wake(MonoTime deadline)
+    {
+        MonoTime now = getTime();
+        if (deadline <= now)
+            return;
+        _wake_event.wait(deadline - now);
+    }
+
+    void process_events()
+    {
+        enum Duration bulk_slice = msecs(500);
+
+        _wake_event.reset();
+        PendingEvent e;
+        for (;;)
+        {
+            bool any_priority = false;
+            while (_priority_events.dequeue(e))
+            {
+                e.handler(e.when);
+                any_priority = true;
+            }
+
+            MonoTime slice_end = getTime() + bulk_slice;
+            bool any_bulk = false;
+            while (_bulk_events.dequeue(e))
+            {
+                e.handler(e.when);
+                any_bulk = true;
+                if (getTime() >= slice_end)
+                {
+                    _wake_event.set();   // re-arm; let main loop fire timers,
+                    return;              // then drop back in priority-first.
+                }
+            }
+
+            if (!any_priority && !any_bulk)
+                break;
+        }
     }
 
     void update()
@@ -728,6 +883,36 @@ nothrow @nogc:
         }
     }
 
+
+private:
+
+    struct PendingEvent
+    {
+        EventHandler handler;
+        MonoTime     when;
+    }
+
+    Array!WallclockHandler _wallclock_handlers;
+
+    Array!MonoTime _timer_when;
+    Array!TimerHandler _timer_handler;
+
+    Event _wake_event;
+
+    MpscQueue!(PendingEvent, 32)  _priority_events;
+    MpscQueue!(PendingEvent, 256) _bulk_events;
+
+    void _timer_remove(size_t i)
+    {
+        _timer_when.removeSwapLast(i);
+        _timer_handler.removeSwapLast(i);
+    }
+
+    void heartbeat(MonoTime scheduled)
+    {
+        update();
+        schedule(scheduled + msecs(1000 / update_rate_hz), &heartbeat);
+    }
 }
 
 Element* resolve_global_element(const(char)[] path) nothrow @nogc


### PR DESCRIPTION
This creates a timed event series, and also an interrupt queue, where interrupts or service threads can post jobs to the main thread for immediate dispatch, and move execution away from a tick-loop.