### PR TITLE
TLS shutdown must branch on ownership

### DIFF
--- a/src/protocol/tls/stream.d
+++ b/src/protocol/tls/stream.d
@@ -331,7 +331,7 @@ nothrow @nogc:
         _selected_cert = null;
         _handshake_start = SysTime();
 
-        if (_conn.get !is null)
+        if (_conn.has_remote())
             _conn.stop();
         else if (_stream)
             _stream.destroy();


### PR DESCRIPTION
The client-mode stream cache is not ours to destroy.