### PR TITLE
Packet queues: deadline scheduling and admission policy

### DIFF
--- a/src/driver/baremetal/wifi.d
+++ b/src/driver/baremetal/wifi.d
@@ -256,7 +256,7 @@ protected:
         apply_channel(ch);
     }
 
-    override int transmit(ref const Packet packet, MessageCallback callback)
+    override int transmit(ref const Packet packet, MessageCallback callback, const(QueuePolicy)*)
     {
         if (packet.type != PacketType.wifi_80211 || !_wifi.is_open)
         {

--- a/src/protocol/ble/iface.d
+++ b/src/protocol/ble/iface.d
@@ -283,7 +283,7 @@ protected:
         send_queued_messages();
     }
 
-    final override int transmit(ref Packet packet, MessageCallback callback = null)
+    final override int transmit(ref Packet packet, MessageCallback callback = null, const(QueuePolicy)* queue_policy = null)
     {
         if (packet.type != PacketType.ble)
         {

--- a/src/protocol/can/iface.d
+++ b/src/protocol/can/iface.d
@@ -373,7 +373,7 @@ protected:
         }
     }
 
-    override int transmit(ref const Packet packet, MessageCallback)
+    override int transmit(ref const Packet packet, MessageCallback, const(QueuePolicy)*)
     {
         // can only handle can packets
         if (packet.type != PacketType.can)

--- a/src/protocol/cpc/package.d
+++ b/src/protocol/cpc/package.d
@@ -176,7 +176,7 @@ nothrow @nogc:
 
     // API...
 
-    override int transmit(ref Packet packet, MessageCallback)
+    override int transmit(ref Packet packet, MessageCallback callback, const(QueuePolicy)* queue_policy)
     {
         // data rides on the endpoint interfaces; the trunk carries no packets of its own
         return -1;
@@ -1093,7 +1093,7 @@ nothrow @nogc:
 
     // API...
 
-    override int transmit(ref Packet packet, MessageCallback)
+    override int transmit(ref Packet packet, MessageCallback callback, const(QueuePolicy)* queue_policy)
     {
         if (packet.type != PacketType.raw)
             return -1;

--- a/src/protocol/ezsp/ashv2.d
+++ b/src/protocol/ezsp/ashv2.d
@@ -217,7 +217,7 @@ protected:
         }
     }
 
-    override int transmit(ref Packet packet, MessageCallback)
+    override int transmit(ref Packet packet, MessageCallback, const(QueuePolicy)*)
     {
         if (packet.type != PacketType.raw)
             return -1;

--- a/src/protocol/http/websocket.d
+++ b/src/protocol/http/websocket.d
@@ -480,7 +480,7 @@ protected:
             _message[] = tmp[0 .. read];
     }
 
-    override int transmit(ref Packet packet, MessageCallback)
+    override int transmit(ref Packet packet, MessageCallback, const(QueuePolicy)*)
     {
         if (packet.type != PacketType.raw)
         {

--- a/src/protocol/modbus/iface.d
+++ b/src/protocol/modbus/iface.d
@@ -454,7 +454,7 @@ protected:
         }
     }
 
-    override int transmit(ref const Packet packet, MessageCallback callback = null) nothrow @nogc
+    override int transmit(ref const Packet packet, MessageCallback callback = null, const(QueuePolicy)* queue_policy = null) nothrow @nogc
     {
         if (packet.type != PacketType.modbus)
         {

--- a/src/protocol/ppp/client.d
+++ b/src/protocol/ppp/client.d
@@ -177,7 +177,7 @@ protected:
         }
     }
 
-    override int transmit(ref const Packet packet, MessageCallback)
+    override int transmit(ref const Packet packet, MessageCallback, const(QueuePolicy)*)
     {
         assert(false, "TODO: frame and transmit");
     }
@@ -275,7 +275,7 @@ nothrow @nogc:
 protected:
     mixin RekeyHandler;
 
-    override int transmit(ref const Packet packet, MessageCallback)
+    override int transmit(ref const Packet packet, MessageCallback, const(QueuePolicy)*)
     {
         assert(false, "TODO: frame and transmit");
     }

--- a/src/protocol/ppp/server.d
+++ b/src/protocol/ppp/server.d
@@ -95,7 +95,7 @@ protected:
         assert(false, "TODO");
     }
 
-    override int transmit(ref const Packet packet, MessageCallback)
+    override int transmit(ref const Packet packet, MessageCallback, const(QueuePolicy)*)
     {
         assert(false, "TODO: frame and transmit");
     }

--- a/src/protocol/tesla/iface.d
+++ b/src/protocol/tesla/iface.d
@@ -191,7 +191,7 @@ protected:
         }
     }
 
-    override int transmit(ref const Packet packet, MessageCallback) nothrow @nogc
+    override int transmit(ref const Packet packet, MessageCallback, const(QueuePolicy)*) nothrow @nogc
     {
         if (packet.type != PacketType.tesla_twc)
         {

--- a/src/protocol/zigbee/iface.d
+++ b/src/protocol/zigbee/iface.d
@@ -267,7 +267,8 @@ protected:
         super.update();
     }
 
-    final override int transmit(ref const Packet packet, MessageCallback callback = null) nothrow @nogc
+    final override int transmit(ref const Packet packet, MessageCallback callback = null,
+        const(QueuePolicy)* queue_policy = null) nothrow @nogc
     {
         // can only handle zigbee packets
         switch (packet.type)

--- a/src/router/iface/bridge.d
+++ b/src/router/iface/bridge.d
@@ -289,7 +289,7 @@ nothrow @nogc:
             g_bridge_cpu_promisc_changed(this);
     }
 
-    protected override int transmit(ref Packet packet, MessageCallback callback)
+    protected override int transmit(ref Packet packet, MessageCallback callback, const(QueuePolicy)*)
     {
         // this is a packet entering the bridge from the bridge interface...
 

--- a/src/router/iface/ethernet.d
+++ b/src/router/iface/ethernet.d
@@ -52,7 +52,7 @@ protected:
         dispatch(inner);
     }
 
-    override int transmit(ref Packet packet, MessageCallback)
+    override int transmit(ref Packet packet, MessageCallback, const(QueuePolicy)*)
     {
         switch (packet.type)
         {

--- a/src/router/iface/package.d
+++ b/src/router/iface/package.d
@@ -433,7 +433,7 @@ nothrow @nogc:
     {
     }
 
-    int forward(ref Packet packet, MessageCallback callback = null)
+    int forward(ref Packet packet, MessageCallback callback = null, const(QueuePolicy)* queue_policy = null)
     {
         if (!running)
         {
@@ -448,7 +448,7 @@ nothrow @nogc:
                 subscriber.recv_packet(packet, this, PacketDirection.outgoing, subscriber.user_data);
         }
 
-        int result = transmit(packet, callback);
+        int result = transmit(packet, callback, queue_policy);
         if (result <= 0 && callback)
             callback(result, result == 0 ? MessageState.complete : MessageState.failed);
         return result;
@@ -521,7 +521,7 @@ protected:
                                   "avg-queue-time", "avg-service-time", "max-service-time" ])();
     }
 
-    abstract int transmit(ref Packet packet, MessageCallback callback = null);
+    abstract int transmit(ref Packet packet, MessageCallback callback = null, const(QueuePolicy)* queue_policy = null);
 
     final void incoming_packet(ref Packet packet)
     {

--- a/src/router/iface/packet.d
+++ b/src/router/iface/packet.d
@@ -72,6 +72,26 @@ enum PCP : ubyte
 
 immutable ubyte[8] pcp_priority_map = [1, 0, 2, 3, 4, 5, 6, 7];
 
+struct QueuePolicy
+{
+nothrow @nogc:
+    void set_deadline(Duration timeout, PCP urgent, ubyte escalation_percent = 50)
+    {
+        assert(timeout > Duration.zero, "Queue deadline must be positive");
+        assert(escalation_percent <= 100, "Escalation percentage must be at most 100");
+
+        long timeout_ms = timeout.as!"msecs";
+        assert(timeout_ms <= uint.max, "Queue deadline must fit in milliseconds");
+        deadline_after = cast(uint)timeout_ms;
+        priority_escalation_after = cast(uint)(timeout_ms * escalation_percent / 100);
+        urgent_pcp = urgent;
+    }
+
+    uint deadline_after;
+    uint priority_escalation_after;
+    PCP urgent_pcp = PCP.be;
+}
+
 
 alias AddressExtract = ulong function(ref const Packet) pure nothrow @nogc;
 alias IsMulticastAddress = bool function(ulong address) pure nothrow @nogc;

--- a/src/router/iface/priority_queue.d
+++ b/src/router/iface/priority_queue.d
@@ -17,10 +17,14 @@ struct QueuedFrame
     MessageCallback callback;
     MonoTime enqueue_time;
     MonoTime dispatch_time;
+    uint deadline_after;
+    uint priority_escalation_after;
     ubyte tag;
     PCP pcp;
+    PCP urgent_pcp;
     bool dei;
     bool in_flight;
+    bool priority_escalated;
 }
 
 struct PriorityPacketQueue
@@ -29,11 +33,16 @@ nothrow @nogc:
 
     void init(ubyte max_in_flight, ubyte reserved_slots = 0, PCP reserved_min_pcp = PCP.vo, BaseInterface iface = null)
     {
+        set_capacity(max_in_flight, reserved_slots, reserved_min_pcp);
+        _if = iface;
+    }
+
+    void set_capacity(ubyte max_in_flight, ubyte reserved_slots = 0, PCP reserved_min_pcp = PCP.vo)
+    {
         assert(max_in_flight > 0, "max_in_flight must be greater than 0");
         assert(reserved_slots < max_in_flight, "Reserved slots cannot exceed total capacity");
 
         _max_in_flight = max_in_flight;
-        _if = iface;
         _reserved_slots = reserved_slots;
         _reserved_min_rank = pcp_priority_map[reserved_min_pcp];
     }
@@ -90,7 +99,7 @@ nothrow @nogc:
         return null;
     }
 
-    int enqueue(ref Packet packet, MessageCallback callback = null)
+    int enqueue(ref Packet packet, MessageCallback callback = null, const(QueuePolicy)* policy = null)
     {
         PCP pcp = packet.pcp;
         bool dei = packet.dei;
@@ -98,17 +107,18 @@ nothrow @nogc:
         // check total queue capacity
         if (_queued_count >= _max_queue_depth)
         {
-            // try to drop a DEI=1 frame if this frame is DEI=0
             if (!dei && !drop_lowest_dei())
                 return -1;
             else if (dei)
-                return -1; // drop the new DEI=1 frame
+                return -1;
         }
 
         QueuedFrame* frame = _pool.alloc();
         frame.packet = packet.clone();
         frame.callback = callback;
         frame.enqueue_time = getTime();
+        frame.deadline_after = policy ? policy.deadline_after : 0;
+        frame.priority_escalation_after = policy ? policy.priority_escalation_after : 0;
         int tag = _tags.alloc();
         if (tag < 0)
         {
@@ -118,8 +128,10 @@ nothrow @nogc:
         }
         frame.tag = cast(ubyte)tag;
         frame.pcp = pcp;
+        frame.urgent_pcp = policy ? policy.urgent_pcp : PCP.be;
         frame.dei = dei;
         frame.in_flight = false;
+        frame.priority_escalated = false;
 
         ubyte rank = pcp_priority_map[pcp];
         _buckets[rank].pushBack(frame);
@@ -238,25 +250,25 @@ nothrow @nogc:
 
     void timeout_stale(MonoTime now)
     {
-        if (_queue_timeout != Duration())
+        promote_due(now);
+
+        foreach (ref bucket; _buckets)
         {
-            foreach (ref bucket; _buckets)
+            size_t i = 0;
+            while (i < bucket.length)
             {
-                size_t i = 0;
-                while (i < bucket.length)
+                QueuedFrame* frame = bucket[i];
+                if ((frame.deadline_after != 0 && packet_age_ms(frame, now) >= frame.deadline_after) ||
+                    (_queue_timeout != Duration() && (now - frame.enqueue_time) > _queue_timeout))
                 {
-                    QueuedFrame* frame = bucket[i];
-                    if ((now - frame.enqueue_time) > _queue_timeout)
-                    {
-                        if (frame.callback)
-                            frame.callback(frame.tag, MessageState.expired);
-                        free_frame(frame);
-                        bucket.remove(i);
-                        --_queued_count;
-                    }
-                    else
-                        ++i;
+                    if (frame.callback)
+                        frame.callback(frame.tag, MessageState.expired);
+                    free_frame(frame);
+                    bucket.remove(i);
+                    --_queued_count;
                 }
+                else
+                    ++i;
             }
         }
 
@@ -314,6 +326,32 @@ private:
         _if.queue_update_service_times(wait_us, service_us);
     }
 
+    void promote_due(MonoTime now)
+    {
+        for (int rank = 0; rank <= 7; ++rank)
+        {
+            size_t i = 0;
+            while (i < _buckets[rank].length)
+            {
+                QueuedFrame* frame = _buckets[rank][i];
+                ubyte urgent_rank = pcp_priority_map[frame.urgent_pcp];
+                if (frame.deadline_after != 0 && !frame.priority_escalated &&
+                    packet_age_ms(frame, now) >= frame.priority_escalation_after && urgent_rank > rank)
+                {
+                    _buckets[rank].remove(i);
+                    frame.priority_escalated = true;
+                    frame.pcp = frame.urgent_pcp;
+                    _buckets[urgent_rank].pushBack(frame);
+                }
+                else
+                    ++i;
+            }
+        }
+    }
+
+    long packet_age_ms(const QueuedFrame* frame, MonoTime now) pure
+        => (now - frame.packet.creation_time).as!"msecs";
+
     bool drop_lowest_dei()
     {
         for (int rank = 0; rank <= 7; ++rank)
@@ -347,4 +385,90 @@ private:
         frame.callback = null;
         _pool.free(frame);
     }
+}
+
+unittest
+{
+    ubyte[1] data;
+    Packet low;
+    low.init!RawFrame(data[]);
+    low.pcp = PCP.be;
+
+    Packet urgent;
+    urgent.init!RawFrame(data[]);
+    urgent.pcp = PCP.vo;
+
+    PriorityPacketQueue queue;
+    queue.init(3, 1, PCP.vo);
+
+    assert(queue.enqueue(low) >= 0);
+    assert(queue.enqueue(low) >= 0);
+    assert(queue.dequeue() !is null);
+    assert(queue.dequeue() !is null);
+
+    assert(queue.enqueue(low) >= 0);
+    assert(queue.dequeue() is null);
+
+    assert(queue.enqueue(urgent) >= 0);
+    assert(queue.dequeue() !is null);
+
+    queue.set_capacity(5, 1, PCP.vo);
+    assert(queue.dequeue() !is null);
+
+    queue.abort_all();
+
+    Packet deadline_packet;
+    MonoTime base = MonoTime(1);
+    deadline_packet.init!RawFrame(data[], base);
+    deadline_packet.pcp = PCP.ca;
+    QueuePolicy deadline;
+    deadline.urgent_pcp = PCP.ic;
+    deadline.priority_escalation_after = 100;
+    deadline.deadline_after = 200;
+
+    int deadline_tag = queue.enqueue(deadline_packet, null, &deadline);
+    assert(deadline_tag > 0);
+    queue.timeout_stale(base + 100.msecs);
+    QueuedFrame* promoted = queue.dequeue();
+    assert(promoted !is null);
+    assert(promoted.tag == deadline_tag);
+    assert(promoted.pcp == PCP.ic);
+    assert(promoted.packet.pcp == PCP.ca);
+    queue.complete(promoted.tag);
+
+    deadline.priority_escalation_after = 300;
+    deadline.deadline_after = 400;
+    deadline_tag = queue.enqueue(deadline_packet, null, &deadline);
+    assert(queue.is_queued(cast(ubyte)deadline_tag));
+    queue.timeout_stale(base + 400.msecs);
+    assert(!queue.is_queued(cast(ubyte)deadline_tag));
+
+    Packet background;
+    background.init!RawFrame(data[]);
+    background.pcp = PCP.bk;
+    background.dei = true;
+
+    int newest_background_tag;
+    int next_background_tag;
+    foreach (i; 0 .. 32)
+    {
+        int tag = queue.enqueue(background);
+        assert(tag > 0);
+        next_background_tag = newest_background_tag;
+        newest_background_tag = tag;
+    }
+
+    Packet routine;
+    routine.init!RawFrame(data[]);
+    routine.pcp = PCP.be;
+    assert(queue.enqueue(routine) > 0);
+    assert(!queue.is_queued(cast(ubyte)newest_background_tag));
+
+    Packet important;
+    important.init!RawFrame(data[]);
+    important.pcp = PCP.vo;
+    assert(queue.enqueue(important) > 0);
+    assert(!queue.is_queued(cast(ubyte)next_background_tag));
+
+    queue.abort_all();
 }

--- a/src/router/iface/vlan.d
+++ b/src/router/iface/vlan.d
@@ -140,10 +140,10 @@ protected:
     // override forward() instead of transmit() for the ethernet path, to pass the
     // callback through to the parent without double firing; exotic packets route
     // through the inherited station egress.
-    final override int forward(ref Packet packet, MessageCallback callback = null)
+    final override int forward(ref Packet packet, MessageCallback callback = null, const(QueuePolicy)* queue_policy = null)
     {
         if (packet.type != PacketType.ethernet)
-            return super.forward(packet, callback);
+            return super.forward(packet, callback, queue_policy);
 
         if (!running)
         {
@@ -161,7 +161,7 @@ protected:
                 sub.recv_packet(packet, this, PacketDirection.outgoing, sub.user_data);
         }
 
-        int result = _interface.forward(packet, callback);
+        int result = _interface.forward(packet, callback, queue_policy);
         if (result >= 0)
             add_tx_frame(packet.data.length);
         return result;

--- a/src/router/iface/wifi.d
+++ b/src/router/iface/wifi.d
@@ -188,7 +188,7 @@ protected:
             sink(packet.data);
     }
 
-    override int transmit(ref const Packet packet, MessageCallback)
+    override int transmit(ref const Packet packet, MessageCallback, const(QueuePolicy)*)
     {
         add_tx_drop();
         return -1;


### PR DESCRIPTION
Adds QueuePolicy: per-queue admission and deadline scheduling, carried alongside the packet rather than inside it since it expires when the queue has delivered or dropped the frame. Deadlines store as ms offsets from the enqueue stamp so an ageing deadline cannot roll over, and the policy passes by pointer. Frames escalate to an urgent PCP part-way to their deadline and drop past it.

transmit() takes the policy, so every interface implementation picks up the parameter.