### PR TITLE
gpio: realtime edge-sampler binding (cdev + pigpio)

### DIFF
--- a/openwatt.vcxproj
+++ b/openwatt.vcxproj
@@ -174,6 +174,7 @@
     <DCompile Include="src\protocol\goodwe\aa55.d" />
     <DCompile Include="src\protocol\goodwe\binding.d" />
     <DCompile Include="src\protocol\goodwe\package.d" />
+    <DCompile Include="src\protocol\gpio\package.d" />
     <DCompile Include="src\protocol\http\binding.d" />
     <DCompile Include="src\protocol\http\client.d" />
     <DCompile Include="src\protocol\http\message.d" />

--- a/openwatt.vcxproj.filters
+++ b/openwatt.vcxproj.filters
@@ -97,6 +97,9 @@
     <Filter Include="src\protocol\goodwe">
       <UniqueIdentifier>{45765f37-2305-4031-b32b-a2c3b88bebe0}</UniqueIdentifier>
     </Filter>
+    <Filter Include="src\protocol\gpio">
+      <UniqueIdentifier>{8d1f7c1a-433e-4b2e-9a76-5b0c2f9d5a21}</UniqueIdentifier>
+    </Filter>
     <Filter Include="src\protocol\modbus">
       <UniqueIdentifier>{aba64285-47d8-4af3-a4bf-5284dbbeea44}</UniqueIdentifier>
     </Filter>
@@ -584,6 +587,9 @@
     </DCompile>
     <DCompile Include="src\protocol\goodwe\package.d">
       <Filter>src\protocol\goodwe</Filter>
+    </DCompile>
+    <DCompile Include="src\protocol\gpio\package.d">
+      <Filter>src\protocol\gpio</Filter>
     </DCompile>
     <DCompile Include="src\protocol\http\binding.d">
       <Filter>src\protocol\http</Filter>

--- a/src/manager/plugin.d
+++ b/src/manager/plugin.d
@@ -142,6 +142,7 @@ void register_modules(Application app)
         register_module!(protocol.esphome)(app);
         register_module!(protocol.ezsp)(app);
         register_module!(protocol.goodwe)(app);
+        register_module!(protocol.gpio)(app);
         register_module!(protocol.http)(app);
         register_module!(protocol.ip)(app);
         register_module!(protocol.modbus)(app);

--- a/src/protocol/gpio/package.d
+++ b/src/protocol/gpio/package.d
@@ -1,0 +1,361 @@
+module protocol.gpio;
+
+import urt.driver.gpio;
+import urt.meta : AliasSeq;
+import urt.result;
+import urt.string;
+import urt.time;
+
+import manager;
+import manager.base;
+import manager.binding;
+import manager.collection;
+import manager.device;
+import manager.element;
+import manager.plugin;
+import manager.reactor;
+
+nothrow @nogc:
+
+
+class GpioBinding : ProtocolBinding
+{
+    alias Properties = AliasSeq!(Prop!("chip", chip),
+                                 Prop!("rx-line", rx_line),
+                                 Prop!("tx-line", tx_line),
+                                 Prop!("element", element_path),
+                                 Prop!("pull", pull),
+                                 Prop!("debounce", debounce),
+                                 Prop!("records", records, "status", "d"),
+                                 Prop!("buckets", buckets, "status", "d"),
+                                 Prop!("edge-rate", edge_rate, "status", "d"),
+                                 Prop!("last-edge", last_edge, "status", "d"),
+                                 Prop!("backend", backend, "status", "d"),
+                                 Prop!("clock", clock, "status", "d"),
+                                 Prop!("stream-start", stream_start, "status", "d"),
+                                 Prop!("anchor-error", anchor_error, "status", "d"));
+nothrow @nogc:
+
+    enum type_name = "gpio-binding";
+    enum path = "/binding/gpio";
+
+    this(CID id, ObjectFlags flags = ObjectFlags.none)
+    {
+        super(collection_type_info!GpioBinding, id, flags);
+        _fmt.type = ValueType.bool_;
+        _fmt.kind = SeriesKind.held;
+        _fmt.clock = &_clock;
+    }
+
+    final uint chip() const pure
+        => _chip;
+    final void chip(uint value)
+    {
+        if (_chip == value)
+            return;
+        _chip = value;
+        mark_set!(typeof(this), "chip")();
+        restart();
+    }
+
+    final uint rx_line() const pure
+        => _rx_line;
+    final void rx_line(uint value)
+    {
+        if (_rx_line == value)
+            return;
+        _rx_line = value;
+        mark_set!(typeof(this), "rx-line")();
+        restart();
+    }
+
+    // reserved for the waveform generator (sink series / send functions); not consumed yet
+    final uint tx_line() const pure
+        => _tx_line;
+    final void tx_line(uint value)
+    {
+        if (_tx_line == value)
+            return;
+        _tx_line = value;
+        mark_set!(typeof(this), "tx-line")();
+        restart();
+    }
+
+    final ref const(String) element_path() const pure
+        => _element_path;
+    final void element_path(String value)
+    {
+        if (value == _element_path)
+            return;
+        _element_path = value.move;
+        mark_set!(typeof(this), "element")();
+        restart();
+    }
+
+    final Pull pull() const pure
+        => _pull;
+    final void pull(Pull value)
+    {
+        if (_pull == value)
+            return;
+        _pull = value;
+        mark_set!(typeof(this), "pull")();
+        restart();
+    }
+
+    final Duration debounce() const pure
+        => _debounce;
+    final void debounce(Duration value)
+    {
+        if (_debounce == value)
+            return;
+        _debounce = value;
+        mark_set!(typeof(this), "debounce")();
+        restart();
+    }
+
+    final ulong records() const pure
+        => _element ? _element.record_count : 0;
+
+    final uint buckets() const pure
+        => _element ? _element.bucket_count : 0;
+
+    final uint edge_rate() const pure
+        => _edge_rate;
+
+    final SysTime last_edge() const pure
+        => _element ? _element.last_update : SysTime();
+
+    final const(char)[] backend() const pure
+    {
+        static if (has_gpio_sampler)
+            return _sampler.backend_name();
+        else
+            return "none";
+    }
+
+    final uint clock() const pure
+        => _clock.nominal_rate;
+
+    final SysTime stream_start() const pure
+        => _stream_start;
+
+    final Duration anchor_error() const pure
+        => _anchor_err;
+
+    final inout(Element)* element() inout pure
+        => _element;
+
+    final override bool validate() const pure
+        => _rx_line != uint.max && !_device.empty;
+
+    override bool materialise()
+    {
+        Device* dev = _device[] in g_app.devices;
+        if (!dev)
+            return false;
+        FormatId format = register_format(_fmt);
+        Element* e = (*dev).find_or_create_element(
+            _element_path.empty ? "state" : _element_path[], format);
+        if (_element is null)
+        {
+            e.access = Access.read;
+            e.sampling_mode = SamplingMode.report;
+        }
+        _element = e;
+        return true;
+    }
+
+    static if (has_gpio_sampler)
+    {
+        override CompletionStatus startup()
+        {
+            if (!materialise())
+                return CompletionStatus.error;
+
+            Result r = gpio_sampler_open(_chip, _rx_line, _sampler, _pull, cast(uint)_debounce.as!"usecs");
+            if (r.failed)
+            {
+                log.error("failed to open gpio sampler chip=", _chip, " line=", _rx_line, " (error ", r.system_code, ")");
+                return CompletionStatus.error;
+            }
+            if (!g_app.reactor.watch_fd(_sampler.fd, false, &on_ready))
+            {
+                _sampler.close();
+                log.error("failed to register gpio sampler with the reactor");
+                return CompletionStatus.error;
+            }
+            _watched = true;
+            log.info("gpio sampler backend=", _sampler.backend_name(), " chip=", _chip, " line=", _rx_line);
+            _element.ensure_history();   // scaffold retains everything; retention policy TODO
+            _edges_at_window = _element.record_count;
+            _window_start = getTime();
+            _last_anchor = _window_start;
+            _stream_start = SysTime();
+            _clock.nominal_rate = _sampler.clock_hz();
+            _clock.anchors.clear();     // new stream: sample-0 anchor is re-established on the first edge
+            _have_stream = false;
+            return CompletionStatus.complete;
+        }
+
+        override CompletionStatus shutdown()
+        {
+            detach_watch();
+            _sampler.close();
+            if (_element)
+                _element.mark_gap();
+            return CompletionStatus.complete;
+        }
+
+        override void update()
+        {
+            MonoTime now = getTime();
+            if (now - _window_start >= 1.seconds)
+            {
+                ulong count = _element.record_count;
+                uint rate = cast(uint)(count - _edges_at_window);
+                if (rate != _edge_rate)
+                {
+                    _edge_rate = rate;
+                    mark_set!(typeof(this), "edge-rate")();
+                }
+                _edges_at_window = count;
+                _window_start = now;
+            }
+            if (_have_stream && now - _last_anchor >= 10.seconds)
+            {
+                ulong tick_c;
+                SysTime wall_c;
+                ulong err_ns;
+                if (_sampler.correlate(tick_c, wall_c, err_ns))    // adds an anchor to track sample-clock drift
+                {
+                    _clock.add_anchor(tick_c - _stream_first_tick, wall_c);
+                    _anchor_err = nsecs(cast(long)(err_ns / 2));
+                }
+                _last_anchor = now;
+            }
+        }
+    }
+    else
+    {
+        override CompletionStatus startup()
+        {
+            log.error("gpio sampler is not supported on this platform");
+            return CompletionStatus.error;
+        }
+    }
+
+private:
+    Element* _element;          // series owner in the device tree
+    String _element_path;
+    ClockDomain _clock;         // owned by this binding; _fmt.clock points at it
+    DataFormat _fmt;
+    Duration _debounce;
+    Duration _anchor_err;
+    uint _chip = 0;
+    uint _rx_line = uint.max;
+    uint _tx_line = uint.max;
+    uint _edge_rate;
+    ulong _edges_at_window;
+    MonoTime _window_start;
+    SysTime _stream_start;
+    Pull _pull;
+
+    static if (has_gpio_sampler)
+    {
+        GpioSampler _sampler;
+        bool _watched;
+        bool _have_stream;
+        ulong _stream_first_tick;
+        MonoTime _last_anchor;
+
+        void on_ready(IoReady ready)
+        {
+            GpioEdge[64] edges = void;
+            GpioDrainStatus status = GpioDrainStatus.drained;
+            if (ready & IoReady.readable)
+            {
+                size_t count;
+                do
+                {
+                    status = _sampler.drain(edges[], count);
+                    if (count)
+                        write_edges(edges[0 .. count]);
+                }
+                while (status == GpioDrainStatus.drained && count == edges.length);
+            }
+
+            if (status != GpioDrainStatus.drained || (ready & IoReady.error))
+            {
+                detach_watch();
+                restart();
+            }
+        }
+
+        void write_edges(const(GpioEdge)[] edges)
+        {
+            if (!_have_stream)
+                anchor_stream(edges[0].tick);
+
+            bool[64] levels = void;
+            ulong[64] ticks = void;
+            foreach (i, ref edge; edges)
+            {
+                levels[i] = edge.level;
+                ticks[i] = edge.tick - _stream_first_tick;
+            }
+            _element.write_samples(levels[0 .. edges.length], ticks[0 .. edges.length]);
+            mark_set!(typeof(this), ["records", "buckets", "last-edge"])();
+        }
+
+        void detach_watch()
+        {
+            if (_watched)
+            {
+                g_app.unwatch_io(_sampler.fd);
+                _watched = false;
+            }
+        }
+
+        // First sample of a stream: pin index 0 to its realtime via a fresh correlation, back-projected
+        // from the correlation point to the first tick (the driver correlates just after the edge arrives).
+        void anchor_stream(ulong first_tick)
+        {
+            _stream_first_tick = first_tick;
+            _have_stream = true;
+
+            // a restart resumes into the retained series; force a fresh bucket so the new stream's low
+            // relative ticks can't underflow the old bucket's offset base (cross-segment wall: TODO)
+            if (_element.record_count > 0)
+                _element.mark_gap();
+
+            ulong tick_c;
+            SysTime wall_c;
+            ulong err_ns;
+            if (_sampler.correlate(tick_c, wall_c, err_ns))
+            {
+                _stream_start = wall_c - usecs(tick_c - first_tick);
+                _anchor_err = nsecs(cast(long)(err_ns / 2));
+            }
+            else
+            {
+                _stream_start = getSysTime();   // correlate failed: pin index 0 to now, best effort
+                _anchor_err = Duration();
+            }
+            _clock.add_anchor(0, _stream_start);    // always anchor, so to_wall never falls back to epoch
+        }
+    }
+}
+
+
+class GpioModule : Module
+{
+    mixin DeclareModule!"protocol.gpio";
+nothrow @nogc:
+
+    override void init()
+    {
+        g_app.register_enum!Pull();
+        g_app.console.register_collection!GpioBinding();
+    }
+}

--- a/src/protocol/package.d
+++ b/src/protocol/package.d
@@ -9,6 +9,7 @@ public static import protocol.dns;
 public static import protocol.esphome;
 public static import protocol.ezsp;
 public static import protocol.goodwe;
+public static import protocol.gpio;
 public static import protocol.http;
 public static import protocol.ip;
 public static import protocol.modbus;


### PR DESCRIPTION
Event-driven GPIO producer on top of element2's native series: edges write native records directly through the typed Element path. Registers protocol.gpio. Rides urt/driver/gpio.d.