### PR TITLE
binding: profile parameters are required only where referenced

### DIFF
--- a/src/manager/binding.d
+++ b/src/manager/binding.d
@@ -116,14 +116,6 @@ protected:
         }
 
         bool bad = false;
-        foreach (declared; profile.get_parameters())
-        {
-            if (declared[] !in _params)
-            {
-                writeWarning(name, ": missing required parameter '", declared, "' for profile '", pname, "'");
-                bad = true;
-            }
-        }
         foreach (k; _params.keys)
         {
             bool declared = false;


### PR DESCRIPTION
## Problem

`ProfileBinding.materialise()` refused a binding whenever *any* parameter declared by the profile was unset, whether or not anything the binding instantiates referenced it. The device was never created, so the binding sent no traffic at all and just logged a warning on every retry.

This is live on the production config. `conf/startup.conf` creates the SmartEVSE HTTP binding without `device_id`:

```
/binding/http/client/add name=smartevse device=smartevse client=evse_http profile=smartevse
```

`smartevse.conf` declares `parameters: device_id`, but it is referenced only by the `mqtt:` element paths. An HTTP binding instantiates no MQTT subscriptions, so `device_id` is irrelevant to it. The binding was refused anyway and the charger has been unpolled, which is why its energy elements never populate.

## Why this is the right fix

Both transports already diagnose unset parameters correctly, at the point of use and without killing the device:

- `protocol/http/binding.d` `build_request_state` warns per request that substitutes an unset parameter, and skips only that request.
- `protocol/mqtt/binding.d` does the same per subscription.

The blanket check in `manager/binding.d` preempted both with a hard failure. Removing it lets the existing per-reference diagnostics do their job. The "unknown parameter" check is untouched, so typos are still caught.

## Provenance

This restores the hunk from `591efe7` on `origin/backup`, which was lost when that branch's side-quest commits were excluded from the reconciliation. `591efe7` bundled it with the Home Assistant MQTT discovery work; only the `binding.d` hunk is taken here.

## Verification

Built a mock SmartEVSE serving the documented `/settings` schema and pointed a binding at it with **no** `device_id`:

| build | `device_id` | GETs in 12s | warnings |
|---|---|---|---|
| master | absent | **0** | `missing required parameter 'device_id'`, repeating |
| master | present | 28 | none |
| this PR | **absent** | **28** | none |

Polling starts immediately and no spurious warning is emitted, since no HTTP request references `device_id`.