### PR TITLE
Stream: add release_rx_handler

### DIFF
--- a/src/router/stream/package.d
+++ b/src/router/stream/package.d
@@ -194,6 +194,12 @@ nothrow @nogc:
     final RecvHandler rx_handler() const pure
         => _incoming;
 
+    final void release_rx_handler(RecvHandler handler)
+    {
+        if (_incoming is handler)
+            _incoming = null;
+    }
+
     // Passive taps observe raw traffic without consuming it (unlike the single-owner rx_handler),
     // so any number can attach - used by the /stream/tap sniffer.
     final void add_tap(TapHandler h)


### PR DESCRIPTION
A consumer tearing down late (deferred through the state machine) must not strip a successor that already took over the handler.