### PR TITLE
Sync: stream logs over the sync channel

### DIFF
--- a/openwatt.vcxproj
+++ b/openwatt.vcxproj
@@ -135,6 +135,7 @@
     <DCompile Include="src\manager\sync\package.d" />
     <DCompile Include="src\manager\sync\peer.d" />
     <DCompile Include="src\manager\sync\ws_server.d" />
+    <DCompile Include="src\manager\syslog.d" />
     <DCompile Include="src\manager\system.d" />
     <DCompile Include="src\manager\value.d" />
     <DCompile Include="src\protocol\ble\att.d" />

--- a/openwatt.vcxproj.filters
+++ b/openwatt.vcxproj.filters
@@ -678,6 +678,9 @@
     <DCompile Include="src\protocol\tesla\twc.d">
       <Filter>src\protocol\tesla</Filter>
     </DCompile>
+    <DCompile Include="src\manager\syslog.d">
+      <Filter>src\manager</Filter>
+    </DCompile>
     <DCompile Include="src\manager\system.d">
       <Filter>src\manager</Filter>
     </DCompile>

--- a/src/manager/sync/encoder.d
+++ b/src/manager/sync/encoder.d
@@ -122,6 +122,9 @@ nothrow @nogc:
     abstract void encode_history_req(SyncPeer peer, const(char)[] path, ulong from_ms, ulong to_ms, uint max_points, uint seq);
     abstract void encode_history(SyncPeer peer, uint seq, const(char)[] path, const(Sample)[] samples);
 
+    abstract void encode_log_sub(SyncPeer peer, Severity max_severity, bool off, const(char)[] tag);
+    abstract void encode_log(SyncPeer peer, const(char)[] line);
+
     // Time sync (clock discipline over the channel)
     //
     // Pull: a remote sends time_req to its authority and stashes its own send

--- a/src/manager/sync/json_encoder.d
+++ b/src/manager/sync/json_encoder.d
@@ -261,6 +261,28 @@ nothrow @nogc:
         send_frame(peer);
     }
 
+    // Outbound: log streaming
+
+    override void encode_log_sub(SyncPeer peer, Severity max_severity, bool off, const(char)[] tag)
+    {
+        begin_frame("log_sub");
+        _buf.append(",\"severity\":\"", off ? "off" : enum_key_from_value!Severity(max_severity), "\"");
+        if (tag.length)
+        {
+            _buf.append(",\"tag\":");
+            write_str(tag);
+        }
+        send_frame(peer);
+    }
+
+    override void encode_log(SyncPeer peer, const(char)[] line)
+    {
+        begin_frame("log");
+        _buf.append(",\"msg\":");
+        write_str(line);
+        send_frame(peer);
+    }
+
     override void encode_enum(SyncPeer peer, const(char)[] type_name, ref const Variant members, uint seq)
     {
         begin_frame("enum");
@@ -473,6 +495,53 @@ nothrow @nogc:
                 sync.inbound_enum(peer,
                     json.getMember("type").asString(),
                     members ? *members : empty, seq);
+                break;
+            }
+
+            case "log_sub":
+            {
+                Variant* sev_v = json.getMember("severity");
+                if (!sev_v || !sev_v.isString)
+                {
+                    log.warning("sync/json: log_sub missing string 'severity'");
+                    break;
+                }
+
+                const(char)[] sev_str = sev_v.asString();
+                bool off = sev_str == "off";
+                Severity sev = Severity.info;
+                if (!off)
+                {
+                    const(Severity)* s = enum_from_key!Severity(sev_str);
+                    if (!s)
+                    {
+                        log.warning("sync/json: unknown log_sub severity: ", sev_str);
+                        break;
+                    }
+                    sev = *s;
+                }
+
+                Variant* tag_v = json.getMember("tag");
+                if (tag_v && !tag_v.isNull && !tag_v.isString)
+                {
+                    log.warning("sync/json: log_sub 'tag' is not a string");
+                    break;
+                }
+                sync.inbound_log_sub(peer, sev, off, tag_v && tag_v.isString ? tag_v.asString() : null);
+                break;
+            }
+
+            case "log":
+            {
+                Variant* msg_v = json.getMember("msg");
+                if (!msg_v)
+                    msg_v = json.getMember("payload"); // tolerate older browser clients
+                if (!msg_v || !msg_v.isString)
+                {
+                    log.warning("sync/json: log missing string 'msg'");
+                    break;
+                }
+                sync.inbound_log(peer, msg_v.asString());
                 break;
             }
 

--- a/src/manager/sync/package.d
+++ b/src/manager/sync/package.d
@@ -50,6 +50,7 @@ import urt.log;
 import urt.map;
 import urt.mem.allocator;
 import urt.meta.enuminfo : VoidEnumInfo;
+import urt.meta.nullable;
 import urt.string;
 import urt.time;
 import urt.variant;
@@ -64,17 +65,16 @@ import manager.console.command : CommandState, CommandCompletionState;
 import manager.console.session;
 import manager.plugin;
 import manager.features;
+import manager.syslog;
+import manager.system : hostname;
 import manager.sync.encoder;
 import manager.sync.json_encoder;
 import manager.sync.peer;
 static if (has_http)
     import manager.sync.ws_server;
 
-
 nothrow @nogc:
 
-
-alias log = Log!"sync";
 
 // History responses must fit in one raw packet (64KB); JSON samples are ~25 bytes each.
 enum uint max_history_points = 2000;
@@ -219,6 +219,10 @@ nothrow @nogc:
         static if (has_http)
             g_app.console.register_collection!WebSocketSyncServer();
 
+        g_app.console.register_command!sync_log_sub("/sync", this, "log-sub");
+
+        set_log_hostname(hostname[]);
+
         register_object_lifecycle_handler(&on_object_lifecycle);
         register_object_state_handler(&on_object_state);
         subscribe_clock_change(&on_clock_step);
@@ -236,7 +240,10 @@ nothrow @nogc:
         Collection!SyncPeer().update_all();
 
         foreach (p; peers[])
+        {
             encoder_for(p._encoder).tick_dirty(p);
+            p.flush_logs();
+        }
 
         poll_time_authorities();
 
@@ -803,6 +810,30 @@ nothrow @nogc:
         echo_reset(obj, prop_idx, prop, from, seq);
     }
 
+    // Inbound: log streaming
+
+    void inbound_log_sub(SyncPeer from, Severity max_severity, bool off, const(char)[] tag)
+    {
+        from.set_log_sub(max_severity, off, tag);
+    }
+
+    void inbound_log(SyncPeer from, const(char)[] line)
+    {
+        LogMessage msg;
+        if (!parse_syslog(line, msg))
+        {
+            log.warning("sync: malformed log frame from '", from.name[], "'");
+            return;
+        }
+        // Re-inject into local logging. Split-horizon: mark the arrival peer so
+        // the fan-out's tap back toward `from` skips it. Keying on `from` (not
+        // msg.hostname) is what makes relays correct - msg.hostname is the
+        // original emitter, possibly several hops upstream of `from`.
+        g_log_reinject_source = from;
+        write_log(msg);
+        g_log_reinject_source = null;
+    }
+
     // Inbound: commands, errors, enums, subscriptions
 
     void inbound_cmd(SyncPeer from, uint seq, const(char)[] text)
@@ -1347,4 +1378,33 @@ nothrow @nogc:
         if (s == 0) s = ++next_seq;  // skip reserved zero on wrap
         return s;
     }
+}
+
+
+private:
+
+package __gshared SyncPeer g_log_reinject_source;
+
+// /sync/log-sub peer=<name> [severity=<sev>] [tag=<prefix>]
+CommandState sync_log_sub(Session session, const(char)[] peer, Nullable!Severity severity, Nullable!(const(char)[]) tag)
+{
+    SyncModule mod = get_module!SyncModule;
+    SyncPeer target;
+    foreach (p; mod.peers[])
+    {
+        if (p.name[] == peer)
+        {
+            target = p;
+            break;
+        }
+    }
+    if (!target)
+    {
+        session.write_line("no such sync peer: ", peer);
+        return null;
+    }
+
+    bool off = !severity;
+    target.request_logs(off ? Severity.info : severity.value, off, tag ? tag.value : null);
+    return null;
 }

--- a/src/manager/sync/peer.d
+++ b/src/manager/sync/peer.d
@@ -3,6 +3,8 @@ module manager.sync.peer;
 import urt.array;
 import urt.lifetime;
 import urt.log;
+import urt.mem.allocator;
+import urt.mem.temp : tconcat;
 import urt.meta : AliasSeq;
 import urt.string;
 import urt.time;
@@ -10,8 +12,10 @@ import urt.time;
 import manager;
 import manager.base;
 import manager.collection;
+import manager.syslog;
 import manager.sync;
 import manager.sync.encoder;
+import manager.system : hostname;
 
 import router.iface;
 import router.iface.packet;
@@ -80,22 +84,93 @@ nothrow @nogc:
         return _transport.forward(p);
     }
 
+    void request_logs(Severity max_severity, bool off, const(char)[] tag)
+    {
+        _want_logs = !off;
+        _want_log_severity = max_severity;
+        _want_log_tag = tag.makeString(defaultAllocator);
+        if (_transport && _transport.running)
+            encoder_for(_encoder).encode_log_sub(this, max_severity, off, tag);
+    }
+
+    void set_log_sub(Severity max_severity, bool off, const(char)[] tag)
+    {
+        if (off)
+        {
+            clear_log_sink();
+            return;
+        }
+
+        _log_tag = tag.makeString(defaultAllocator);
+        LogFilter filter;
+        filter.max_severity = max_severity;
+        filter.tag_prefix = _log_tag[];
+
+        if (_log_active)
+            set_sink_filter(_log_sink, filter);
+        else
+        {
+            _log_sink = register_log_sink(&log_sink_out, cast(void*)this, filter);
+            _log_active = _log_sink.valid;
+            if (!_log_active)
+                log.warning("no free log sink slot for peer '", name[], "'");
+        }
+    }
+
+    void flush_logs()
+    {
+        if (!_log_count && !_log_dropped)
+            return;
+
+        SyncEncoder enc = encoder_for(_encoder);
+        while (_log_count)
+        {
+            enc.encode_log(this, _log_ring[_log_head][]);
+            _log_head = (_log_head + 1) % log_ring_size;
+            --_log_count;
+        }
+        if (_log_dropped)
+        {
+            LogMessage drop;
+            drop.severity = Severity.warning;
+            drop.tag = "sync";
+            drop.hostname = hostname[];
+            drop.timestamp = get_sys_time();
+            drop.message = tconcat(_log_dropped, " log messages dropped to peer")[];
+            enc.encode_log(this, format_syslog(drop));
+            _log_dropped = 0;
+        }
+    }
+
 protected:
     mixin RekeyHandler;
 
     override bool validate() const pure
         => _transport !is null;
 
+    // Idempotent; WS-spawned peers call this at accept time, because the client's
+    // first frames can arrive before our first startup tick and unsubscribed
+    // packets are dropped.
+    package void subscribe_transport()
+    {
+        if (_transport_subscribed || !_transport)
+            return;
+        _transport.subscribe(&on_transport_packet, PacketFilter(PacketType.raw, PacketDirection.incoming));
+        _transport.subscribe(&on_transport_state);
+        _transport_subscribed = true;
+    }
+
     override CompletionStatus startup()
     {
         if (!_transport || !_transport.running)
             return CompletionStatus.continue_;
 
-        _transport.subscribe(&on_transport_packet, PacketFilter(PacketType.raw, PacketDirection.incoming));
-        _transport.subscribe(&on_transport_state);
-        _transport_subscribed = true;
+        subscribe_transport();
 
         get_module!SyncModule.attach_peer(this);
+
+        if (_want_logs)
+            encoder_for(_encoder).encode_log_sub(this, _want_log_severity, false, _want_log_tag[]);
         return CompletionStatus.complete;
     }
 
@@ -103,6 +178,13 @@ protected:
     {
         get_module!SyncModule.detach_peer(this);
         detach_transport();
+
+        // Peer-derived tap state dies with the stream; the desire to receive
+        // (_want_*) persists so a reconnect re-subscribes.
+        clear_log_sink();
+        _log_head = 0;
+        _log_count = 0;
+        _log_dropped = 0;
         return CompletionStatus.complete;
     }
 
@@ -119,9 +201,58 @@ package:
     MonoTime _time_t1;
     MonoTime _next_time_poll;
 
+    // Outbound tap: the remote subscribed to our logs; our fan-out sink queues
+    // matching lines here for flush_logs to drain each tick.
+    enum uint log_ring_size = 256;
+    LogSinkHandle _log_sink;
+    bool          _log_active;
+    String        _log_tag;              // owned; backs _log_sink's filter tag_prefix
+    Array!(char, 0)[log_ring_size] _log_ring;
+    uint _log_head;
+    uint _log_count;
+    uint _log_dropped;
+
+    // Inbound tap: we subscribed to the remote's logs. Persists across reconnect.
+    bool     _want_logs;
+    Severity _want_log_severity;
+    String   _want_log_tag;
+
 private:
     ObjectRef!BaseInterface _transport;
     bool                    _transport_subscribed;
+
+    static void log_sink_out(void* ctx, scope ref const LogMessage msg) nothrow @nogc
+    {
+        auto peer = cast(SyncPeer)ctx;
+        // Split-horizon: don't echo a re-injected log back out the peer it
+        // arrived on. msg.hostname is the original emitter (possibly upstream of
+        // this peer in a relay chain), so the guard keys on arrival identity.
+        if (peer is g_log_reinject_source)
+            return;
+        peer.enqueue_log(format_syslog(msg));
+    }
+
+    void enqueue_log(const(char)[] line)
+    {
+        if (_log_count >= log_ring_size)
+        {
+            ++_log_dropped;
+            return;
+        }
+        uint slot = (_log_head + _log_count) % log_ring_size;
+        _log_ring[slot].clear();
+        _log_ring[slot] ~= line;
+        ++_log_count;
+    }
+
+    void clear_log_sink()
+    {
+        if (!_log_active)
+            return;
+        unregister_log_sink(_log_sink);
+        _log_sink = LogSinkHandle.init;
+        _log_active = false;
+    }
 
     void detach_transport()
     {

--- a/src/manager/sync/ws_server.d
+++ b/src/manager/sync/ws_server.d
@@ -139,6 +139,7 @@ private:
         }
         peer.transport(ws);
         peer.encoder(_encoder);
+        peer.subscribe_transport();
         _peers ~= peer;
 
         debug log.info("client connected -> ", peer.name[]);

--- a/src/manager/syslog.d
+++ b/src/manager/syslog.d
@@ -1,0 +1,85 @@
+module manager.syslog;
+
+import urt.log;
+import urt.mem.temp : tconcat;
+import urt.string : contains;
+import urt.time;
+
+nothrow @nogc:
+
+
+// A LogMessage maps onto the 5424 header as:
+// hostname -> HOSTNAME, tag -> APP-NAME, object_name -> PROCID, timestamp -> TIMESTAMP (RFC3339), severity -> PRI.
+// Syslog severity is 0..7 with `trace` being mapped as 7 (debug) + `[trace]` in structured data.
+
+const(char)[] format_syslog(ref const LogMessage msg)
+{
+    uint pri = syslog_facility * 8 + to_syslog_severity(msg.severity);
+    const(char)[] host = msg.hostname.length ? msg.hostname : "-";
+    const(char)[] app  = msg.tag.length ? msg.tag : "-";
+    const(char)[] proc = msg.object_name.length ? msg.object_name : "-";
+    const(char)[] ts   = msg.timestamp.ticks ? tconcat(msg.timestamp)[] : "-";
+
+    return tconcat("<", pri, ">1 ", ts, ' ', host, ' ', app, ' ', proc, msg.severity == Severity.trace ? " - [trace] " : " - - ", msg.message)[];
+}
+
+// Parses our own emission shape. Fields alias into `line`, so the LogMessage is
+// only valid while `line` lives; copy anything retained past that (the sink
+// fan-out consumes it synchronously, so re-injection is safe).
+bool parse_syslog(const(char)[] line, out LogMessage msg)
+{
+    if (line.length < 3 || line[0] != '<')
+        return false;
+
+    size_t i = 1;
+    uint pri = 0;
+    while (i < line.length && line[i] >= '0' && line[i] <= '9')
+        pri = pri * 10 + (line[i++] - '0');
+    if (i >= line.length || line[i] != '>')
+        return false;
+
+    // VERSION + 6 SP-delimited header fields (TS HOST APP PROCID MSGID SD), then MSG.
+    const(char)[] rest = line[i + 1 .. $];
+    const(char)[][7] fields;
+    size_t fi = 0;
+    size_t start = 0;
+    for (size_t j = 0; j < rest.length && fi < 7; ++j)
+    {
+        if (rest[j] == ' ')
+        {
+            fields[fi++] = rest[start .. j];
+            start = j + 1;
+        }
+    }
+    if (fi < 7)
+        return false;
+
+    msg.severity = from_syslog_severity(pri);
+    msg.hostname = is_nil(fields[2]) ? null : fields[2];
+    msg.tag = is_nil(fields[3]) ? null : fields[3];
+    msg.object_name = is_nil(fields[4]) ? null : fields[4];
+    if (!is_nil(fields[1]))
+    {
+        SysTime t;
+        if (t.fromString(fields[1]) >= 0)
+            msg.timestamp = t;
+    }
+    if (!is_nil(fields[6]) && fields[6].contains("[trace]"))
+        msg.severity = Severity.trace;
+    msg.message = rest[start .. $];
+    return true;
+}
+
+
+private:
+
+enum uint syslog_facility = 1; // user-level messages
+
+uint to_syslog_severity(Severity s)
+    => s >= Severity.trace ? Severity.debug_ : cast(uint)s;
+
+Severity from_syslog_severity(uint pri)
+    => cast(Severity)(pri & 7);
+
+bool is_nil(const(char)[] field)
+    => field.length == 1 && field[0] == '-';

--- a/src/manager/system.d
+++ b/src/manager/system.d
@@ -32,6 +32,7 @@ void log_level(Session session, Severity severity)
 void set_hostname(Session session, const(char)[] hostname)
 {
     .hostname = hostname.makeString(defaultAllocator());
+    set_log_hostname(.hostname[]);   // keep log HOSTNAME stamping in sync
 }
 
 void get_hostname(Session session)


### PR DESCRIPTION
Add a log tap to the sync layer. `/sync/log-sub peer=<name> [severity=] [tag=]` asks a peer to stream its logs; the remote registers a fan-out sink toward us and matching lines arrive as RFC5424-shaped `log` frames that re-enter local logging.

- syslog.d: format_syslog/parse_syslog map LogMessage <-> a 5424 line.
- SyncPeer holds both taps: an outbound ring drained by flush_logs each tick (bounded, with a dropped-count marker), and the inbound desire that persists across reconnect and re-subscribes on startup.
- Split-horizon via g_log_reinject_source keeps a re-injected line from echoing back out the peer it arrived on; keyed on arrival identity so relay chains stay correct.
- system.d keeps the log HOSTNAME stamp in sync with set_hostname.
- ws_server subscribes the transport at accept time, since a client's first frames can precede the peer's first startup tick.