### PR TITLE
Component.is_device

### DIFF
--- a/src/manager/component.d
+++ b/src/manager/component.d
@@ -60,6 +60,10 @@ nothrow @nogc:
     Array!(Component) components;
     Array!(Element*) elements;
 
+    // extern(C++) has no dynamic cast: cast(Device) always "succeeds", so test this before painting
+    bool is_device() const pure
+        => false;
+
     final void subscribe(ComponentSubscriber handler)
     {
         assert(!_subscribers[].contains(handler), "Already registered");

--- a/src/manager/device.d
+++ b/src/manager/device.d
@@ -119,6 +119,9 @@ nothrow @nogc:
         super(id.move);
     }
 
+    override bool is_device() const pure
+        => true;
+
     ~this()
     {
         clear_computations();
@@ -522,4 +525,17 @@ Device create_device_from_profile(ref Profile profile, const(char)[] model, cons
     device.notify(ComponentEvent.online);
 
     return device;
+}
+
+unittest
+{
+    import urt.mem : defaultAllocator;
+    import urt.string : makeString;
+
+    Device d = defaultAllocator.allocT!Device("testdev".makeString(defaultAllocator()));
+    Component c = defaultAllocator.allocT!Component("child".makeString(defaultAllocator()));
+    c.parent = d;
+    assert(!c.is_device);
+    Component as_comp = d;
+    assert(as_comp.is_device);
 }


### PR DESCRIPTION
Safe device-ness test before an unchecked extern(C++) cast(Device)

extern(C++) classes have no dynamic downcast, so cast(Device) always succeeds; is_device() lets callers test container-ness first. Self-tested. Base prerequisite for both the data-model epic (element index tables) and the energy app.