### PR TITLE
http: parsed responses carry a timestamp

### DIFF
--- a/src/protocol/http/message.d
+++ b/src/protocol/http/message.d
@@ -344,8 +344,7 @@ nothrow @nogc:
                     if (result != 0)
                         return -1;
 
-                    if (message.is_request)
-                        message.timestamp = getSysTime();
+                    message.timestamp = getSysTime();
 
                     // message complete
                     current_leftover = cast(const(ubyte)[])msg;


### PR DESCRIPTION
## Problem

`HTTPParser` stamps only requests:

```d
if (message.is_request)
    message.timestamp = getSysTime();
```

So every parsed **response** leaves `timestamp` default-initialised. Samplers pass `response.timestamp` straight into `Element` writes, so each sample lands about 159 years in the future — the uninitialised value reads back as `2185-07-21T23:34:33.709551616Z` (note `.709551616`, the tail of 2^64).

`Element.record_value()` gates on `_last_update`, and every consumer compares sample times, so the HTTP sampling path silently produced elements that were *written but never readable*. The binding logged successful samples while `/device/print` showed every mapped field blank.

## Evidence

Instrumented `on_response` against a mock serving `{"version":"v3","serialnr":12345,"evse":{"temp":32}}`:

```
PROBE serial_number: fmt_valid=true same_fmt=true val_isnull=false val=12345
PROBE serial_number: after write last_update=2185-07-21T23:34:33.709551616Z
                                 value=null
                                 resp_ts=2185-07-21T23:34:33.709551616Z
                                 now=2026-07-27T02:53:51.6384715Z
```

JSON parse, path walk, format match and `parse_record` were all correct. Only the timestamp was wrong, and it was enough to make every value unreadable.

## After

Same profile, same response, unchanged otherwise:

```
├─ info                  [DeviceInfo]
│  ├─ serial_number      12345
│  └─ software_version   v3
├─ status                [DeviceStatus]
│  ├─ temp               32°C          0.1s
```

## Scope

This affects every HTTP-sampled device, not just the one I was chasing. `create_response` already stamps correctly, so only the parse path needed it.