### PR TITLE
Ethernet packet domain

### DIFF
--- a/src/driver/baremetal/ble.d
+++ b/src/driver/baremetal/ble.d
@@ -734,7 +734,7 @@ private:
                 // notify subscribers via disconnect frame
                 Packet p;
                 ref f = p.init!BLEFrame(null);
-                f.src = mac;
+                f.src = _bd_addr;
                 f.dst = session.client;
                 f.kind = BLEFrameKind.control;
                 f.code = BLEControl.disconnected;

--- a/src/driver/baremetal/wifi.d
+++ b/src/driver/baremetal/wifi.d
@@ -405,7 +405,7 @@ private:
         }
         hdr.rssi = rssi;
         hdr.channel = channel;
-        radio.dispatch(pkt);
+        radio.incoming_packet(pkt);
     }
 
     void dispatch_rx(WifiVif vif, const(ubyte)[] data)
@@ -572,11 +572,7 @@ protected:
 
         ubyte[6] mac_buf = void;
         if (radio.drv_get_mac(WifiVif.sta, mac_buf))
-        {
-            remove_address(mac);
             mac = MACAddress(mac_buf);
-            add_address(mac, this);
-        }
 
         _connect_initiated = true;
         _status_detail = "Connecting";
@@ -759,11 +755,7 @@ protected:
 
         ubyte[6] mac_buf = void;
         if (radio.drv_get_mac(WifiVif.ap, mac_buf))
-        {
-            remove_address(mac);
             mac = MACAddress(mac_buf);
-            add_address(mac, this);
-        }
 
         _ap_config_sent = true;
         _status_detail = "Starting AP";

--- a/src/driver/linux/ble.d
+++ b/src/driver/linux/ble.d
@@ -528,7 +528,7 @@ private:
 
                 Packet p;
                 ref f = p.init!BLEFrame(null);
-                f.src = mac;
+                f.src = _bd_addr;
                 f.dst = session.client;
                 f.kind = BLEFrameKind.control;
                 f.code = BLEControl.disconnected;

--- a/src/driver/linux/bridge.d
+++ b/src/driver/linux/bridge.d
@@ -9,11 +9,11 @@ version (KernelMirror):
 // br-<name> as OpenWatt's window for L3 / management / sniffing. OpenWatt is the
 // control plane; the kernel is the data plane.
 //
-// Non-netdev members (Modbus/CAN ...) stay software-switched on the bridge; they
-// live in disjoint PacketType address sub-domains, so today nothing crosses
-// between the kernel ethernet segment and those members (a non-ethernet frame
-// can't be emitted on an ethernet port yet). The cross-domain forwarding shape is
-// reserved (the CPU-port flood seam in bridge.d) but inert.
+// Non-netdev members (Modbus/CAN ...) stay software-switched on the bridge.
+// Exotic traffic crosses the kernel segment OW-encapsulated: the bridge's
+// EthernetStation wraps it into ordinary ethernet frames before they reach this
+// conduit, and OW frames drained from the CPU socket decap at the bridge's
+// attachment. This module only ever sees ethernet frames.
 //
 // Ownership discipline (mirrors RTPROT_OPENWATT for routes): we only ever delete
 // br-* we created and only detach members we enslaved -- tracked in the ledger.
@@ -76,16 +76,17 @@ private:
         bool engaged;
 
         // CpuPortSink: frame an ethernet packet to the wire and push it into the
-        // kernel-switched segment. Non-ethernet sub-domains can't traverse a kernel
-        // bridge (yet), so they're dropped here -- this is the egress half of the
-        // inert cross-domain seam.
+        // kernel-switched segment. Exotic packets are OW-encapsulated at the
+        // bridge's station before they reach this sink, so only ethernet frames
+        // arrive here. Anything else is a routing bug upstream.
         int inject(ref Packet packet)
         {
+            debug assert(packet.type == PacketType.ethernet);
             if (packet.type != PacketType.ethernet)
                 return -1;
 
-            // Mirror EthernetInterface.send (ethernet case). TODO: factor out a
-            // shared framing helper so this isn't a second copy.
+            // Mirror EthernetInterface.medium_tx. TODO: factor out a shared
+            // framing helper so this isn't a second copy.
             ubyte[1518] buffer = void;
             Ethernet* eth = cast(Ethernet*)buffer.ptr;
             eth.dst = packet.eth.dst;

--- a/src/driver/linux/ethernet.d
+++ b/src/driver/linux/ethernet.d
@@ -88,7 +88,7 @@ nothrow @nogc:
     override CompletionStatus shutdown()
     {
         _raw.close();
-        return CompletionStatus.complete;
+        return super.shutdown();
     }
 
     // Enslaved to a kernel bridge (offloaded): the kernel switches this port's

--- a/src/driver/windows/ethernet.d
+++ b/src/driver/windows/ethernet.d
@@ -82,7 +82,7 @@ nothrow @nogc:
     override CompletionStatus shutdown()
     {
         _pcap.close();
-        return CompletionStatus.complete;
+        return super.shutdown();
     }
 
     override void update()

--- a/src/protocol/ble/iface.d
+++ b/src/protocol/ble/iface.d
@@ -160,12 +160,15 @@ abstract class BLEInterface : BaseInterface
     alias Properties = AliasSeq!(Prop!("max-in-flight", max_in_flight));
 nothrow @nogc:
 
+    MACAddress _bd_addr; // synthetic local BD_ADDR; the radio's real address is below this layer
+
     protected this(const CollectionTypeInfo* type_info, CID id, ObjectFlags flags = ObjectFlags.none)
     {
         super(type_info, id, flags);
         _mtu = 247; // BLE 5.x max ATT MTU (251 - 4 byte L2CAP header)
         _max_l2mtu = 251;
         _l2mtu = _max_l2mtu;
+        _bd_addr = generate_mac_address(name[]);
 
         mark_set!(typeof(this), "max-l2mtu")();
     }
@@ -404,7 +407,7 @@ protected:
             log_frame(f, cast(const(ubyte)[])p.data, PacketDirection.incoming);
 
         _status.rx_bytes += 14;
-        dispatch(p);
+        incoming_packet(p);
     }
 
     // --- session lifecycle ---

--- a/src/protocol/ble/iface.d
+++ b/src/protocol/ble/iface.d
@@ -102,6 +102,53 @@ struct BLEFrame
         => cast(BLEAdvPDU)code;
     BLEControl control() const pure nothrow @nogc
         => cast(BLEControl)code;
+
+    static ulong extract_src(ref const Packet p) pure nothrow @nogc
+    {
+        ulong addr = p.hdr!BLEFrame().src.ul;
+        addr |= ulong(p.vlan & 0xFFF) << 48;
+        addr |= ulong(PacketType.ble) << 60;
+        return addr;
+    }
+
+    static ulong extract_dst(ref const Packet p) pure nothrow @nogc
+    {
+        ulong addr = p.hdr!BLEFrame().dst.ul;
+        addr |= ulong(p.vlan & 0xFFF) << 48;
+        addr |= ulong(PacketType.ble) << 60;
+        return addr;
+    }
+
+    static bool is_multicast(ulong address) pure nothrow @nogc
+        => (address & 0xFFFF_FFFF_FFFF) == 0xFFFF_FFFF_FFFF;
+
+    // OW encapsulation wire codec: [src:6][dst:6][kind:1][code:1][rssi:1]
+    static ptrdiff_t encode_ow_header(ref const Packet p, ubyte[] buffer) nothrow @nogc
+    {
+        if (buffer.length < 15)
+            return -1;
+        ref const f = p.hdr!BLEFrame;
+        buffer[0 .. 6] = f.src.b[];
+        buffer[6 .. 12] = f.dst.b[];
+        buffer[12] = f.kind;
+        buffer[13] = f.code;
+        buffer[14] = cast(ubyte)f.rssi;
+        return 15;
+    }
+
+    static ptrdiff_t decode_ow_header(ref Packet p, const(ubyte)[] header) nothrow @nogc
+    {
+        if (header.length < 15)
+            return -1;
+        p.type = PacketType.ble;
+        ref f = p.hdr!BLEFrame;
+        f.src = MACAddress(header[0 .. 6]);
+        f.dst = MACAddress(header[6 .. 12]);
+        f.kind = cast(BLEFrameKind)header[12];
+        f.code = header[13];
+        f.rssi = cast(byte)header[14];
+        return 15;
+    }
 }
 static assert(BLEFrame.sizeof <= 24);
 

--- a/src/protocol/ble/package.d
+++ b/src/protocol/ble/package.d
@@ -35,6 +35,7 @@ nothrow @nogc:
 
     override void init()
     {
+        register_packet_codec!BLEFrame();
         register_frame_handler(PacketType.ble, &on_ble_frame);
 
         g_app.console.register_collection!BLEClient();

--- a/src/protocol/can/binding.d
+++ b/src/protocol/can/binding.d
@@ -166,14 +166,7 @@ private:
     void packet_handler(ref const Packet p, BaseInterface i, PacketDirection dir, void* u)
     {
         if (p.type != PacketType.can)
-        {
-            if (p.type == PacketType.ethernet && p.eth.ether_type == EtherType.ow && p.eth.ow_sub_type == OW_SubType.can)
-            {
-                // de-frame CANoE...
-                assert(false, "TODO");
-            }
             return;
-        }
 
         ref can = p.hdr!CANFrame;
         foreach (ref e; elements)

--- a/src/protocol/can/iface.d
+++ b/src/protocol/can/iface.d
@@ -54,8 +54,33 @@ struct CANFrame
         return addr;
     }
 
-    static bool is_broadcast(ulong address) pure nothrow @nogc
+    static bool is_multicast(ulong address) pure nothrow @nogc
         => true; // CAN is always broadcast
+
+    // OW encapsulation wire codec: [id:4 BE][flags:1] (bit0 = extended, bit1 = rtr)
+    static ptrdiff_t encode_ow_header(ref const Packet p, ubyte[] buffer) nothrow @nogc
+    {
+        import urt.endian : nativeToBigEndian;
+        if (buffer.length < 5)
+            return -1;
+        ref const f = p.hdr!CANFrame;
+        buffer[0 .. 4] = f.id.nativeToBigEndian;
+        buffer[4] = (f.extended ? 1 : 0) | (f.remote_transmission_request ? 2 : 0);
+        return 5;
+    }
+
+    static ptrdiff_t decode_ow_header(ref Packet p, const(ubyte)[] header) nothrow @nogc
+    {
+        import urt.endian : bigEndianToNative;
+        if (header.length < 5)
+            return -1;
+        p.type = PacketType.can;
+        ref f = p.hdr!CANFrame;
+        f.id = header[0 .. 4].bigEndianToNative!uint;
+        f.extended = (header[4] & 1) != 0;
+        f.remote_transmission_request = (header[4] & 2) != 0;
+        return 5;
+    }
 }
 
 
@@ -347,11 +372,6 @@ protected:
         // can only handle can packets
         if (packet.type != PacketType.can)
         {
-            if (packet.type == PacketType.ethernet && packet.eth.ether_type == EtherType.ow && packet.eth.ow_sub_type == OW_SubType.can)
-            {
-                // de-frame CANoE...
-                assert(false, "TODO");
-            }
             add_tx_drop();
             return -1;
         }

--- a/src/protocol/can/iface.d
+++ b/src/protocol/can/iface.d
@@ -355,7 +355,7 @@ protected:
                 version (DebugCANInterface)
                     writeDebug("CAN packet received from interface '", name, "': id=", can.id, " (", packet.length , ")[ ", packet.data, " - ", packet.data.bin_to_ascii(), " ]");
 
-                dispatch(packet);
+                incoming_packet(packet);
             }
 
             // shuffle remaining unparsed bytes to the front for the next read
@@ -502,7 +502,7 @@ private:
             can.id = hw.id;
             can.extended = hw.extended;
             can.remote_transmission_request = hw.rtr;
-            dispatch(packet);
+            incoming_packet(packet);
         }
     }
 }

--- a/src/protocol/can/package.d
+++ b/src/protocol/can/package.d
@@ -26,7 +26,7 @@ nothrow @nogc:
 
     override void init()
     {
-        register_address_extractor(PacketType.can, &CANFrame.extract_src, &CANFrame.extract_dst, &CANFrame.is_broadcast);
+        register_packet_codec!CANFrame();
 
         g_app.register_enum!CANInterfaceProtocol();
 

--- a/src/protocol/dhcp/client.d
+++ b/src/protocol/dhcp/client.d
@@ -21,6 +21,7 @@ import protocol.ip.route;
 import protocol.ip : IPv4Header, IPProtocol;
 
 import router.iface;
+import router.iface.ethernet;
 import router.iface.mac;
 import router.iface.packet;
 
@@ -52,6 +53,8 @@ nothrow @nogc:
     {
         if (!value)
             return "interface cannot be null";
+        if (!cast(EthernetStation)value)
+            return "interface must be an ethernet interface";
         if (_iface is value)
             return null;
         if (_subscribed)
@@ -224,6 +227,10 @@ private:
     enum size_t max_retries = 5;
 
     ObjectRef!BaseInterface _iface;
+
+    // TODO: delete this hack, promote _iface to EthernetStation...
+    EthernetStation station()
+        => cast(EthernetStation)_iface.get;
     bool _add_default_route = true;
     bool _subscribed;
 
@@ -294,14 +301,14 @@ private:
             log.debug_("tx DISCOVER xid=", _xid);
 
         DhcpBuild b;
-        b.start(BootpRequest, _iface.mac, _xid, secs_field, true);
+        b.start(BootpRequest, station.mac, _xid, secs_field, true);
         b.add_message_type(DhcpMessageType.discover);
-        b.add_client_identifier(_iface.mac);
+        b.add_client_identifier(station.mac);
         add_hostname(b);
         add_vendor_class_id(b);
         b.add_parameter_request_list();
         b.finish();
-        b.transmit(_iface, IPAddr.any, IPAddr.broadcast, MACAddress.broadcast, DhcpClientPort, DhcpServerPort);
+        b.transmit(station, IPAddr.any, IPAddr.broadcast, MACAddress.broadcast, DhcpClientPort, DhcpServerPort);
     }
 
     void send_request_select()
@@ -310,16 +317,16 @@ private:
             log.debug_("tx REQUEST (selecting) xid=", _xid, " offered=", _offered_addr, " server=", _server_id);
 
         DhcpBuild b;
-        b.start(BootpRequest, _iface.mac, _xid, secs_field, true);
+        b.start(BootpRequest, station.mac, _xid, secs_field, true);
         b.add_message_type(DhcpMessageType.request);
-        b.add_client_identifier(_iface.mac);
+        b.add_client_identifier(station.mac);
         b.add_addr_option(DhcpOption.requested_address, _offered_addr);
         b.add_addr_option(DhcpOption.server_id, _server_id);
         add_hostname(b);
         add_vendor_class_id(b);
         b.add_parameter_request_list();
         b.finish();
-        b.transmit(_iface, IPAddr.any, IPAddr.broadcast, MACAddress.broadcast, DhcpClientPort, DhcpServerPort);
+        b.transmit(station, IPAddr.any, IPAddr.broadcast, MACAddress.broadcast, DhcpClientPort, DhcpServerPort);
     }
 
     void send_request_renew()
@@ -328,16 +335,16 @@ private:
             log.debug_("tx REQUEST (renew) xid=", _xid, " ciaddr=", _offered_addr, " server=", _server_id);
 
         DhcpBuild b;
-        b.start(BootpRequest, _iface.mac, _xid, secs_field, false);
+        b.start(BootpRequest, station.mac, _xid, secs_field, false);
         b.set_ciaddr(_offered_addr);
         b.add_message_type(DhcpMessageType.request);
-        b.add_client_identifier(_iface.mac);
+        b.add_client_identifier(station.mac);
         add_hostname(b);
         add_vendor_class_id(b);
         b.add_parameter_request_list();
         b.finish();
         // TODO: ARP-resolve _server_id MAC; for now broadcast renew too.
-        b.transmit(_iface, _offered_addr, _server_id, MACAddress.broadcast, DhcpClientPort, DhcpServerPort);
+        b.transmit(station, _offered_addr, _server_id, MACAddress.broadcast, DhcpClientPort, DhcpServerPort);
     }
 
     void send_request_rebind()
@@ -346,15 +353,15 @@ private:
             log.debug_("tx REQUEST (rebind) xid=", _xid, " ciaddr=", _offered_addr);
 
         DhcpBuild b;
-        b.start(BootpRequest, _iface.mac, _xid, secs_field, true);
+        b.start(BootpRequest, station.mac, _xid, secs_field, true);
         b.set_ciaddr(_offered_addr);
         b.add_message_type(DhcpMessageType.request);
-        b.add_client_identifier(_iface.mac);
+        b.add_client_identifier(station.mac);
         add_hostname(b);
         add_vendor_class_id(b);
         b.add_parameter_request_list();
         b.finish();
-        b.transmit(_iface, _offered_addr, IPAddr.broadcast, MACAddress.broadcast, DhcpClientPort, DhcpServerPort);
+        b.transmit(station, _offered_addr, IPAddr.broadcast, MACAddress.broadcast, DhcpClientPort, DhcpServerPort);
     }
 
     void add_hostname(ref DhcpBuild b)
@@ -378,13 +385,13 @@ private:
         // RFC 2131 §4.4.4: RELEASE is unicast to the server with ciaddr set.
         // TODO: ARP-resolve _server_id MAC; for now broadcast at L2 (same shortcut as renew).
         DhcpBuild b;
-        b.start(BootpRequest, _iface.mac, rand(), 0, false);
+        b.start(BootpRequest, station.mac, rand(), 0, false);
         b.set_ciaddr(_offered_addr);
         b.add_message_type(DhcpMessageType.release);
-        b.add_client_identifier(_iface.mac);
+        b.add_client_identifier(station.mac);
         b.add_addr_option(DhcpOption.server_id, _server_id);
         b.finish();
-        b.transmit(_iface, _offered_addr, _server_id, MACAddress.broadcast, DhcpClientPort, DhcpServerPort);
+        b.transmit(station, _offered_addr, _server_id, MACAddress.broadcast, DhcpClientPort, DhcpServerPort);
     }
 
     // ---- packet parse ----
@@ -432,7 +439,7 @@ private:
         if (xid != _xid)
             return;
 
-        if (dh.chaddr[0 .. 6] != _iface.mac.b[])
+        if (dh.chaddr[0 .. 6] != station.mac.b[])
             return;
 
         // verify magic cookie

--- a/src/protocol/dhcp/message.d
+++ b/src/protocol/dhcp/message.d
@@ -7,6 +7,7 @@ import urt.time;
 import protocol.ip : IPv4Header, IPProtocol;
 
 import router.iface;
+import router.iface.ethernet;
 import router.iface.mac;
 import router.iface.packet;
 
@@ -248,7 +249,7 @@ nothrow @nogc:
 
     // Frame the IP+UDP+DHCP payload and hand it to the interface for transmission.
     // src_port/dst_port choose the BOOTP direction (server -> client uses 67->68).
-    void transmit(BaseInterface iface, IPAddr src, IPAddr dst, MACAddress eth_dst, ushort src_port, ushort dst_port)
+    void transmit(EthernetStation iface, IPAddr src, IPAddr dst, MACAddress eth_dst, ushort src_port, ushort dst_port)
     {
         ubyte[] frame = buf[0 .. total_len];
         size_t udp_len = total_len - IPv4Header.sizeof;

--- a/src/protocol/dhcp/server.d
+++ b/src/protocol/dhcp/server.d
@@ -21,6 +21,7 @@ import protocol.ip.pool;
 import protocol.ip : IPv4Header, IPProtocol;
 
 import router.iface;
+import router.iface.ethernet;
 import router.iface.mac;
 import router.iface.packet;
 
@@ -57,6 +58,8 @@ nothrow @nogc:
     {
         if (!value)
             return "interface cannot be null";
+        if (!cast(EthernetStation)value)
+            return "interface must be an ethernet interface";
         if (_iface is value)
             return null;
         if (_subscribed)
@@ -226,6 +229,10 @@ private:
     enum size_t offer_hold_seconds = 30;
 
     ObjectRef!BaseInterface _iface;
+
+    // TODO: remove this hack and promote _iface to EthernetStation...
+    EthernetStation station()
+        => cast(EthernetStation)_iface.get;
     ObjectRef!IPPool _pool;
     Duration _lease_time;       // initialised in ctor; default = 1 day
     uint _mac_limit;        // 0 = unlimited
@@ -569,7 +576,7 @@ private:
         b.finish();
 
         // NAK always broadcast (RFC 2131 4.3.2).
-        b.transmit(_iface, _server_ip, IPAddr.broadcast, MACAddress.broadcast,
+        b.transmit(station, _server_ip, IPAddr.broadcast, MACAddress.broadcast,
                    DhcpServerPort, DhcpClientPort);
     }
 
@@ -589,13 +596,13 @@ private:
 
         if (broadcast)
         {
-            b.transmit(_iface, _server_ip, IPAddr.broadcast, MACAddress.broadcast,
+            b.transmit(station, _server_ip, IPAddr.broadcast, MACAddress.broadcast,
                        DhcpServerPort, DhcpClientPort);
         }
         else
         {
             IPAddr ip_dst = ciaddr != IPAddr.any ? ciaddr : yiaddr;
-            b.transmit(_iface, _server_ip, ip_dst, client_mac,
+            b.transmit(station, _server_ip, ip_dst, client_mac,
                        DhcpServerPort, DhcpClientPort);
         }
     }

--- a/src/protocol/ezsp/ashv2.d
+++ b/src/protocol/ezsp/ashv2.d
@@ -423,7 +423,7 @@ private:
         {
             Packet p;
             p.init!RawFrame(data, timestamp);
-            dispatch(p);
+            incoming_packet(p);
         }
 
         ack_in_flight(ack_num, timestamp);

--- a/src/protocol/http/websocket.d
+++ b/src/protocol/http/websocket.d
@@ -402,9 +402,9 @@ protected:
                         Packet p;
                         ref hdr = p.init!RawFrame(msg[offset .. msg_len], timestamp);
                         hdr.is_text = _pending_message_type == WSMessageType.text;
-                        _status.rx_bytes += _rx_overhead; // dispatch() counts the payload; we add framing
+                        _status.rx_bytes += _rx_overhead; // incoming_packet() counts the payload; we add framing
                         _rx_overhead = 0;
-                        dispatch(p);
+                        incoming_packet(p);
 
                         frame_start += msg_len;
                         _pending_message_type = WSMessageType.unknown;
@@ -429,7 +429,7 @@ protected:
                     hdr.is_text = _pending_message_type == WSMessageType.text;
                     _status.rx_bytes += _rx_overhead;
                     _rx_overhead = 0;
-                    dispatch(p);
+                    incoming_packet(p);
 
                     _pending_message_type = WSMessageType.unknown;
                     _decoded_bytes = 0;

--- a/src/protocol/ip/arp.d
+++ b/src/protocol/ip/arp.d
@@ -9,6 +9,7 @@ import urt.endian;
 import manager.collection;
 
 import router.iface;
+import router.iface.ethernet;
 import router.iface.mac;
 import router.iface.packet;
 
@@ -49,7 +50,7 @@ static assert(ArpV4Packet.sizeof == 28);
 
 // Send an ARP who-has request for `target` out `iface`.
 // Source IP is the first IPAddress we own on `iface`; if none, sent as 0.0.0.0 (probe-style).
-void send_arp_request(IPAddr target, BaseInterface iface)
+void send_arp_request(IPAddr target, EthernetStation iface)
 {
     IPAddr our_ip;
     foreach (a; Collection!IPAddress().values)
@@ -80,7 +81,7 @@ void send_arp_request(IPAddr target, BaseInterface iface)
 
 
 // Parse incoming ARP frame, learn from observed traffic, and reply to who-has-our-IP.
-void on_arp(ref const Packet pkt, BaseInterface iface, ref NeighbourCache!IPAddr cache)
+void on_arp(ref const Packet pkt, EthernetStation iface, ref NeighbourCache!IPAddr cache)
 {
     const data = pkt.data;
     if (data.length < ArpV4Packet.sizeof)

--- a/src/protocol/ip/stack.d
+++ b/src/protocol/ip/stack.d
@@ -12,6 +12,7 @@ import urt.time;
 import manager.collection;
 
 import router.iface;
+import router.iface.ethernet;
 import router.iface.mac;
 import router.iface.packet;
 
@@ -203,7 +204,13 @@ nothrow @nogc:
         version (DebugRawIngress)
             log.trace("ingress if=", iface.name, " type=", pkt.type, " (", pkt.length, ") [ ", pkt.data[0 .. 24 < pkt.length ? 24 : pkt.length], 24 < pkt.length ? " ... ]" : " ]");
 
-        ethernet_ingress(pkt, iface);
+        if (pkt.type == PacketType.ethernet)
+        {
+            EthernetStation station = cast(EthernetStation)iface;
+            debug assert(station !is null);
+            if (station)
+                ethernet_ingress(pkt, station);
+        }
         // TODO: sixlowpan handler -> register for PacketType._6lowpan
         // TODO: ppp handler -> register for an appropriate PacketType
         // TODO: raw_ip tunnel handler -> register for PacketType.raw (peek IP version byte)
@@ -217,10 +224,8 @@ nothrow @nogc:
 
 private:
 
-    void ethernet_ingress(ref Packet pkt, BaseInterface iface)
+    void ethernet_ingress(ref Packet pkt, EthernetStation iface)
     {
-        if (pkt.type != PacketType.ethernet)
-            return;
         const Ethernet eth = pkt.hdr!Ethernet();
         if (eth.dst != iface.mac && !eth.dst.is_multicast())
             return; // promiscuous capture; not addressed to us
@@ -410,13 +415,14 @@ private:
     //       (or by a virtual on BaseInterface) to choose the framing.
     void frame_and_send(ref Packet pkt, BaseInterface out_iface, const(ubyte)[] link_addr)
     {
-        if (link_addr.length != 6 || pkt.data.length < 1)
+        EthernetStation station = cast(EthernetStation)out_iface;
+        if (!station || link_addr.length != 6 || pkt.data.length < 1)
             return;
         MACAddress dst;
         dst.b[] = link_addr[0 .. 6];
         ubyte ver = (cast(const(ubyte)*)pkt.data.ptr)[0] >> 4;
         EtherType etype = ver == 6 ? EtherType.ip6 : EtherType.ip4;
-        out_iface.send(dst, pkt.data, etype);
+        station.send(dst, pkt.data, etype);
     }
 
     void deliver_local(ref Packet pkt)
@@ -447,7 +453,8 @@ private:
 
     void v4_send_request(IPAddr target, BaseInterface iface)
     {
-        send_arp_request(target, iface);
+        if (EthernetStation station = cast(EthernetStation)iface)
+            send_arp_request(target, station);
     }
 
     void v4_drain(ref Packet pkt, BaseInterface iface, const(ubyte)[] link_addr)

--- a/src/protocol/modbus/iface.d
+++ b/src/protocol/modbus/iface.d
@@ -62,6 +62,55 @@ struct ModbusFrame
     ubyte src_address;
     ubyte dst_address;
     ubyte function_code;
+
+    static ulong extract_src(ref const Packet p) pure nothrow @nogc
+    {
+        ulong addr = p.hdr!ModbusFrame().src_address;
+        addr |= ulong(p.vlan & 0xFFF) << 48;
+        addr |= ulong(PacketType.modbus) << 60;
+        return addr;
+    }
+
+    static ulong extract_dst(ref const Packet p) pure nothrow @nogc
+    {
+        ulong addr = p.hdr!ModbusFrame().dst_address;
+        addr |= ulong(p.vlan & 0xFFF) << 48;
+        addr |= ulong(PacketType.modbus) << 60;
+        return addr;
+    }
+
+    static bool is_multicast(ulong addr) pure nothrow @nogc
+        => (addr & 0x7F) == 0;
+
+    // OW encapsulation wire codec: [seq:2 BE][type:1][src:1][dst:1][fnc:1]
+    static ptrdiff_t encode_ow_header(ref const Packet p, ubyte[] buffer) nothrow @nogc
+    {
+        import urt.endian : nativeToBigEndian;
+        if (buffer.length < 6)
+            return -1;
+        ref const f = p.hdr!ModbusFrame;
+        buffer[0 .. 2] = f.sequence_number.nativeToBigEndian;
+        buffer[2] = f.type;
+        buffer[3] = f.src_address;
+        buffer[4] = f.dst_address;
+        buffer[5] = f.function_code;
+        return 6;
+    }
+
+    static ptrdiff_t decode_ow_header(ref Packet p, const(ubyte)[] header) nothrow @nogc
+    {
+        import urt.endian : bigEndianToNative;
+        if (header.length < 6)
+            return -1;
+        p.type = PacketType.modbus;
+        ref f = p.hdr!ModbusFrame;
+        f.sequence_number = header[0 .. 2].bigEndianToNative!ushort;
+        f.type = cast(ModbusFrameType)header[2];
+        f.src_address = header[3];
+        f.dst_address = header[4];
+        f.function_code = header[5];
+        return 6;
+    }
 }
 
 

--- a/src/protocol/modbus/iface.d
+++ b/src/protocol/modbus/iface.d
@@ -692,7 +692,7 @@ private:
                     break;
                 }
                 offset += taken;
-                incoming_packet(message, rx_time, frame_info);
+                incoming_frame(message, rx_time, frame_info);
             }
             if (!partial)
                 length = 0;
@@ -914,7 +914,7 @@ private:
         log.info("estimated remote baud rate: ", closest);
     }
 
-    final void incoming_packet(const(void)[] message, MonoTime recvTime, ref ModbusFrameInfo frame_info)
+    final void incoming_frame(const(void)[] message, MonoTime recvTime, ref ModbusFrameInfo frame_info)
     {
         debug assert(running, "Shouldn't receive packets while not running...?");
 
@@ -1011,7 +1011,7 @@ private:
                     hdr.src_address = address;
                     hdr.dst_address = pm.request_from_address;
                     hdr.sequence_number = pm.sequence_number;
-                    dispatch(p);
+                    incoming_packet(p);
                     _queue.complete(matched_tag, MessageState.complete);
                 }
 
@@ -1030,7 +1030,7 @@ private:
                     hdr.src_address = address;
                     hdr.dst_address = pm.request_from_address;
                     hdr.sequence_number = pm.sequence_number;
-                    dispatch(p);
+                    incoming_packet(p);
                     _queue.complete(tag, MessageState.complete);
                 }
                 else
@@ -1066,7 +1066,7 @@ private:
             }
             hdr.sequence_number = seq;
 
-            dispatch(p);
+            incoming_packet(p);
 
             _expect_message_type = type == ModbusFrameType.request ? ModbusFrameType.response : ModbusFrameType.request;
         }

--- a/src/protocol/modbus/package.d
+++ b/src/protocol/modbus/package.d
@@ -37,25 +37,6 @@ struct ServerMap
     String model;
 }
 
-ulong extract_modbus_src_address(ref const Packet p) pure
-{
-    ulong addr = p.hdr!ModbusFrame().src_address;
-    addr |= ulong(p.vlan & 0xFFF) << 48;
-    addr |= ulong(PacketType.modbus) << 60;
-    return addr;
-}
-
-ulong extract_modbus_dst_address(ref const Packet p) pure
-{
-    ulong addr = p.hdr!ModbusFrame().dst_address;
-    addr |= ulong(p.vlan & 0xFFF) << 48;
-    addr |= ulong(PacketType.modbus) << 60;
-    return addr;
-}
-
-bool is_modbus_broadcast_address(ulong addr) pure
-    => (addr & 0x7F) == 0;
-
 class ModbusProtocolModule : Module
 {
     mixin DeclareModule!"protocol.mb";
@@ -66,7 +47,7 @@ nothrow @nogc:
 
     override void init()
     {
-        register_address_extractor(PacketType.modbus, &extract_modbus_src_address, &extract_modbus_dst_address, &is_modbus_broadcast_address);
+        register_packet_codec!ModbusFrame();
 
         g_app.register_enum!ModbusProtocol();
         g_app.register_enum!SunSpecInverterState();

--- a/src/protocol/tesla/binding.d
+++ b/src/protocol/tesla/binding.d
@@ -22,8 +22,6 @@ import manager.plugin;
 import protocol.tesla;
 import protocol.tesla.master;
 
-import router.iface.mac;
-
 version = DebugTWCBinding;
 
 nothrow @nogc:
@@ -31,8 +29,7 @@ nothrow @nogc:
 
 class TeslaTWCBinding : ProtocolBinding
 {
-    alias Properties = AliasSeq!(Prop!("slave_id", slave_id),
-                                 Prop!("mac", mac));
+    alias Properties = AliasSeq!(Prop!("slave_id", slave_id));
 nothrow @nogc:
 
     enum type_name = "twc-binding";
@@ -53,19 +50,9 @@ nothrow @nogc:
         restart();
     }
 
-    final MACAddress mac() const pure
-        => _mac;
-    final void mac(MACAddress value)
-    {
-        if (_mac == value)
-            return;
-        _mac = value;
-        restart();
-    }
-
     final override bool validate() const pure
     {
-        return !_device.empty && (_slave_id != 0 || _mac != MACAddress());
+        return !_device.empty && _slave_id != 0;
     }
 
     override CompletionStatus startup()
@@ -80,7 +67,7 @@ nothrow @nogc:
             {
                 foreach (i, ref c; twc.chargers)
                 {
-                    if ((_slave_id != 0 && _slave_id == c.id) || (_mac != MACAddress() && _mac == c.mac))
+                    if (_slave_id == c.id)
                     {
                         _master = twc;
                         _charger_index = cast(ubyte)i;
@@ -198,7 +185,6 @@ protected:
 private:
 
     ushort _slave_id;
-    MACAddress _mac;
 
     TeslaTWCMaster _master;
     ubyte _charger_index;

--- a/src/protocol/tesla/iface.d
+++ b/src/protocol/tesla/iface.d
@@ -186,7 +186,7 @@ protected:
             msg = msg[0 .. $-1];
 
             // we seem to have a valid packet...
-            incoming_packet(msg, now);
+            incoming_frame(msg, now);
         }
     }
 
@@ -248,7 +248,7 @@ protected:
 private:
     ObjectRef!Stream _stream;
 
-    final void incoming_packet(const(ubyte)[] msg, MonoTime recv_time)
+    void incoming_frame(const(ubyte)[] msg, MonoTime recv_time)
     {
         debug assert(running, "Shouldn't receive packets while not running...?");
 
@@ -263,7 +263,7 @@ private:
         twc.src = message.sender;
         twc.dst = message.receiver ? message.receiver : TWCFrame.broadcast;
 
-        dispatch(p);
+        incoming_packet(p);
     }
 }
 

--- a/src/protocol/tesla/iface.d
+++ b/src/protocol/tesla/iface.d
@@ -29,8 +29,53 @@ struct TWCFrame
 {
     enum Type = PacketType.tesla_twc;
 
+    enum ushort broadcast = 0xFFFF;
+
     ushort src;
     ushort dst;
+
+    static ulong extract_src(ref const Packet p) pure nothrow @nogc
+    {
+        ulong addr = p.hdr!TWCFrame().src;
+        addr |= ulong(p.vlan & 0xFFF) << 48;
+        addr |= ulong(PacketType.tesla_twc) << 60;
+        return addr;
+    }
+
+    static ulong extract_dst(ref const Packet p) pure nothrow @nogc
+    {
+        ulong addr = p.hdr!TWCFrame().dst;
+        addr |= ulong(p.vlan & 0xFFF) << 48;
+        addr |= ulong(PacketType.tesla_twc) << 60;
+        return addr;
+    }
+
+    static bool is_multicast(ulong address) pure nothrow @nogc
+        => (address & 0xFFFF) == broadcast;
+
+    // OW encapsulation wire codec: [src:2 BE][dst:2 BE]
+    static ptrdiff_t encode_ow_header(ref const Packet p, ubyte[] buffer) nothrow @nogc
+    {
+        import urt.endian : nativeToBigEndian;
+        if (buffer.length < 4)
+            return -1;
+        ref const f = p.hdr!TWCFrame;
+        buffer[0 .. 2] = f.src.nativeToBigEndian;
+        buffer[2 .. 4] = f.dst.nativeToBigEndian;
+        return 4;
+    }
+
+    static ptrdiff_t decode_ow_header(ref Packet p, const(ubyte)[] header) nothrow @nogc
+    {
+        import urt.endian : bigEndianToNative;
+        if (header.length < 4)
+            return -1;
+        p.type = PacketType.tesla_twc;
+        ref f = p.hdr!TWCFrame;
+        f.src = header[0 .. 2].bigEndianToNative!ushort;
+        f.dst = header[2 .. 4].bigEndianToNative!ushort;
+        return 4;
+    }
 }
 
 class TeslaInterface : BaseInterface
@@ -147,7 +192,7 @@ protected:
 
     override int transmit(ref const Packet packet, MessageCallback) nothrow @nogc
     {
-        if (packet.eth.ether_type != EtherType.ow || packet.eth.ow_sub_type != OW_SubType.tesla_twc)
+        if (packet.type != PacketType.tesla_twc)
         {
             add_tx_drop();
             return -1;
@@ -193,16 +238,12 @@ protected:
 
         version (DebugTeslaInterface) {
             import urt.io;
-            writef("{4} - {0}: TWC packet sent {1}-->{2} [{3}]\n", name, packet.src, packet.dst, packet.data, packet.creation_time);
+            writef("{4} - {0}: TWC packet sent {1,04x}-->{2,04x} [{3}]\n", name, packet.hdr!TWCFrame.src, packet.hdr!TWCFrame.dst, packet.data, packet.creation_time);
         }
 
         add_tx_frame(packet.data.length); // TODO: but should we record the ACTUAL protocol packet?
         return 0;
     }
-
-package:
-    final MACAddress generate_mac_address() pure
-        => super.generate_mac_address();
 
 private:
     ObjectRef!Stream _stream;
@@ -218,34 +259,11 @@ private:
             return;
 
         Packet p;
-        p.init!Ethernet(msg);
-        p.creation_time = recv_time;
-        p.eth.ether_type = EtherType.ow;
-        p.eth.ow_sub_type = OW_SubType.tesla_twc;
+        ref TWCFrame twc = p.init!TWCFrame(msg, recv_time);
+        twc.src = message.sender;
+        twc.dst = message.receiver ? message.receiver : TWCFrame.broadcast;
 
-        auto mod_tesla = get_module!TeslaProtocolModule();
-
-        DeviceMap* map = mod_tesla.find_server_by_address(message.sender);
-        if (!map)
-            map = mod_tesla.add_device(null, this, message.sender);
-        p.eth.src = map.mac;
-
-        if (!message.receiver)
-            p.eth.dst = MACAddress.broadcast;
-        else
-        {
-            // find receiver... do we have a global device registry?
-            map = mod_tesla.find_server_by_address(message.receiver);
-            if (!map)
-            {
-                // we haven't seen the other guy, so we can't assign a dst address
-                return;
-            }
-            p.eth.dst = map.mac;
-        }
-
-        if (p.eth.dst)
-            dispatch(p);
+        dispatch(p);
     }
 }
 

--- a/src/protocol/tesla/master.d
+++ b/src/protocol/tesla/master.d
@@ -44,7 +44,6 @@ nothrow @nogc:
     {
     nothrow @nogc:
         String name;
-        MACAddress mac;
         ushort id;
 
         ubyte req_seq;
@@ -147,9 +146,7 @@ nothrow @nogc:
         this.id = 0x7770 + id_counter++;
         this.sig = iface.mac.b[3];
 
-        iface.subscribe(&incoming_packet, PacketFilter(ether_type: EtherType.ow, ow_subtype: OW_SubType.tesla_twc));
-
-        get_module!TeslaProtocolModule.add_server(name[], iface, id);
+        iface.subscribe(&incoming_packet, PacketFilter(type: PacketType.tesla_twc));
     }
 
     ~this()
@@ -217,7 +214,7 @@ nothrow @nogc:
             message[0..2] = ushort(round_robin_index++ < -5 ? 0xFCE1 : 0xFBE2).nativeToBigEndian;
             message[2..4] = id.nativeToBigEndian;
             message[4] = sig;
-            send_twc_message(MACAddress.broadcast, message[]);
+            send_twc_message(TWCFrame.broadcast, message[]);
             return;
         }
 
@@ -327,22 +324,22 @@ nothrow @nogc:
         }
 
         // send request
-        send_twc_message(c.mac, message[]);
+        send_twc_message(c.id, message[]);
     }
 
-    void send_twc_message(MACAddress dst, const(void)[] message)
+    void send_twc_message(ushort dst, const(void)[] message)
     {
         Packet p;
-        ref Ethernet hdr = p.init!Ethernet(message[]);
-        hdr.src = iface.mac;
-        hdr.dst = dst;
-        hdr.ether_type = EtherType.ow;
-        hdr.ow_sub_type = OW_SubType.tesla_twc;
+        ref TWCFrame twc = p.init!TWCFrame(message[]);
+        twc.src = id;
+        twc.dst = dst;
         iface.forward(p);
     }
 
     void incoming_packet(ref const Packet p, BaseInterface iface, PacketDirection dir, void* user_data) nothrow @nogc
     {
+        ref const twc = p.hdr!TWCFrame;
+
         TWCMessage msg;
         if (parse_twc_message(cast(ubyte[])p.data, msg))
         {
@@ -357,18 +354,17 @@ nothrow @nogc:
             }
             if (!slave)
             {
-                // there's a slave on the bus that was never registered...
-                //... ???
+                // a device on the bus that was never registered (or another master)
+                return;
             }
 
-            if (p.eth.dst.is_broadcast)
+            if (twc.dst == TWCFrame.broadcast)
             {
                 switch (msg.type)
                 {
                     case TWCMessageType.SlaveLinkReady:
                         if (slave.link_ready)
                             break;
-                        slave.mac = p.eth.src;
                         slave.link_ready = true;
                         slave.sig_byte = msg.link_ready.signature;
                         slave.device_max_current = msg.link_ready.amps;
@@ -433,7 +429,7 @@ nothrow @nogc:
                         break;
                 }
             }
-            else if (p.eth.dst == iface.mac && msg.type == TWCMessageType.SlaveHeartbeat)
+            else if (twc.dst == id && msg.type == TWCMessageType.SlaveHeartbeat)
             {
                 // record heartbeat response state...
                 slave.state = msg.heartbeat.state;

--- a/src/protocol/tesla/master.d
+++ b/src/protocol/tesla/master.d
@@ -144,7 +144,9 @@ nothrow @nogc:
 
         static ubyte id_counter = 0;
         this.id = 0x7770 + id_counter++;
-        this.sig = iface.mac.b[3];
+
+        import urt.crc;
+        this.sig = cast(ubyte)calculate_crc!(Algorithm.crc32_iso_hdlc)(iface.name[]);
 
         iface.subscribe(&incoming_packet, PacketFilter(type: PacketType.tesla_twc));
     }

--- a/src/protocol/tesla/package.d
+++ b/src/protocol/tesla/package.d
@@ -18,18 +18,9 @@ import protocol.tesla.master;
 import protocol.tesla.binding;
 
 import router.iface;
-import router.iface.mac;
 
 nothrow @nogc:
 
-
-struct DeviceMap
-{
-    String name;
-    MACAddress mac;
-    ushort address;
-    TeslaInterface iface;
-}
 
 class TeslaProtocolModule : Module
 {
@@ -37,11 +28,10 @@ class TeslaProtocolModule : Module
 nothrow @nogc:
 
     Map!(const(char)[], TeslaTWCMaster) twc_masters;
-    Map!(ushort, DeviceMap) devices;
 
     override void init()
     {
-        register_address_extractor(PacketType.tesla_twc, &extract_twc_src_address, &extract_twc_dst_address, &is_twc_broadcast);
+        register_packet_codec!TWCFrame();
 
         g_app.console.register_collection!TeslaInterface();
         g_app.console.register_collection!TeslaTWCBinding();
@@ -54,60 +44,6 @@ nothrow @nogc:
         // TeslaInterface update handled by base interface collection
         foreach(m; twc_masters.values)
             m.update();
-    }
-
-        DeviceMap* find_server_by_name(const(char)[] name)
-    {
-        foreach (ref map; devices.values)
-        {
-            if (map.name[] == name[])
-                return &map;
-        }
-        return null;
-    }
-
-    DeviceMap* find_server_by_mac(MACAddress mac)
-    {
-        foreach (ref map; devices.values)
-        {
-            if (map.mac == mac)
-                return &map;
-        }
-        return null;
-    }
-
-    DeviceMap* find_server_by_address(ushort address)
-    {
-        return address in devices;
-    }
-
-    DeviceMap* add_device(const(char)[] name, TeslaInterface iface, ushort address)
-    {
-        if (!name)
-            name = tformat("{0}.{1,04X}", iface.name[], address);
-
-        DeviceMap map;
-        map.name = name.makeString(defaultAllocator());
-        map.address = address;
-        map.mac = iface.generate_mac_address();
-        map.mac.b[4] = address >> 8;
-        map.mac.b[5] = address & 0xFF;
-//        while (find_mac_address(map.mac) !is null)
-//            ++map.mac.b[5];
-        map.iface = iface;
-
-        iface.add_address(map.mac, iface);
-        return devices.insert(address, map);
-    }
-
-    DeviceMap* add_server(const(char)[] name, BaseInterface iface, ushort address)
-    {
-        DeviceMap map;
-        map.name = name.makeString(defaultAllocator());
-        map.address = address;
-        map.mac = iface.mac;
-//        map.iface = iface;
-        return devices.insert(address, map);
     }
 
     void twc_add(Session session, const(char)[] name, const(char)[] _interface, ushort id, float max_current)
@@ -151,22 +87,3 @@ nothrow @nogc:
     }
 
 }
-
-ulong extract_twc_src_address(ref const Packet p) pure
-{
-    ulong addr = p.hdr!TWCFrame().src;
-    addr |= ulong(p.vlan & 0xFFF) << 48;
-    addr |= ulong(PacketType.tesla_twc) << 60;
-    return addr;
-}
-
-ulong extract_twc_dst_address(ref const Packet p) pure
-{
-    ulong addr = p.hdr!TWCFrame().dst;
-    addr |= ulong(p.vlan & 0xFFF) << 48;
-    addr |= ulong(PacketType.tesla_twc) << 60;
-    return addr;
-}
-
-bool is_twc_broadcast(ulong address) pure
-    => (address & 0xFFFF) == 0xFFFF;

--- a/src/protocol/zigbee/aps.d
+++ b/src/protocol/zigbee/aps.d
@@ -72,28 +72,28 @@ struct APSFrame
     // TODO: should we keep these? it's not really APS data, but it's interesting incoming packet knowledge...
     ubyte last_hop_lqi;
     byte last_hop_rssi;
-}
 
-ulong extract_aps_src_address(ref const Packet p) pure
-{
-    ref aps = p.hdr!APSFrame();
-    ulong addr = (aps.pan_id << 16) | aps.src;
-    addr |= ulong(p.vlan & 0xFFF) << 48;
-    addr |= ulong(PacketType.zigbee_aps) << 60;
-    return addr;
-}
+    static ulong extract_src(ref const Packet p) pure nothrow @nogc
+    {
+        ref aps = p.hdr!APSFrame();
+        ulong addr = (aps.pan_id << 16) | aps.src;
+        addr |= ulong(p.vlan & 0xFFF) << 48;
+        addr |= ulong(PacketType.zigbee_aps) << 60;
+        return addr;
+    }
 
-ulong extract_aps_dst_address(ref const Packet p) pure
-{
-    ref aps = p.hdr!APSFrame();
-    ulong addr = (aps.pan_id << 16) | aps.dst;
-    addr |= ulong(p.vlan & 0xFFF) << 48;
-    addr |= ulong(PacketType.zigbee_aps) << 60;
-    return addr;
-}
+    static ulong extract_dst(ref const Packet p) pure nothrow @nogc
+    {
+        ref aps = p.hdr!APSFrame();
+        ulong addr = (aps.pan_id << 16) | aps.dst;
+        addr |= ulong(p.vlan & 0xFFF) << 48;
+        addr |= ulong(PacketType.zigbee_aps) << 60;
+        return addr;
+    }
 
-bool is_aps_broadcast(ulong address) pure
-    => (address & 0xFFFF) >= 0xFFFB;
+    static bool is_multicast(ulong address) pure nothrow @nogc
+        => (address & 0xFFFF) >= 0xFFFB;
+}
 
 ptrdiff_t parse_aps_frame(const void[] packet, out APSFrame frame) pure
 {

--- a/src/protocol/zigbee/iface.d
+++ b/src/protocol/zigbee/iface.d
@@ -703,7 +703,7 @@ private:
         version (DebugZigbeeMessageFlow)
             writeDebugf("Zigbee: APS recv ({0, 03}) - {1, 04x}:{2, 02x}<-{3, 04x}:{4, 02x} [{5}:{6, 04x}] - [{7}]", hdr.counter, hdr.dst, hdr.dst_endpoint, hdr.src, hdr.src_endpoint, profile_name(hdr.profile_id), hdr.cluster_id, cast(void[])message);
 
-        dispatch(p);
+        incoming_packet(p);
     }
 
     void lookup_eui_response(void* user_data, EmberStatus status, EmberEUI64 eui64)

--- a/src/protocol/zigbee/package.d
+++ b/src/protocol/zigbee/package.d
@@ -281,10 +281,10 @@ nothrow @nogc:
 
     override void init()
     {
-        import protocol.zigbee.aps : extract_aps_src_address, extract_aps_dst_address, is_aps_broadcast;
+        import protocol.zigbee.aps : APSFrame;
 
-//        register_address_extractor(PacketType.zigbee_nwk, &extract_nwk_src_address, &extract_nwk_dst_address);
-        register_address_extractor(PacketType.zigbee_aps, &extract_aps_src_address, &extract_aps_dst_address, &is_aps_broadcast);
+//        register_packet_codec!NWKFrame();
+        register_packet_codec!APSFrame();
 
         g_app.console.register_collection!ZigbeeInterface();
         g_app.console.register_collection!ZigbeeNode();

--- a/src/router/iface/address_table.d
+++ b/src/router/iface/address_table.d
@@ -82,6 +82,21 @@ nothrow @nogc:
             _backing.remove(key);
     }
 
+    int opApply(scope int delegate(ulong address, ubyte port) nothrow @nogc dg)
+    {
+        foreach (i; 0 .. _len)
+        {
+            if (int r = dg(_keys[i], _values[i]))
+                return r;
+        }
+        foreach (ref kvp; _backing)
+        {
+            if (int r = dg(kvp.key, kvp.value))
+                return r;
+        }
+        return 0;
+    }
+
     void remove_port(ubyte port_index)
     {
         ulong[64] remove_buf = void;

--- a/src/router/iface/bridge.d
+++ b/src/router/iface/bridge.d
@@ -16,6 +16,7 @@ import manager.plugin;
 
 import router.iface;
 import router.iface.address_table;
+import router.iface.ethernet;
 import router.iface.vlan;
 
 nothrow @nogc:
@@ -40,7 +41,13 @@ void register_bridge_offload_hooks(MemberAddedHook member_added, CpuPromiscHook 
 }
 
 
-class BridgeInterface : BaseInterface
+// Bridge switches two domains, split by InterfaceCaps.ethernet:
+//  - the ethernet domain: ethernet members, the kernel-offloaded segment via the
+//    CPU conduit, and the attachment (frames addressed to the bridge itself)
+//  - the exotic domain: exotic members, local delivery, and the attachment
+//    (exotic packets crossing the ethernet domain OW-encapsulated)
+// The attachment appears in both: it is where the domains meet.
+class BridgeInterface : EthernetStation
 {
     alias Properties = AliasSeq!(Prop!("vlan-filtering", vlan_filtering),
                                  Prop!("pvid", pvid),
@@ -133,7 +140,7 @@ nothrow @nogc:
     bool add_member(BaseInterface iface, ushort pvid = 1, bool ingress_filtering = true, bool untagged_egress = true)
     {
         assert(iface !is this, "Cannot add a bridge to itself!");
-        assert(_members.length < 256, "Too many _members in the bridge!");
+        assert(_members.length < _cpu_port, "Too many _members in the bridge!"); // member indices live below the pseudo-ports
         assert(!(iface.flags & ObjectFlags.slave), "Interface is already slaved!");
 
         ubyte port = cast(ubyte)_members.length;
@@ -157,6 +164,10 @@ nothrow @nogc:
                     _address_table.insert(ulong(map.universal_address) | (ulong(vlan) << 48) | (ulong(PacketType.modbus) << 60), port);
             }
         }
+
+        // a new ethernet member extends the segment: re-prime the neighbour table
+        if (running && (iface.caps & InterfaceCaps.ethernet))
+            station_link_up();
 
         // Member added to a running bridge: let the backend (re-)evaluate offload --
         // a second netdev member may newly qualify it, or an already-offloaded
@@ -235,29 +246,31 @@ nothrow @nogc:
     }
 
     // Ingress from the kernel-switched ethernet segment (the offload module drains
-    // the CPU-port socket and feeds frames here).
+    // the CPU-port socket and feeds frames here). This is a switching ingress like
+    // any member port, with src = _cpu_port.
     void cpu_port_incoming(ref Packet packet)
     {
         if (!running || !_cpu.active)
             return;
 
-        // Intra-segment unicast the kernel already switched can still surface here
-        // when the CPU port is promiscuous (a sniffer is attached). The kernel has
-        // delivered it among the netdev members -- nothing for OW to do.
+        // Promisc surfaces frames the kernel already switched among its own ports
+        // (a sniffer is attached): feed subscribers, nothing else to do.
         ulong dst = get_network_dst_address(packet);
         if (!dst.is_multicast_address)
         {
             int dp = _address_table.get(dst);
-            if (dp >= 0 && dp != _local_port && _members[dp].offloaded)
+            if (dp >= 0 && (dp == _cpu_port || (dp < _members.length && _members[dp].offloaded)))
+            {
+                fire_subscribers(packet);
                 return;
+            }
         }
 
-        // dispatch() fires bridge subscribers (sniff) and delivers bridge-addressed
-        // frames to OW's L3 handlers. Forwarding kernel-segment frames on to
-        // non-netdev members is the (today-inert) cross-domain seam: PacketType
-        // sub-domains don't share frames yet. TODO: wrap-and-forward once an
-        // OW-ethertype carrier exists.
-        dispatch(packet);
+        ulong src = get_network_src_address(packet);
+        if (!src.is_multicast_address)
+            _address_table.insert(src, _cpu_port);
+
+        send(packet, _cpu_port);
     }
 
     // The CPU port only needs promiscuous mode to feed a sniffer; bridge-addressed
@@ -387,7 +400,7 @@ protected:
                 cb(entry.bridge_tag, MessageState.aborted);
             recycle_tracking(entry);
         }
-        return CompletionStatus.complete;
+        return super.shutdown();
     }
 
     override void update()
@@ -407,6 +420,46 @@ protected:
         else
             _address_table.insert(key, _local_port);
         return true;
+    }
+
+    // The medium is the switched ethernet domain: wrapped frames from the station
+    // enter switching at the attachment.
+    final override void medium_tx(ref Packet packet)
+    {
+        send(packet, _attach_port);
+    }
+
+    // Decapped exotic traffic enters the exotic switching domain at the attachment.
+    final override void station_deliver(ref Packet inner)
+    {
+        ulong src_address = get_network_src_address(inner);
+        if (!src_address.is_multicast_address)
+            _address_table.insert(src_address, _attach_port);
+
+        send(inner, _attach_port);
+    }
+
+    final override bool station_owns(ulong address)
+    {
+        if (cast(PacketType)(address >> 60) == PacketType.ethernet)
+            return false;
+        int port = _address_table.get(address);
+        return port >= 0 && software_domain_port(cast(ubyte)port);
+    }
+
+    final override void station_list(PacketType type, scope void delegate(ulong address) nothrow @nogc sink)
+    {
+        foreach (ulong address, ubyte port; _address_table)
+        {
+            if (!software_domain_port(port))
+                continue;
+            PacketType t = cast(PacketType)(address >> 60);
+            if (t == PacketType.ethernet)
+                continue;
+            if (type != PacketType.unknown && t != type)
+                continue;
+            sink(address);
+        }
     }
 
     final override void slave_incoming(ref Packet packet, byte slave_id)
@@ -476,7 +529,7 @@ protected:
                 int dst_port = _address_table.get(dst_address);
                 if (dst_port >= 0)
                 {
-                    if (dst_port != src_port && dst_port != _local_port)
+                    if (dst_port != src_port && dst_port < _members.length)
                         log.trace("forward: ", packet.eth.src, " -> ", _members[dst_port].iface.name, "(", packet.eth.dst, ") [", packet.data, "]");
                 }
                 else
@@ -491,8 +544,9 @@ protected:
 
 private:
 
-    enum ubyte _local_port = 0xFE;
-    enum ubyte _cpu_port = 0xFD;    // kernel-offloaded ethernet segment, reached via the CPU-port AF_PACKET on br-<name>
+    enum ubyte _local_port  = 0xFE;
+    enum ubyte _attach_port = 0xFD; // the station (EthernetStation): where the exotic and ethernet domains meet
+    enum ubyte _cpu_port    = 0xFC; // kernel-offloaded ethernet segment, reached via the CPU-port AF_PACKET on br-<name>
     enum _tracking_batch_size = 4;
 
     struct CpuPort
@@ -583,11 +637,22 @@ private:
     TagTracking* _tracking_active;
     TagAllocator _bridge_tags;
 
+    // an exotic address is ours if it lives behind a software-domain port (a local
+    // endpoint or an exotic member), not across the ethernet domain
+    bool software_domain_port(ubyte port)
+    {
+        if (port == _attach_port || port == _cpu_port)
+            return false;
+        if (port == _local_port)
+            return true;
+        return port < _members.length && !(_members[port].iface.caps & InterfaceCaps.ethernet);
+    }
+
     void local_dispatch(ref Packet packet)
     {
         if (!_vlan_filtering)
         {
-            dispatch(packet);
+            incoming_packet(packet);
             return;
         }
 
@@ -596,7 +661,7 @@ private:
         {
             if (_bridge_port.untagged_egress)
                 packet.vlan &= 0xF000;
-            dispatch(packet);
+            incoming_packet(packet);
             return;
         }
         // walk inherited _vlans Array for the matching sub-iface
@@ -616,6 +681,8 @@ private:
         if (!running)
             return;
 
+        bool is_eth = packet.type == PacketType.ethernet;
+
         ulong address = get_network_dst_address(packet);
         if (!address.is_multicast_address)
         {
@@ -628,6 +695,18 @@ private:
                 if (dst_port == _local_port)
                 {
                     local_dispatch(packet);
+                }
+                else if (dst_port == _attach_port)
+                {
+                    // exotic packet crossing to the ethernet domain
+                    if (!is_eth && !station_egress(packet))
+                        add_tx_drop();
+                }
+                else if (dst_port == _cpu_port)
+                {
+                    // host across the kernel-switched segment; inject via the CPU port
+                    if (_cpu.active && is_eth)
+                        _cpu.send(packet);
                 }
                 else if (_members[dst_port].offloaded)
                 {
@@ -658,35 +737,51 @@ private:
             }
         }
 
-        // broadcast, or unknown sender...
+        // broadcast, or unknown destination: flood within the packet's switching domain
         foreach (i, ref member; _members)
         {
-            if (i != src_port && !member.offloaded && member.iface.running)
-            {
-                if (_vlan_filtering)
-                {
-                    if (packet.vlan == member.pvid)
-                    {
-                        if (member.untagged_egress)
-                            packet.vlan &= 0xF000; // should we leave the pcp bits in-tact?
-                    }
-                    else
-                    {
-                        // check if bridge port is a vlan member?
-                        assert(false);
-                    }
-                }
+            if (i == src_port || member.offloaded || !member.iface.running)
+                continue;
+            bool eth_member = (member.iface.caps & InterfaceCaps.ethernet) != 0;
+            if (eth_member != is_eth)
+                continue;
 
-                if (member.iface.forward(packet) < 0)
-                    add_tx_drop();
+            if (_vlan_filtering)
+            {
+                if (packet.vlan == member.pvid)
+                {
+                    if (member.untagged_egress)
+                        packet.vlan &= 0xF000; // should we leave the pcp bits in-tact?
+                }
+                else
+                {
+                    // check if bridge port is a vlan member?
+                    assert(false);
+                }
             }
+
+            if (member.iface.forward(packet) < 0)
+                add_tx_drop();
         }
-        // flood once into the kernel-switched ethernet segment (split-horizon: not
-        // when the frame came from there). The kernel floods among the netdev members.
-        if (_cpu.active && src_port != _cpu_port)
-            _cpu.send(packet);
-        if (src_port != _local_port)
-            local_dispatch(packet);
+
+        if (is_eth)
+        {
+            // flood once into the kernel-switched ethernet segment (split-horizon: not
+            // when the frame came from there). The kernel floods among the netdev members.
+            if (_cpu.active && src_port != _cpu_port)
+                _cpu.send(packet);
+            // ethernet local delivery is the attachment itself
+            if (src_port != _local_port && src_port != _attach_port)
+                local_dispatch(packet);
+        }
+        else
+        {
+            // exotic floods cross the attachment once; the wrapped frame floods the ethernet domain
+            if (src_port != _attach_port)
+                station_egress(packet);
+            if (src_port != _local_port)
+                local_dispatch(packet);
+        }
     }
 
     TagTracking* alloc_tracking()
@@ -748,6 +843,8 @@ private:
         if (!running)
             return -1;
 
+        bool is_eth = packet.type == PacketType.ethernet;
+
         TagTracking* tracking = alloc_tracking();
         bool any_succeeded = false;
 
@@ -764,7 +861,17 @@ private:
                     return 0;
                 }
 
-                if (_members[dst_port].offloaded)
+                if (dst_port == _attach_port)
+                {
+                    // crossing to the ethernet domain is synchronous
+                    recycle_tracking(tracking);
+                    if (is_eth || !station_egress(packet))
+                        return -1;
+                    add_tx_frame(packet.data.length);
+                    return 0;
+                }
+
+                if (dst_port == _cpu_port || _members[dst_port].offloaded)
                 {
                     // kernel switches the ethernet segment; inject via the CPU port
                     // (fire-and-forget -- AF_PACKET sendto has no ack to track).
@@ -808,10 +915,11 @@ private:
             }
         }
 
-        // broadcast / unknown destination
+        // broadcast / unknown destination: flood within the packet's switching domain
         foreach (i, ref member; _members)
         {
-            if (!member.iface.running || member.offloaded)
+            bool eth_member = (member.iface.caps & InterfaceCaps.ethernet) != 0;
+            if (!member.iface.running || member.offloaded || eth_member != is_eth)
                 continue;
 
             if (_vlan_filtering)
@@ -835,12 +943,21 @@ private:
                 any_succeeded = true;
         }
 
-        // flood into the kernel-switched ethernet segment (send_tracked is only
-        // called for the bridge's own egress, so src is never the CPU port).
-        if (_cpu.active)
+        if (is_eth)
         {
-            _cpu.send(packet);
-            any_succeeded = true;
+            // flood into the kernel-switched ethernet segment (send_tracked is only
+            // called for the bridge's own egress, so src is never the CPU port).
+            if (_cpu.active)
+            {
+                _cpu.send(packet);
+                any_succeeded = true;
+            }
+        }
+        else
+        {
+            // exotic floods cross the attachment; the wrapped frame floods the ethernet domain
+            if (station_egress(packet))
+                any_succeeded = true;
         }
 
         if (tracking.pending == 0)

--- a/src/router/iface/bridge.d
+++ b/src/router/iface/bridge.d
@@ -452,14 +452,6 @@ protected:
                     // TODO: check if port is a member of tag_vlan...
                     assert(false, "TODO");
                 }
-
-                if (packet.eth.ether_type == EtherType.ow)
-                {
-                    if (packet.data.length < 2)
-                        goto drop_packet;
-                    packet.eth.ow_sub_type = loadBigEndian(++tag);
-                    packet._offset += 2;
-                }
             }
             else
                 src_vlan = (packet.vlan & 0xF000) | port.pvid;

--- a/src/router/iface/ethernet.d
+++ b/src/router/iface/ethernet.d
@@ -1,35 +1,239 @@
 module router.iface.ethernet;
 
-import urt.array;
 import urt.endian;
 import urt.log;
 import urt.map;
-import urt.mem;
-import urt.mem.temp;
-import urt.string;
 import urt.time;
-import urt.fibre;
+import urt.util : min;
 
 import manager.collection;
 import manager.console;
 import manager.plugin;
 
 import router.iface;
-import router.iface.vlan;
 
 //version = DebugEthernetFlow;
 
 nothrow @nogc:
 
 
-abstract class EthernetInterface : BaseInterface
+abstract class EthernetStation : BaseInterface
 {
 nothrow @nogc:
 
-    protected override int transmit(ref const Packet packet, MessageCallback)
+    MACAddress mac;
+
+    final int send(MACAddress dest, const(void)[] message, EtherType type, MessageCallback callback = null)
     {
-        send(packet);
-        return 0;
+        Packet p;
+        ref eth = p.init!Ethernet(message);
+        eth.src = mac;
+        eth.dst = dest;
+        eth.ether_type = type;
+        return forward(p, callback);
+    }
+
+protected:
+
+    this(const CollectionTypeInfo* typeInfo, CID id, ObjectFlags flags = ObjectFlags.none)
+    {
+        super(typeInfo, id, flags);
+        _caps |= InterfaceCaps.ethernet;
+        mac = generate_mac_address(name[]);
+    }
+
+    // Egress seam toward the segment; takes a fully-formed ethernet packet.
+    abstract void medium_tx(ref Packet packet);
+
+    // Where locally-decapped exotic traffic enters: standalone = local delivery;
+    // Bridge redirects this into its exotic switching domain.
+    void station_deliver(ref Packet inner)
+    {
+        dispatch(inner);
+    }
+
+    override int transmit(ref Packet packet, MessageCallback)
+    {
+        switch (packet.type)
+        {
+            case PacketType.ethernet:
+                medium_tx(packet);
+                return 0;
+
+            case PacketType._6lowpan:
+                assert(false, "TODO: reframe as ipv6?");
+
+            default:
+                // exotic frames are OW-encapsulated for transit across the segment
+                if (!station_egress(packet))
+                    add_tx_drop();
+                return 0;
+        }
+    }
+
+    override void ingress(ref Packet packet)
+    {
+        // vlan-tagged OW frames are not intercepted here: a VLAN sub-interface is the
+        // station for its vlan, and the vlan demux in dispatch() routes tagged frames
+        // to it. No sub-interface configured = not attached to that segment.
+        if (packet.type == PacketType.ethernet && packet.eth.ether_type == EtherType.ow)
+        {
+            if (packet.eth.src == mac)
+                return; // capture echo of our own transmission
+            if (packet.eth.dst != mac && !packet.eth.dst.is_multicast)
+                return; // unicast for another station
+            if (!station_ingress(packet))
+                add_rx_drop();
+            return;
+        }
+        dispatch(packet);
+    }
+
+    override void online()
+    {
+        super.online();
+
+        // prime the neighbour table: ask the segment for everyone's exotic addresses
+        station_link_up();
+    }
+
+    override CompletionStatus shutdown()
+    {
+        // station state is segment-derived; it dies with the link
+        _neighbours.clear();
+        _local_addresses.clear();
+        _who_has_sent.clear();
+        return super.shutdown();
+    }
+
+    // Local-address knowledge for answering who_has/addr_query. The default is the
+    // egress-learned set: complete for a standalone interface, where every outbound
+    // exotic packet passes through station_egress. The bridge overrides with its
+    // address table, which also knows pre-populated and never-crossed addresses.
+    bool station_owns(ulong address)
+        => (address in _local_addresses) !is null;
+
+    void station_list(PacketType type, scope void delegate(ulong address) nothrow @nogc sink)
+    {
+        foreach (ref kvp; _local_addresses)
+        {
+            if (type != PacketType.unknown && cast(PacketType)(kvp.key >> 60) != type)
+                continue;
+            sink(kvp.key);
+        }
+    }
+
+    final MACAddress station_of(ulong address) const
+    {
+        if (!is_network_multicast_address(address))
+        {
+            if (auto r = address in _neighbours)
+                return *r;
+        }
+        return MACAddress.broadcast;
+    }
+
+    final void station_link_up()
+    {
+        ubyte[2] query = ushort(PacketType.unknown).nativeToBigEndian;
+        station_send_control(OWControl.addr_query, MACAddress.broadcast, query);
+    }
+
+    // Encapsulate an exotic packet and transmit it across the segment.
+    final bool station_egress(ref const Packet packet)
+    {
+        const(PacketCodec)* codec = get_ow_codec(packet.type);
+        if (!codec)
+        {
+            log.trace("no ow codec for packet type ", cast(ushort)packet.type, "; frame dropped");
+            return false;
+        }
+
+        // by construction, the inner src is an address on our side
+        ulong src = get_network_src_address(packet);
+        if (!is_network_multicast_address(src))
+            _local_addresses[src] = getTime();
+
+        ubyte[1518] buffer = void;
+        ptrdiff_t len = build_ow_payload(packet, *codec, buffer);
+        if (len <= 0)
+            return false;
+
+        Packet wrapped;
+        ref eth = wrapped.init!Ethernet(buffer[0 .. len], packet.creation_time);
+        eth.src = mac;
+        eth.dst = resolve(get_network_dst_address(packet));
+        eth.ether_type = EtherType.ow;
+        wrapped.vlan = packet.vlan;
+        medium_tx(wrapped);
+        return true;
+    }
+
+    // Decapsulate an OW frame addressed to this station (caller pre-filtered outer src/dst).
+    final bool station_ingress(ref Packet packet)
+    {
+        const(ubyte)[] content = cast(const(ubyte)[])packet.data;
+        if (content.length < 5)
+            return false;
+        ushort wire_type = loadBigEndian(cast(const(ushort)*)content.ptr);
+        ushort data_len = loadBigEndian(cast(const(ushort)*)(content.ptr + 2));
+        ubyte hdr_len = content[4];
+
+        if (wire_type & ow_control_flag)
+        {
+            if (content.length < 5 + data_len)
+                return false;
+            add_rx_frame(packet.length);
+            station_control(cast(OWControl)wire_type, content[5 .. 5 + data_len], packet.eth.src);
+            return true;
+        }
+
+        if (content.length < 5 + hdr_len + data_len)
+            return false;
+
+        const(PacketCodec)* codec = wire_type < PacketType.count ? get_ow_codec(cast(PacketType)wire_type) : null;
+        if (!codec)
+        {
+            log.trace("ow frame with unknown packet type ", wire_type, "; dropped");
+            return false;
+        }
+
+        Packet inner;
+        inner.creation_time = packet.creation_time;
+        inner.vlan = packet.vlan;
+        inner.data = content[5 + hdr_len .. 5 + hdr_len + data_len];
+        if (codec.decode(inner, content[5 .. 5 + hdr_len]) <= 0)
+            return false;
+
+        // learn the station carrying the inner src so replies can unicast
+        learn(get_network_src_address(inner), packet.eth.src);
+
+        // the inner packet accounts where it terminates; the encap overhead counts here
+        _status.rx_bytes += packet.length - inner.length;
+        station_deliver(inner);
+        return true;
+    }
+
+    // [type:u16][data_len:u16][hdr_len:u8][header][payload]; <= 0 on failure.
+    // data_len is explicit because short frames gain padding on the wire (60-byte minimum).
+    static ptrdiff_t build_ow_payload(ref const Packet packet, ref const PacketCodec codec, ubyte[] buffer)
+    {
+        if (buffer.length < 5)
+            return -1;
+        storeBigEndian(cast(ushort*)buffer.ptr, ushort(packet.type));
+        storeBigEndian(cast(ushort*)(buffer.ptr + 2), cast(ushort)packet.data.length);
+
+        size_t offset = 5;
+        ptrdiff_t hl = codec.encode(packet, buffer[offset .. min(buffer.length, offset + 255)]);
+        if (hl <= 0)
+            return -1;
+        buffer[4] = cast(ubyte)hl;
+        offset += hl;
+
+        if (packet.data.length > buffer.length - offset)
+            return -1;
+        buffer[offset .. offset + packet.data.length] = cast(const(ubyte)[])packet.data[];
+        return offset + packet.data.length;
     }
 
     override ushort pcap_type() const
@@ -37,8 +241,6 @@ nothrow @nogc:
 
     override void pcap_write(ref const Packet packet, PacketDirection dir, scope void delegate(scope const void[] packet_data) nothrow @nogc sink) const
     {
-        import urt.endian;
-
         if (packet.type == PacketType.ethernet)
         {
             struct Header
@@ -62,11 +264,24 @@ nothrow @nogc:
             return;
 
         bool outgoing = dir == PacketDirection.outgoing;
-        MACAddress remote = ow_station_mac(outgoing ? get_network_dst_address(packet) : get_network_src_address(packet));
+        MACAddress remote = station_of(outgoing ? get_network_dst_address(packet) : get_network_src_address(packet));
+
+        ubyte[18] hdr = void;
+        Ethernet* eth = cast(Ethernet*)hdr.ptr;
+        eth.dst = outgoing ? remote : mac;
+        eth.src = outgoing ? mac : remote;
+        ushort* ethertype = &eth.ether_type;
+        if (packet.vlan)
+        {
+            storeBigEndian(ethertype++, ushort(EtherType.vlan));
+            storeBigEndian(ethertype++, packet.vlan);
+        }
+        storeBigEndian(ethertype++, ushort(EtherType.ow));
+        sink(hdr[0 .. cast(ubyte*)ethertype - hdr.ptr]);
 
         ubyte[1518] buffer = void;
-        size_t len = frame_ow(packet, *codec, outgoing ? mac : remote, outgoing ? remote : mac, buffer);
-        if (len == 0)
+        ptrdiff_t len = build_ow_payload(packet, *codec, buffer);
+        if (len <= 0)
             return;
         sink(buffer[0 .. len]);
 
@@ -77,6 +292,132 @@ nothrow @nogc:
             ushort crc = packet.data[3..$].calculate_crc!(Algorithm.crc16_modbus)();
             sink(crc.nativeToLittleEndian());
         }
+    }
+
+private:
+    enum resolve_interval = 5.seconds;
+    enum max_report_entries = 180; // TODO: segment larger reports
+
+    // exotic address -> ethernet station carrying it, learned from OW-encap ingress
+    Map!(ulong, MACAddress) _neighbours;
+    // exotic addresses on our side, learned from encap egress
+    Map!(ulong, MonoTime) _local_addresses;
+    // who_has rate limiting
+    Map!(ulong, MonoTime) _who_has_sent;
+
+    void learn(ulong address, MACAddress station)
+    {
+        if (is_network_multicast_address(address))
+            return;
+        _neighbours[address] = station;
+        _who_has_sent.remove(address);
+    }
+
+    // an unknown unicast also fires who_has; the frame still floods, so delivery never waits on the reply
+    MACAddress resolve(ulong address)
+    {
+        if (is_network_multicast_address(address))
+            return MACAddress.broadcast;
+        if (auto r = address in _neighbours)
+            return *r;
+
+        MonoTime now = getTime();
+        MonoTime* last = address in _who_has_sent;
+        if (!last || now - *last >= resolve_interval)
+        {
+            if (last)
+                *last = now;
+            else
+                _who_has_sent[address] = now;
+            ubyte[8] request = address.nativeToBigEndian;
+            station_send_control(OWControl.who_has, MACAddress.broadcast, request);
+        }
+        return MACAddress.broadcast;
+    }
+
+    void station_send_control(OWControl msg, MACAddress dst, scope const(ubyte)[] content)
+    {
+        ubyte[512] buffer = void;
+        if (content.length + 5 > buffer.length)
+            return;
+        storeBigEndian(cast(ushort*)buffer.ptr, ushort(msg));
+        storeBigEndian(cast(ushort*)(buffer.ptr + 2), cast(ushort)content.length);
+        buffer[4] = 0; // control messages carry no packet header
+        buffer[5 .. 5 + content.length] = content[];
+
+        Packet wrapped;
+        ref eth = wrapped.init!Ethernet(buffer[0 .. 5 + content.length]);
+        eth.src = mac;
+        eth.dst = dst;
+        eth.ether_type = EtherType.ow;
+        medium_tx(wrapped);
+    }
+
+    void station_control(OWControl msg, const(ubyte)[] content, MACAddress src)
+    {
+        switch (msg)
+        {
+            case OWControl.who_has:
+                if (content.length < 8)
+                    return;
+                ulong address = content[0 .. 8].bigEndianToNative!ulong;
+                if (station_owns(address))
+                    station_send_control(OWControl.addr_report, src, content[0 .. 8]);
+                return;
+
+            case OWControl.addr_query:
+                if (content.length < 2)
+                    return;
+                ushort type = content[0 .. 2].bigEndianToNative!ushort;
+                if (type != PacketType.unknown && type >= PacketType.count)
+                    return;
+                ubyte[max_report_entries * 8] entries = void;
+                size_t len = 0;
+                station_list(cast(PacketType)type, (ulong address) {
+                    if (len + 8 <= entries.length)
+                    {
+                        entries[len .. len + 8] = address.nativeToBigEndian;
+                        len += 8;
+                    }
+                });
+                if (len)
+                    station_send_control(OWControl.addr_report, src, entries[0 .. len]);
+                return;
+
+            case OWControl.addr_report:
+                while (content.length >= 8)
+                {
+                    ulong address = content[0 .. 8].bigEndianToNative!ulong;
+                    content = content[8 .. $];
+                    if (cast(PacketType)(address >> 60) >= PacketType.count)
+                        continue;
+                    learn(address, src);
+                }
+                return;
+
+            default:
+                return;
+        }
+    }
+}
+
+
+abstract class EthernetInterface : EthernetStation
+{
+nothrow @nogc:
+
+protected:
+
+    this(const CollectionTypeInfo* typeInfo, CID id, ObjectFlags flags = ObjectFlags.none)
+    {
+        super(typeInfo, id, flags);
+
+        // TODO: proper values?
+//        _mtu = 1500;
+//        _max_l2mtu = _mtu;
+//        _l2mtu = 1500;
+
+//        mark_set!(typeof(this), "max-l2mtu")();
     }
 
     final void incoming_ethernet_frame(const(ubyte)[] data, MonoTime ts)
@@ -95,23 +436,6 @@ nothrow @nogc:
         eth.ether_type = data[12 .. 14].bigEndianToNative!ushort;
         packet._offset = 14;
 
-        // OW-encapsulated exotic frames unwrap at ingress so subscribers and bridges
-        // see the inner packet natively; peek through a single 802.1Q tag if present
-        ushort ow_ether_type = eth.ether_type;
-        size_t ow_offset = 14;
-        ushort tci = 0;
-        if (eth.ether_type == EtherType.vlan && data.length >= 18)
-        {
-            tci = data[14 .. 16].bigEndianToNative!ushort;
-            ow_ether_type = data[16 .. 18].bigEndianToNative!ushort;
-            ow_offset = 18;
-        }
-        if (ow_ether_type == EtherType.ow)
-        {
-            incoming_ow_frame(data, ow_offset, tci, eth.src, eth.dst, ts);
-            return;
-        }
-
         if (eth.ether_type == 0x88E5) // MACsec
         {
             // TODO: handle MACsec frames?
@@ -120,191 +444,49 @@ nothrow @nogc:
             return;
         }
 
-        // dispatch counts only payload bytes; account for the link-layer overhead here
+        // the packet accounts only payload bytes; account the link-layer overhead here
         _status.rx_bytes += data.length - packet.length;
-        dispatch(packet);
+        incoming_packet(packet);
     }
 
-    void send(ref const Packet packet) nothrow @nogc
+    // The medium is the wire: frame the packet and push it via wire_send.
+    final override void medium_tx(ref Packet packet)
     {
+        debug assert(packet.type == PacketType.ethernet, "medium_tx expects an ethernet packet");
+
         ubyte[1518] buffer = void; // 1500 IP + 14 ETH + 4 VLAN. TODO: jumbos / double-tag.
-        size_t packet_len;
-
-        switch (packet.type)
-        {
-            case PacketType.ethernet:
-                Ethernet* eth = cast(Ethernet*)buffer.ptr;
-                eth.dst = packet.eth.dst;
-                eth.src = packet.eth.src;
-                ushort* ethertype = &eth.ether_type;
-
-                // if there should be a vlan header
-                if (packet.vlan)
-                {
-                    storeBigEndian(ethertype++, ushort(EtherType.vlan));
-                    storeBigEndian(ethertype++, packet.vlan);
-                }
-                storeBigEndian(ethertype++, packet.eth.ether_type);
-
-                // write the payload...
-                ubyte* payload = cast(ubyte*)ethertype;
-                if (packet.data.length > buffer.sizeof - (payload - buffer.ptr))
-                {
-                    log.warning("egress buffer too small: payload=", packet.data.length, " avail=", buffer.sizeof - (payload - buffer.ptr), " vlan=", packet.vlan, " etype=", packet.eth.ether_type);
-                    add_tx_drop();
-                    return;
-                }
-                payload[0 .. packet.data.length] = cast(ubyte[])packet.data[];
-                packet_len = (payload + packet.data.length) - buffer.ptr;
-                break;
-
-            case PacketType._6lowpan:
-                assert(false, "TODO: reframe as ipv6?");
-
-            default:
-                // exotic frames are OW-encapsulated for transit across the ethernet segment
-                const(PacketCodec)* codec = get_ow_codec(packet.type);
-                if (!codec)
-                {
-                    log.trace("no ow codec for packet type ", cast(ushort)packet.type, "; frame dropped");
-                    add_tx_drop();
-                    return;
-                }
-                packet_len = frame_ow(packet, *codec, mac, ow_station_mac(get_network_dst_address(packet)), buffer);
-                if (packet_len == 0)
-                {
-                    add_tx_drop();
-                    return;
-                }
-                break;
-        }
-
-        if (wire_send(buffer[0 .. packet_len]) != 0)
-            add_tx_drop();
-
-        add_tx_frame(packet_len);
-    }
-
-    // Subclass hook: push a fully-framed ethernet frame onto the wire.
-    // Return 0 on success, non-zero on failure (already logged by the subclass).
-    abstract int wire_send(const(ubyte)[] frame);
-
-    override CompletionStatus shutdown()
-    {
-        _ow_neighbours.clear();
-        return super.shutdown();
-    }
-
-    this(const CollectionTypeInfo* typeInfo, CID id, ObjectFlags flags = ObjectFlags.none)
-    {
-        super(typeInfo, id, flags);
-        _caps |= InterfaceCaps.ethernet;
-
-        // TODO: proper values?
-//        _mtu = 1500;
-//        _max_l2mtu = _mtu;
-//        _l2mtu = 1500;
-
-//        mark_set!(typeof(this), "max-l2mtu")();
-    }
-
-private:
-    // exotic address -> ethernet station carrying it, learned from OW-encap ingress
-    Map!(ulong, MACAddress) _ow_neighbours;
-
-    MACAddress ow_station_mac(ulong address) const
-    {
-        if (!is_network_multicast_address(address))
-        {
-            if (auto r = address in _ow_neighbours)
-                return *r;
-        }
-        return MACAddress.broadcast;
-    }
-
-    // Frame an exotic packet as [eth hdr][vlan?][0x88B5][type:u16][data_len:u16][hdr_len:u8][header][payload].
-    // data_len is explicit because short frames gain padding on the wire (60-byte ethernet minimum).
-    // Returns the total frame length, or 0 if the packet can't be encapsulated.
-    size_t frame_ow(ref const Packet packet, ref const PacketCodec codec, MACAddress src, MACAddress dst, ubyte[] buffer) const
-    {
-        import urt.util : min;
 
         Ethernet* eth = cast(Ethernet*)buffer.ptr;
-        eth.dst = dst;
-        eth.src = src;
+        eth.dst = packet.eth.dst;
+        eth.src = packet.eth.src;
         ushort* ethertype = &eth.ether_type;
+
+        // if there should be a vlan header
         if (packet.vlan)
         {
             storeBigEndian(ethertype++, ushort(EtherType.vlan));
             storeBigEndian(ethertype++, packet.vlan);
         }
-        storeBigEndian(ethertype++, ushort(EtherType.ow));
-        storeBigEndian(ethertype++, ushort(packet.type));
-        storeBigEndian(ethertype++, cast(ushort)packet.data.length);
+        storeBigEndian(ethertype++, packet.eth.ether_type);
 
-        ubyte* p = cast(ubyte*)ethertype;
-        ubyte* hdr_len = p++;
-
-        size_t avail = buffer.length - (p - buffer.ptr);
-        ptrdiff_t hl = codec.encode(packet, p[0 .. min(avail, 255)]);
-        if (hl <= 0)
-            return 0;
-        *hdr_len = cast(ubyte)hl;
-        p += hl;
-
-        if (packet.data.length > buffer.length - (p - buffer.ptr))
-            return 0;
-        p[0 .. packet.data.length] = cast(const(ubyte)[])packet.data[];
-        return (p - buffer.ptr) + packet.data.length;
-    }
-
-    // Ingress for an OW-encapsulated frame: unwrap and dispatch the inner packet natively.
-    void incoming_ow_frame(const(ubyte)[] frame, size_t offset, ushort tci, MACAddress src, MACAddress dst, SysTime ts)
-    {
-        if (src == mac)
-            return; // capture echo of our own transmission
-        if (dst != mac && !dst.is_multicast)
-            return; // unicast for another station
-
-        if (frame.length >= offset + 5)
+        // write the payload...
+        ubyte* payload = cast(ubyte*)ethertype;
+        if (packet.data.length > buffer.sizeof - (payload - buffer.ptr))
         {
-            ushort wire_type = loadBigEndian(cast(const(ushort)*)(frame.ptr + offset));
-            ushort data_len = loadBigEndian(cast(const(ushort)*)(frame.ptr + offset + 2));
-            ubyte hdr_len = frame[offset + 4];
-            offset += 5;
-
-            if (wire_type & ow_control_flag)
-            {
-                // OW control-plane message (agent_discover, etc)
-                // TODO: nothing implemented yet
-                return;
-            }
-
-            if (frame.length >= offset + hdr_len + data_len)
-            {
-                const(PacketCodec)* codec = wire_type < PacketType.count ? get_ow_codec(cast(PacketType)wire_type) : null;
-                if (codec)
-                {
-                    Packet packet;
-                    packet.creation_time = ts;
-                    packet.vlan = tci;
-                    packet.data = frame[offset + hdr_len .. offset + hdr_len + data_len];
-                    if (codec.decode(packet, frame[offset .. offset + hdr_len]) > 0)
-                    {
-                        // learn the station carrying the inner src so replies can unicast
-                        ulong inner_src = get_network_src_address(packet);
-                        if (!is_network_multicast_address(inner_src))
-                            _ow_neighbours[inner_src] = src;
-
-                        _status.rx_bytes += frame.length - packet.length;
-                        dispatch(packet);
-                        return;
-                    }
-                }
-                else
-                    log.trace("ow frame with unknown packet type ", wire_type, "; dropped");
-            }
+            log.warning("egress buffer too small: payload=", packet.data.length, " avail=", buffer.sizeof - (payload - buffer.ptr), " vlan=", packet.vlan, " etype=", packet.eth.ether_type);
+            add_tx_drop();
+            return;
         }
-        add_rx_drop();
+        payload[0 .. packet.data.length] = cast(const(ubyte)[])packet.data[];
+        size_t packet_len = (payload + packet.data.length) - buffer.ptr;
+
+        if (wire_send(buffer[0 .. packet_len]) != 0)
+            add_tx_drop();
+        else
+            add_tx_frame(packet_len);
     }
+
+    // Subclass hook: push a fully-framed ethernet frame onto the wire.
+    // Return 0 on success, non-zero on failure (already logged by the subclass).
+    abstract int wire_send(const(ubyte)[] frame);
 }

--- a/src/router/iface/ethernet.d
+++ b/src/router/iface/ethernet.d
@@ -39,28 +39,38 @@ nothrow @nogc:
     {
         import urt.endian;
 
-        bool is_ow = packet.eth.ether_type == EtherType.ow;
-
-        // write ethernet header...
-        struct Header
+        if (packet.type == PacketType.ethernet)
         {
-            MACAddress dst;
-            MACAddress src;
-            ubyte[2] type;
-            ubyte[2] subtype;
+            struct Header
+            {
+                MACAddress dst;
+                MACAddress src;
+                ubyte[2] type;
+            }
+            Header h;
+            h.dst = packet.eth.dst;
+            h.src = packet.eth.src;
+            h.type = nativeToBigEndian(packet.eth.ether_type);
+            sink((cast(ubyte*)&h)[0 .. Header.sizeof]);
+            sink(packet.data);
+            return;
         }
-        Header h;
-        h.dst = packet.eth.dst;
-        h.src = packet.eth.src;
-        h.type = nativeToBigEndian(packet.eth.ether_type);
-        if (is_ow)
-            h.subtype = nativeToBigEndian(packet.eth.ow_sub_type);
-        sink((cast(ubyte*)&h)[0 .. (is_ow ? Header.sizeof : Header.subtype.offsetof)]);
 
-        // write packet data
-        sink(packet.data);
+        // exotic packets appear on the wire OW-encapsulated; synthesize the same frame
+        const(PacketCodec)* codec = get_ow_codec(packet.type);
+        if (!codec)
+            return;
 
-        if (is_ow && packet.eth.ow_sub_type == OW_SubType.modbus)
+        bool outgoing = dir == PacketDirection.outgoing;
+        MACAddress remote = ow_station_mac(outgoing ? get_network_dst_address(packet) : get_network_src_address(packet));
+
+        ubyte[1518] buffer = void;
+        size_t len = frame_ow(packet, *codec, outgoing ? mac : remote, outgoing ? remote : mac, buffer);
+        if (len == 0)
+            return;
+        sink(buffer[0 .. len]);
+
+        if (packet.type == PacketType.modbus)
         {
             // wireshark wants RTU packets for its decoder, so we need to append the crc...
             import urt.crc;
@@ -84,6 +94,23 @@ nothrow @nogc:
         eth.src = MACAddress(data[6 .. 12]);
         eth.ether_type = data[12 .. 14].bigEndianToNative!ushort;
         packet._offset = 14;
+
+        // OW-encapsulated exotic frames unwrap at ingress so subscribers and bridges
+        // see the inner packet natively; peek through a single 802.1Q tag if present
+        ushort ow_ether_type = eth.ether_type;
+        size_t ow_offset = 14;
+        ushort tci = 0;
+        if (eth.ether_type == EtherType.vlan && data.length >= 18)
+        {
+            tci = data[14 .. 16].bigEndianToNative!ushort;
+            ow_ether_type = data[16 .. 18].bigEndianToNative!ushort;
+            ow_offset = 18;
+        }
+        if (ow_ether_type == EtherType.ow)
+        {
+            incoming_ow_frame(data, ow_offset, tci, eth.src, eth.dst, ts);
+            return;
+        }
 
         if (eth.ether_type == 0x88E5) // MACsec
         {
@@ -135,9 +162,21 @@ nothrow @nogc:
                 assert(false, "TODO: reframe as ipv6?");
 
             default:
-                assert(false, "TODO: reframe other protocols as open-watt ethernet...");
-                add_tx_drop();
-                return;
+                // exotic frames are OW-encapsulated for transit across the ethernet segment
+                const(PacketCodec)* codec = get_ow_codec(packet.type);
+                if (!codec)
+                {
+                    log.trace("no ow codec for packet type ", cast(ushort)packet.type, "; frame dropped");
+                    add_tx_drop();
+                    return;
+                }
+                packet_len = frame_ow(packet, *codec, mac, ow_station_mac(get_network_dst_address(packet)), buffer);
+                if (packet_len == 0)
+                {
+                    add_tx_drop();
+                    return;
+                }
+                break;
         }
 
         if (wire_send(buffer[0 .. packet_len]) != 0)
@@ -150,6 +189,12 @@ nothrow @nogc:
     // Return 0 on success, non-zero on failure (already logged by the subclass).
     abstract int wire_send(const(ubyte)[] frame);
 
+    override CompletionStatus shutdown()
+    {
+        _ow_neighbours.clear();
+        return super.shutdown();
+    }
+
     this(const CollectionTypeInfo* typeInfo, CID id, ObjectFlags flags = ObjectFlags.none)
     {
         super(typeInfo, id, flags);
@@ -161,5 +206,105 @@ nothrow @nogc:
 //        _l2mtu = 1500;
 
 //        mark_set!(typeof(this), "max-l2mtu")();
+    }
+
+private:
+    // exotic address -> ethernet station carrying it, learned from OW-encap ingress
+    Map!(ulong, MACAddress) _ow_neighbours;
+
+    MACAddress ow_station_mac(ulong address) const
+    {
+        if (!is_network_multicast_address(address))
+        {
+            if (auto r = address in _ow_neighbours)
+                return *r;
+        }
+        return MACAddress.broadcast;
+    }
+
+    // Frame an exotic packet as [eth hdr][vlan?][0x88B5][type:u16][data_len:u16][hdr_len:u8][header][payload].
+    // data_len is explicit because short frames gain padding on the wire (60-byte ethernet minimum).
+    // Returns the total frame length, or 0 if the packet can't be encapsulated.
+    size_t frame_ow(ref const Packet packet, ref const PacketCodec codec, MACAddress src, MACAddress dst, ubyte[] buffer) const
+    {
+        import urt.util : min;
+
+        Ethernet* eth = cast(Ethernet*)buffer.ptr;
+        eth.dst = dst;
+        eth.src = src;
+        ushort* ethertype = &eth.ether_type;
+        if (packet.vlan)
+        {
+            storeBigEndian(ethertype++, ushort(EtherType.vlan));
+            storeBigEndian(ethertype++, packet.vlan);
+        }
+        storeBigEndian(ethertype++, ushort(EtherType.ow));
+        storeBigEndian(ethertype++, ushort(packet.type));
+        storeBigEndian(ethertype++, cast(ushort)packet.data.length);
+
+        ubyte* p = cast(ubyte*)ethertype;
+        ubyte* hdr_len = p++;
+
+        size_t avail = buffer.length - (p - buffer.ptr);
+        ptrdiff_t hl = codec.encode(packet, p[0 .. min(avail, 255)]);
+        if (hl <= 0)
+            return 0;
+        *hdr_len = cast(ubyte)hl;
+        p += hl;
+
+        if (packet.data.length > buffer.length - (p - buffer.ptr))
+            return 0;
+        p[0 .. packet.data.length] = cast(const(ubyte)[])packet.data[];
+        return (p - buffer.ptr) + packet.data.length;
+    }
+
+    // Ingress for an OW-encapsulated frame: unwrap and dispatch the inner packet natively.
+    void incoming_ow_frame(const(ubyte)[] frame, size_t offset, ushort tci, MACAddress src, MACAddress dst, SysTime ts)
+    {
+        if (src == mac)
+            return; // capture echo of our own transmission
+        if (dst != mac && !dst.is_multicast)
+            return; // unicast for another station
+
+        if (frame.length >= offset + 5)
+        {
+            ushort wire_type = loadBigEndian(cast(const(ushort)*)(frame.ptr + offset));
+            ushort data_len = loadBigEndian(cast(const(ushort)*)(frame.ptr + offset + 2));
+            ubyte hdr_len = frame[offset + 4];
+            offset += 5;
+
+            if (wire_type & ow_control_flag)
+            {
+                // OW control-plane message (agent_discover, etc)
+                // TODO: nothing implemented yet
+                return;
+            }
+
+            if (frame.length >= offset + hdr_len + data_len)
+            {
+                const(PacketCodec)* codec = wire_type < PacketType.count ? get_ow_codec(cast(PacketType)wire_type) : null;
+                if (codec)
+                {
+                    Packet packet;
+                    packet.creation_time = ts;
+                    packet.vlan = tci;
+                    packet.data = frame[offset + hdr_len .. offset + hdr_len + data_len];
+                    if (codec.decode(packet, frame[offset .. offset + hdr_len]) > 0)
+                    {
+                        // learn the station carrying the inner src so replies can unicast
+                        ulong inner_src = get_network_src_address(packet);
+                        if (!is_network_multicast_address(inner_src))
+                            _ow_neighbours[inner_src] = src;
+
+                        _status.rx_bytes += frame.length - packet.length;
+                        dispatch(packet);
+                        return;
+                    }
+                }
+                else
+                    log.trace("ow frame with unknown packet type ", wire_type, "; dropped");
+            }
+        }
+        add_rx_drop();
     }
 }

--- a/src/router/iface/package.d
+++ b/src/router/iface/package.d
@@ -125,10 +125,7 @@ nothrow @nogc:
     MACAddress src;
     MACAddress dst;
     ushort ether_type;
-    union {
-        ushort ow_subtype; // if ether_type == EtherType.ow
-        ushort ether_type_2;
-    }
+    ushort ether_type_2;
     ushort vlan;
 
     bool match(ref const Packet p)
@@ -143,14 +140,7 @@ nothrow @nogc:
                 {
                     if (p.eth.ether_type != ether_type)
                     {
-                        if (!ether_type_2 || ether_type == EtherType.ow)
-                            return false;
-                        if (p.eth.ether_type != ether_type_2)
-                            return false;
-                    }
-                    else if (ether_type == EtherType.ow)
-                    {
-                        if (ow_subtype && p.eth.ow_sub_type != ow_subtype)
+                        if (!ether_type_2 || p.eth.ether_type != ether_type_2)
                             return false;
                     }
                 }

--- a/src/router/iface/package.d
+++ b/src/router/iface/package.d
@@ -176,6 +176,20 @@ struct InterfaceSubscriber
 //      02:FE:ED:xx:xx:yy
 //      02:B0:0B:xx:xx:yy
 
+MACAddress generate_mac_address(const(char)[] name) pure
+{
+    import urt.crc;
+    alias crc_fun = calculate_crc!(Algorithm.crc32_iso_hdlc);
+
+    enum ushort MAGIC = 0x1337;
+
+    uint crc = crc_fun(name);
+    MACAddress addr = MACAddress(0x02, MAGIC >> 8, MAGIC & 0xFF, crc & 0xFF, (crc >> 8) & 0xFF, crc >> 24);
+    if (addr.b[5] < 100 || addr.b[5] >= 240)
+        addr.b[5] ^= 0x80;
+    return addr;
+}
+
 class BaseInterface : ActiveObject
 {
     alias Properties = AliasSeq!(Prop!("actual-mtu", actual_mtu, null, "d"),
@@ -208,15 +222,9 @@ nothrow @nogc:
     enum path = "/interface";
     enum collection_id = CollectionType.interface_;
 
-    MACAddress mac;
-    Map!(MACAddress, BaseInterface) macTable;
-
     this(const CollectionTypeInfo* type_info, CID id, ObjectFlags flags = ObjectFlags.none)
     {
         super(type_info, id, flags);
-
-        mac = generate_mac_address();
-        add_address(mac, this);
     }
 
     // Properties...
@@ -425,16 +433,6 @@ nothrow @nogc:
     {
     }
 
-    int send(MACAddress dest, const(void)[] message, EtherType type, MessageCallback callback = null)
-    {
-        Packet p;
-        ref eth = p.init!Ethernet(message);
-        eth.src = mac;
-        eth.dst = dest;
-        eth.ether_type = type;
-        return forward(p, callback);
-    }
-
     int forward(ref Packet packet, MessageCallback callback = null)
     {
         if (!running)
@@ -470,25 +468,6 @@ nothrow @nogc:
 
     final InterfaceCaps caps() const pure
         => _caps;
-
-    final void add_address(MACAddress mac, BaseInterface iface)
-    {
-        assert(mac !in macTable, "MAC address already in use!");
-        macTable[mac] = iface;
-    }
-
-    final void remove_address(MACAddress mac)
-    {
-        macTable.remove(mac);
-    }
-
-    final BaseInterface find_mac_address(MACAddress mac)
-    {
-        BaseInterface* i = mac in macTable;
-        if (i)
-            return *i;
-        return null;
-    }
 
     ushort pcap_type() const
         => 0;
@@ -544,32 +523,34 @@ protected:
 
     abstract int transmit(ref Packet packet, MessageCallback callback = null);
 
+    final void incoming_packet(ref Packet packet)
+    {
+        if (_master)
+        {
+            add_rx_frame(packet.length);
+            fire_subscribers(packet);
+            _master.slave_incoming(packet, _slave_id);
+            return;
+        }
+
+        ingress(packet);
+    }
+
+    // Ingress stage between reception and local delivery: switching and station
+    // transforms live here. Default: everything terminates locally.
+    void ingress(ref Packet packet)
+    {
+        dispatch(packet);
+    }
+
     final void dispatch(ref Packet packet)
     {
         import urt.endian : loadBigEndian;
 
+        debug assert(_master is null, "dispatch() on a slaved interface; ingress must enter via incoming_packet()");
+
         add_rx_frame(packet.length);
-
-        if (packet.type == PacketType.ethernet && !packet.eth.src.is_multicast)
-        {
-            if (find_mac_address(packet.eth.src) is null)
-                add_address(packet.eth.src, this);
-        }
-
-        if (_num_subscribers)
-        {
-            foreach (ref subscriber; _subscribers[0.._num_subscribers])
-            {
-                if ((subscriber.filter.direction & PacketDirection.incoming) && subscriber.filter.match(packet))
-                    subscriber.recv_packet(packet, this, PacketDirection.incoming, subscriber.user_data);
-            }
-        }
-
-        if (_master)
-        {
-            _master.slave_incoming(packet, _slave_id);
-            return;
-        }
+        fire_subscribers(packet);
 
         // check for vlan tagged packets. fancy mask catches all possible vlan tags while rejecting all common ethertypes.
         if (packet.type == PacketType.ethernet && (packet.eth.ether_type & 0xE457) == 0x8000)
@@ -629,6 +610,17 @@ protected:
         assert(false, "Override this method to implement a _master interface");
     }
 
+    final void fire_subscribers(ref Packet packet)
+    {
+        if (!_num_subscribers)
+            return;
+        foreach (ref subscriber; _subscribers[0.._num_subscribers])
+        {
+            if ((subscriber.filter.direction & PacketDirection.incoming) && subscriber.filter.match(packet))
+                subscriber.recv_packet(packet, this, PacketDirection.incoming, subscriber.user_data);
+        }
+    }
+
     bool bind_vlan(VLANInterface vlan_interface, bool remove)
     {
         if (remove)
@@ -650,20 +642,6 @@ protected:
         }
         _vlans ~= vlan_interface;
         return true;
-    }
-
-    final MACAddress generate_mac_address() pure
-    {
-        import urt.crc;
-        alias crc_fun = calculate_crc!(Algorithm.crc32_iso_hdlc);
-
-        enum ushort MAGIC = 0x1337;
-
-        uint crc = crc_fun(name[]);
-        MACAddress addr = MACAddress(0x02, MAGIC >> 8, MAGIC & 0xFF, crc & 0xFF, (crc >> 8) & 0xFF, crc >> 24);
-        if (addr.b[5] < 100 || addr.b[5] >= 240)
-            addr.b[5] ^= 0x80;
-        return addr;
     }
 
     final void update_service_times(uint wait_us, uint service_us)

--- a/src/router/iface/packet.d
+++ b/src/router/iface/packet.d
@@ -8,20 +8,22 @@ public import router.iface.mac;
 nothrow @nogc:
 
 
+// PacketType is wire-visible (the OW encapsulation type field) and packed into the
+// top nibble of universal addresses: values are append-only, never renumber.
 enum PacketType : ushort
 {
-    unknown = ushort.max,
-    raw = 0,
-    ethernet,
-    wifi_80211,
-    wpan,
-    _6lowpan,
-    zigbee_nwk,
-    zigbee_aps,
-    modbus,
-    can,
-    tesla_twc,
-    ble,
+    unknown     = ushort.max,
+    raw         = 0,
+    ethernet    = 1,
+    wifi_80211  = 2,
+    wpan        = 3,
+    _6lowpan    = 4,
+    zigbee_nwk  = 5,
+    zigbee_aps  = 6,
+    modbus      = 7,
+    can         = 8,
+    tesla_twc   = 9,
+    ble         = 10,
     count
 }
 static assert(PacketType.count <= 16, "PacketType must fit in 4 bits");
@@ -42,17 +44,13 @@ enum EtherType : ushort
     hpgp    = 0x88E1,   // HomePlug Green PHY (HPGP)
 }
 
-enum OW_SubType : ushort
+// Bit 15 of the OW encapsulation type field marks control-plane messages;
+// otherwise the field is the PacketType of the encapsulated frame.
+enum ushort ow_control_flag = 0x8000;
+
+enum OWControl : ushort
 {
-    unspecified         = 0x0000,
-    agent_discover      = 0x0001,   // probably need some way to find peers on the network?
-    modbus              = 0x0010,   // modbus
-    can                 = 0x0020,   // CAN bus
-    mac_802_15_4        = 0x0030,   // 802.15.4 MAC encapsulation
-    zigbee_nwk          = 0x0031,   // zigbee NWK frame
-    zigbee_aps          = 0x0032,   // zigbee APS frame
-    tesla_twc           = 0x0040,   // tesla-twc
-    ble                 = 0x0050,   // BLE frame (advert/control/ATT, kind in frame header)
+    agent_discover = ow_control_flag | 0x0001,  // probably need some way to find peers on the network?
 }
 
 // 802.1p PCP traffic classes
@@ -75,22 +73,50 @@ immutable ubyte[8] pcp_priority_map = [1, 0, 2, 3, 4, 5, 6, 7];
 alias AddressExtract = ulong function(ref const Packet) pure nothrow @nogc;
 alias IsMulticastAddress = bool function(ulong address) pure nothrow @nogc;
 
-void register_address_extractor(PacketType type, AddressExtract src_extract, AddressExtract dst_extract, IsMulticastAddress is_multicast)
+// OW ethertype encapsulation: exotic packet types are carried over ethernet as
+// [0x88B5][type:u16][data_len:u16][hdr_len:u8][encoded header][payload]. Each
+// protocol's codec translates its embed header to/from a stable wire format.
+// encode returns bytes written; decode sets packet type + embed header and returns
+// header bytes consumed; <= 0 = failure for both. decode may consume less than the
+// wire hdr_len (older node, newer peer); the payload is located by hdr_len regardless.
+alias OWHeaderEncode = ptrdiff_t function(ref const Packet, ubyte[] buffer) nothrow @nogc;
+alias OWHeaderDecode = ptrdiff_t function(ref Packet, const(ubyte)[] header) nothrow @nogc;
+
+struct PacketCodec
 {
-    assert(type <= PacketType.count);
-    g_address_extractors[type].src = src_extract;
-    g_address_extractors[type].dst = dst_extract;
-    g_address_extractors[type].is_multicast = is_multicast;
+    AddressExtract extract_src;
+    AddressExtract extract_dst;
+    IsMulticastAddress is_multicast;
+    OWHeaderEncode encode;
+    OWHeaderDecode decode;
 }
 
+void register_packet_codec(Hdr)()
+{
+    static assert(Hdr.Type < PacketType.count);
+    PacketCodec c;
+    c.extract_src = &Hdr.extract_src;
+    c.extract_dst = &Hdr.extract_dst;
+    c.is_multicast = &Hdr.is_multicast;
+    static if (__traits(hasMember, Hdr, "encode_ow_header"))
+    {
+        c.encode = &Hdr.encode_ow_header;
+        c.decode = &Hdr.decode_ow_header;
+    }
+    g_packet_codecs[Hdr.Type] = c;
+}
+
+const(PacketCodec)* get_ow_codec(PacketType type)
+    => g_packet_codecs[type].encode ? &g_packet_codecs[type] : null;
+
 ulong get_network_src_address(ref const Packet p) pure
-    => get_address_extractor(p.type).src(p);
+    => packet_codec(p.type).extract_src(p);
 
 ulong get_network_dst_address(ref const Packet p) pure
-    => get_address_extractor(p.type).dst(p);
+    => packet_codec(p.type).extract_dst(p);
 
 bool is_network_multicast_address(ulong address) pure
-    => get_address_extractor(cast(PacketType)(address >> 60)).is_multicast(address);
+    => packet_codec(cast(PacketType)(address >> 60)).is_multicast(address);
 
 
 struct Packet
@@ -210,7 +236,30 @@ struct Ethernet
     MACAddress dst;
     MACAddress src;
     ushort ether_type;
-    ushort ow_sub_type; // TODO: REMOVE ME!!
+
+    static ulong extract_src(ref const Packet p) pure nothrow @nogc
+    {
+        ulong addr = p.hdr!Ethernet().src.ul;
+        addr |= ulong(p.vlan & 0xFFF) << 48;
+        addr |= ulong(PacketType.ethernet) << 60;
+        return addr;
+    }
+
+    static ulong extract_dst(ref const Packet p) pure nothrow @nogc
+    {
+        ulong addr = p.hdr!Ethernet().dst.ul;
+        addr |= ulong(p.vlan & 0xFFF) << 48;
+        addr |= ulong(PacketType.ethernet) << 60;
+        return addr;
+    }
+
+    static bool is_multicast(ulong address) pure nothrow @nogc
+    {
+        version (LittleEndian)
+            return (address & 1) != 0;
+        else
+            return ((address >> 40) & 1) != 0;
+    }
 }
 
 struct Wifi80211
@@ -230,48 +279,73 @@ struct Wifi80211
     // MACAddress addr4;     // 4-address WDS / mesh frames only
     // ushort qos_ctrl;      // QoS data frames (HT/VHT/HE)
     // uint ht_ctrl;         // HT Control field for +HTC frames
+
+    // 802.11 monitor frames address by RA/TA; multicast follows the ethernet bit semantics
+    static ulong extract_src(ref const Packet p) pure nothrow @nogc
+    {
+        ulong addr = p.hdr!Wifi80211().addr2.ul;
+        addr |= ulong(p.vlan & 0xFFF) << 48;
+        addr |= ulong(PacketType.wifi_80211) << 60;
+        return addr;
+    }
+
+    static ulong extract_dst(ref const Packet p) pure nothrow @nogc
+    {
+        ulong addr = p.hdr!Wifi80211().addr1.ul;
+        addr |= ulong(p.vlan & 0xFFF) << 48;
+        addr |= ulong(PacketType.wifi_80211) << 60;
+        return addr;
+    }
+
+    static bool is_multicast(ulong address) pure nothrow @nogc
+        => Ethernet.is_multicast(address);
+
+    // OW encapsulation wire codec: [fc:2 LE][seq_ctrl:2 LE][addr1:6][addr2:6][addr3:6][rssi:1][channel:1]
+    // FC and seq_ctrl keep 802.11's little-endian convention
+    static ptrdiff_t encode_ow_header(ref const Packet p, ubyte[] buffer) nothrow @nogc
+    {
+        import urt.endian : nativeToLittleEndian;
+        if (buffer.length < 24)
+            return -1;
+        ref const f = p.hdr!Wifi80211;
+        buffer[0 .. 2] = f.frame_control.nativeToLittleEndian;
+        buffer[2 .. 4] = f.seq_ctrl.nativeToLittleEndian;
+        buffer[4 .. 10] = f.addr1.b[];
+        buffer[10 .. 16] = f.addr2.b[];
+        buffer[16 .. 22] = f.addr3.b[];
+        buffer[22] = cast(ubyte)f.rssi;
+        buffer[23] = f.channel;
+        return 24;
+    }
+
+    static ptrdiff_t decode_ow_header(ref Packet p, const(ubyte)[] header) nothrow @nogc
+    {
+        import urt.endian : littleEndianToNative;
+        if (header.length < 24)
+            return -1;
+        p.type = PacketType.wifi_80211;
+        ref f = p.hdr!Wifi80211;
+        f.frame_control = header[0 .. 2].littleEndianToNative!ushort;
+        f.seq_ctrl = header[2 .. 4].littleEndianToNative!ushort;
+        f.addr1 = MACAddress(header[4 .. 10]);
+        f.addr2 = MACAddress(header[10 .. 16]);
+        f.addr3 = MACAddress(header[16 .. 22]);
+        f.rssi = cast(byte)header[22];
+        f.channel = header[23];
+        return 24;
+    }
 }
 static assert(Wifi80211.sizeof == 24);
 
 
 private:
 
-struct AddressExtractors
-{
-    AddressExtract src;
-    AddressExtract dst;
-    IsMulticastAddress is_multicast;
-}
-__gshared AddressExtractors[PacketType.count] g_address_extractors = [ AddressExtractors(), AddressExtractors(&extract_ethernet_src_address, &extract_ethernet_dst_address, &is_ethernet_multicast_address) ];
+__gshared PacketCodec[PacketType.count] g_packet_codecs = [ PacketCodec(), PacketCodec(&Ethernet.extract_src, &Ethernet.extract_dst, &Ethernet.is_multicast) ];
 
-ref const(AddressExtractors) get_address_extractor(PacketType type) pure
+ref const(PacketCodec) packet_codec(PacketType type) pure
 {
-    static ref const(AddressExtractors) impl(PacketType ty) nothrow @nogc
-        => g_address_extractors[ty];
-    alias FP = ref const(AddressExtractors) function(PacketType) pure nothrow @nogc;
+    static ref const(PacketCodec) impl(PacketType ty) nothrow @nogc
+        => g_packet_codecs[ty];
+    alias FP = ref const(PacketCodec) function(PacketType) pure nothrow @nogc;
     return (cast(FP)&impl)(type);
-}
-
-ulong extract_ethernet_src_address(ref const Packet p) pure
-{
-    ulong addr = p.hdr!Ethernet().src.ul;
-    addr |= ulong(p.vlan & 0xFFF) << 48;
-    addr |= ulong(PacketType.ethernet) << 60;
-    return addr;
-}
-
-ulong extract_ethernet_dst_address(ref const Packet p) pure
-{
-    ulong addr = p.hdr!Ethernet().dst.ul;
-    addr |= ulong(p.vlan & 0xFFF) << 48;
-    addr |= ulong(PacketType.ethernet) << 60;
-    return addr;
-}
-
-bool is_ethernet_multicast_address(ulong address) pure
-{
-    version (LittleEndian)
-        return (address & 1) != 0;
-    else
-        return ((address >> 40) & 1) != 0;
 }

--- a/src/router/iface/packet.d
+++ b/src/router/iface/packet.d
@@ -46,11 +46,14 @@ enum EtherType : ushort
 
 // Bit 15 of the OW encapsulation type field marks control-plane messages;
 // otherwise the field is the PacketType of the encapsulated frame.
+// Control messages use hdr_len = 0 and carry their body in the payload.
 enum ushort ow_control_flag = 0x8000;
 
 enum OWControl : ushort
 {
-    agent_discover = ow_control_flag | 0x0001,  // probably need some way to find peers on the network?
+    who_has     = ow_control_flag | 0x0001,  // body: universal address (u64 BE) -- which station carries this?
+    addr_query  = ow_control_flag | 0x0002,  // body: PacketType (u16 BE, unknown = all) -- report your addresses
+    addr_report = ow_control_flag | 0x0003,  // body: N x universal address (u64 BE) -- response to either of the above
 }
 
 // 802.1p PCP traffic classes

--- a/src/router/iface/vlan.d
+++ b/src/router/iface/vlan.d
@@ -9,6 +9,7 @@ import manager.base;
 import manager.collection;
 
 import router.iface;
+import router.iface.ethernet;
 
 nothrow @nogc:
 
@@ -23,7 +24,7 @@ enum VlanTag : ushort
 }
 
 
-class VLANInterface : BaseInterface
+class VLANInterface : EthernetStation
 {
     alias Properties = AliasSeq!(Prop!("interface", iface),
                                  Prop!("vlan", vlan),
@@ -38,7 +39,6 @@ nothrow @nogc:
         super(collection_type_info!VLANInterface, id, flags);
 
         // the super made a mac address, but we don't actually want one...
-        remove_address(mac);
         mac = MACAddress();
     }
 
@@ -85,7 +85,10 @@ nothrow @nogc:
                 return tconcat("interface ", value.name, " of type ", value.type, " does not support vlans");
         }
         _interface = value;
-        mac = _interface.mac;
+        if (auto station = cast(EthernetStation)value)
+            mac = station.mac;
+        else
+            mac = MACAddress();
         mark_set!(typeof(this), "interface")();
         return null;
     }
@@ -123,14 +126,25 @@ protected:
 //        return super.validating();
 //    }
 
-    final override int transmit(ref Packet packet, MessageCallback)
+    final override void medium_tx(ref Packet packet)
     {
-        assert(false, "unreachable - we override forward() instead");
+        debug assert((packet.vlan & 0xFFF) == 0, "packet already has a vlan tag");
+        packet.vlan = (packet.vlan & 0xF000) | (_vlan & 0xFFF);
+
+        if (_interface.forward(packet) < 0)
+            add_tx_drop();
+        else
+            add_tx_frame(packet.data.length);
     }
 
-    // override forward() instead of transmit() to avoid double callback firing
+    // override forward() instead of transmit() for the ethernet path, to pass the
+    // callback through to the parent without double firing; exotic packets route
+    // through the inherited station egress.
     final override int forward(ref Packet packet, MessageCallback callback = null)
     {
+        if (packet.type != PacketType.ethernet)
+            return super.forward(packet, callback);
+
         if (!running)
         {
             if (callback)
@@ -138,8 +152,8 @@ protected:
             return -1;
         }
 
-        assert((packet.vlan & 0xFFF) == 0, "packet already has a vlan tag");
-        packet.vlan = _vlan;
+        debug assert((packet.vlan & 0xFFF) == 0, "packet already has a vlan tag");
+        packet.vlan = (packet.vlan & 0xF000) | (_vlan & 0xFFF);
 
         foreach (ref sub; _subscribers[0 .. _num_subscribers])
         {
@@ -158,7 +172,7 @@ package:
     {
         assert((packet.vlan & 0xFFF) == _vlan, "received packet for wrong vlan!");
         packet.vlan &= 0xF000; // should we clear the p-bits too?
-        dispatch(packet);
+        incoming_packet(packet);
     }
 
 private:

--- a/src/router/iface/wifi.d
+++ b/src/router/iface/wifi.d
@@ -303,7 +303,7 @@ protected:
             _radio.bind_wlan(this, true);
             _bound = false;
         }
-        return CompletionStatus.complete;
+        return super.shutdown();
     }
 
     final const(char)[] get_password() const
@@ -450,6 +450,8 @@ nothrow @nogc:
 
     override void init()
     {
+        register_packet_codec!Wifi80211();
+
         g_app.register_enum!WifiAuth();
         g_app.register_enum!WifiInstallation();
     }

--- a/src/router/pcap.d
+++ b/src/router/pcap.d
@@ -185,8 +185,7 @@ private:
 
     void write_packet(ref const Packet p, BaseInterface i, PacketDirection dir)
     {
-        static if (has_all)
-            import protocol.zigbee.iface : ZigbeeInterface;
+        import router.iface.ethernet : EthernetStation;
 
         if (!enabled)
             return;
@@ -203,13 +202,8 @@ private:
             idb.linkType = ib.linkType;
             buffer ~= idb.as_bytes;
             buffer.write_option(2, i.name[]); // if_name
-            static if (has_all)
-            {
-                if (cast(ZigbeeInterface)i is null)
-                    buffer.write_option(6, i.mac.b[]); // if_MACaddr
-            }
-            else
-                buffer.write_option(6, i.mac.b[]); // if_MACaddr
+            if (auto station = cast(EthernetStation)i)
+                buffer.write_option(6, station.mac.b[]); // if_MACaddr
             ubyte ts = 9; // 6 = microseconds, 9 = nanoseconds
             buffer.write_option(9, (&ts)[0..1]); // if_tsresol
             buffer.write_option(0, null);


### PR DESCRIPTION
This introduces a separation between ethernet packets, and other exotic packets, so that the boundary can be a natural place for marshalling, and also so that the ethernet interfaces can easily form a hardware-offload bridge.