### PR TITLE
Shared profile registry

### DIFF
--- a/src/manager/binding.d
+++ b/src/manager/binding.d
@@ -97,6 +97,8 @@ protected:
 
     override bool materialise()
     {
+        // set only on full success; startup() may poll materialise() while
+        // waiting on dependencies, and must not repeat the work
         if (_profile_data)
             return true;
 
@@ -107,24 +109,15 @@ protected:
             return false;
         }
 
-        import urt.file : load_file;
-
-        void[] file = load_file(tconcat(profile_dir(), pname, ".conf"), g_app.allocator);
-        scope (exit) g_app.allocator.free(file);
-        if (!file)
+        Profile* profile = g_app.acquire_profile(tconcat(profile_dir(), pname, ".conf"));
+        if (!profile)
         {
             writeWarning(name, ": failed to load profile '", pname, "'");
             return false;
         }
-        _profile_data = parse_profile(cast(char[])file, g_app.allocator);
-        if (!_profile_data)
-        {
-            writeWarning(name, ": failed to parse profile '", pname, "'");
-            return false;
-        }
 
         bool bad = false;
-        foreach (declared; _profile_data.get_parameters())
+        foreach (declared; profile.get_parameters())
         {
             if (declared[] !in _params)
             {
@@ -135,7 +128,7 @@ protected:
         foreach (k; _params.keys)
         {
             bool declared = false;
-            foreach (d; _profile_data.get_parameters())
+            foreach (d; profile.get_parameters())
             {
                 if (d[] == k[])
                 {
@@ -150,12 +143,19 @@ protected:
             }
         }
         if (bad)
+        {
+            g_app.release_profile(profile);
             return false;
+        }
 
+        // add_handler reads _profile_data during device creation
+        _profile_data = profile;
         Device device = create_device_from_profile(*_profile_data, model_name(), _device[], null, &add_handler);
         if (!device)
         {
             writeWarning(name, ": failed to materialise device '", _device, "'");
+            g_app.release_profile(_profile_data);
+            _profile_data = null;
             return false;
         }
 
@@ -164,9 +164,12 @@ protected:
 
     override CompletionStatus shutdown()
     {
+        // release, don't free: the registry retains the parse (element descs and
+        // samplers on surviving devices borrow its strings), and the next startup
+        // re-acquires the live copy and re-materialises subclass element state
         if (_profile_data)
         {
-            g_app.allocator.freeT(_profile_data);
+            g_app.release_profile(_profile_data);
             _profile_data = null;
         }
         return CompletionStatus.complete;

--- a/src/manager/device.d
+++ b/src/manager/device.d
@@ -122,11 +122,8 @@ nothrow @nogc:
     ~this()
     {
         clear_computations();
-        if (profile)
-            g_app.allocator.freeT(profile);
     }
 
-    Profile* profile;
     Array!Computation computations;
 
     bool finalise()
@@ -470,6 +467,8 @@ Device create_device_from_profile(ref Profile profile, const(char)[] model, cons
                     break;
 
                 case map:
+                    if (!is_new_element)
+                        break;
                     create_element_handler(device, e, el.get_element_desc(profile), el.index);
                     break;
 

--- a/src/manager/package.d
+++ b/src/manager/package.d
@@ -25,6 +25,7 @@ import manager.element;
 import manager.id;
 import manager.plugin;
 import manager.reactor;
+import manager.profile : Profile, load_profile;
 import manager.secret;
 import manager.signal;
 import manager.system;
@@ -282,6 +283,7 @@ nothrow @nogc:
         console.register_command!link_print("/element/link", this, "print");
 
         console.register_collection!Secret();
+        console.register_collection!ProtocolBinding();
 
         register_modules(this);
 
@@ -835,12 +837,44 @@ nothrow @nogc:
     }
 
 
+    // Shared profile registry: one parse per file, shared by every consumer.
+    // Restarting objects release on shutdown and re-acquire on startup, binding
+    // to the live parse with no file reload.
+    Profile* acquire_profile(const(char)[] filename)
+    {
+        if (ProfileCacheEntry* e = filename in _profiles)
+        {
+            ++e.refs;
+            return e.profile;
+        }
+        Profile* p = load_profile(filename, allocator);
+        if (!p)
+            return null;
+        _profiles.insert(filename.makeString(allocator), ProfileCacheEntry(p, 1));
+        return p;
+    }
+
+    void release_profile(Profile* profile)
+    {
+        if (profile is null)
+            return;
+        foreach (ref e; _profiles.values)
+        {
+            if (e.profile is profile)
+            {
+                if (e.refs != 0)
+                    --e.refs;
+                return;
+            }
+        }
+    }
+
     import urt.meta.nullable;
 
     void device_add(Session session, const(char)[] id, const(char)[] _profile, Nullable!(const(char)[]) name, Nullable!(const(char)[]) model)
     {
         import urt.mem.temp : tconcat;
-        import manager.profile : Profile, ElementDesc, load_profile;
+        import manager.profile : ElementDesc;
         import manager.device : create_device_from_profile;
         import manager.element : Element;
 
@@ -850,7 +884,8 @@ nothrow @nogc:
             return;
         }
 
-        Profile* profile = load_profile(tconcat("conf/device_profiles/", _profile, ".conf"), allocator);
+        // acquired for the device's lifetime; never released
+        Profile* profile = acquire_profile(tconcat("conf/device_profiles/", _profile, ".conf"));
         if (!profile)
         {
             session.write_line("Failed to load profile '", _profile, "'");
@@ -1159,6 +1194,17 @@ private:
         EventHandler handler;
         MonoTime     when;
     }
+
+    // Zero-ref profiles are retained: element descs, samplers, and expressions
+    // on surviving devices borrow the profile's string caches, so freeing needs
+    // device-side ownership first. TODO: free when the last borrower dies.
+    struct ProfileCacheEntry
+    {
+        Profile* profile;
+        uint refs;
+    }
+
+    Map!(String, ProfileCacheEntry) _profiles;
 
     Array!WallclockHandler _wallclock_handlers;
 

--- a/src/protocol/http/binding.d
+++ b/src/protocol/http/binding.d
@@ -143,7 +143,7 @@ nothrow @nogc:
             _client.unsubscribe(&state_change);
             _subscribed = false;
         }
-        // Unsubscribe element write-back delegates before super.shutdown frees the profile
+        // Unsubscribe element write-back delegates before super.shutdown releases the profile
         if (_profile_data)
         {
             foreach (ref se; _elements[])

--- a/src/protocol/modbus/binding.d
+++ b/src/protocol/modbus/binding.d
@@ -252,7 +252,7 @@ nothrow @nogc:
 
         if (_serve_profile_data)
         {
-            g_app.allocator.freeT(_serve_profile_data);
+            g_app.release_profile(_serve_profile_data);
             _serve_profile_data = null;
         }
         return super.shutdown();
@@ -387,19 +387,11 @@ protected:
 
         if (!_serve_profile_data && _serve && _slave_server && _profile_name_explicit.length > 0 && _profile_name_explicit[] != _slave_server.profile[])
         {
-            import urt.file : load_file;
             const(char)[] pname = _profile_name_explicit[];
-            void[] file = load_file(tconcat(profile_dir(), pname, ".conf"), g_app.allocator);
-            scope (exit) g_app.allocator.free(file);
-            if (!file)
-            {
-                log.warning(name[], ": failed to load serve profile '", pname, "'");
-                return false;
-            }
-            _serve_profile_data = parse_profile(cast(char[])file, g_app.allocator);
+            _serve_profile_data = g_app.acquire_profile(tconcat(profile_dir(), pname, ".conf"));
             if (!_serve_profile_data)
             {
-                log.warning(name[], ": failed to parse serve profile '", pname, "'");
+                log.warning(name[], ": failed to load serve profile '", pname, "'");
                 return false;
             }
             const(char)[] serve_model = _model_name_explicit[];

--- a/src/protocol/mqtt/binding.d
+++ b/src/protocol/mqtt/binding.d
@@ -137,7 +137,7 @@ nothrow @nogc:
     override CompletionStatus shutdown()
     {
         detach_source();
-        // Drop write-back delegates before super.shutdown frees the profile.
+        // Drop write-back delegates before super.shutdown releases the profile.
         foreach (ref se; _elements)
         {
             if (se.element.access & Access.write)

--- a/src/protocol/zigbee/controller.d
+++ b/src/protocol/zigbee/controller.d
@@ -105,7 +105,7 @@ protected:
     override CompletionStatus startup() nothrow
     {
         if (!_zigbee_profile)
-            _zigbee_profile = load_profile("conf/zigbee_profiles/zigbee.conf", defaultAllocator());
+            _zigbee_profile = g_app.acquire_profile("conf/zigbee_profiles/zigbee.conf");
 
         return _endpoint.running ? CompletionStatus.complete : CompletionStatus.continue_;
     }
@@ -121,9 +121,10 @@ protected:
             freePromise(p);
         }
 
+        // release, don't free: devices created from this profile borrow its strings
         if (_zigbee_profile)
         {
-            defaultAllocator().freeT(_zigbee_profile);
+            g_app.release_profile(_zigbee_profile);
             _zigbee_profile = null;
         }
 


### PR DESCRIPTION
acquire/release one cached parse per file instead of load/free per consumer; restarting bindings/devices re-acquire the live parse