### PR TITLE
sample: enum text accepts a key or a display string, and unknowns fail

### DIFF
--- a/src/manager/profile.d
+++ b/src/manager/profile.d
@@ -728,8 +728,12 @@ unittest
 
         static immutable string conf_text =
             "enum: Mode\n" ~
-            "\toff: 0\n" ~
-            "\teco: 1\n" ~
+            "\toff: 0, \"Off\"\n" ~
+            "\teco: 1, \"Eco Mode\"\n" ~
+            "\t_2400: 2, \"2400\"\n" ~
+            "bitfield: Features\n" ~
+            "\tfast: 1, \"2400\"\n" ~
+            "\tquiet: 2, \"Quiet\"\n" ~
             "\n" ~
             "troot: alpha, beta\n" ~
             "\n" ~
@@ -738,11 +742,12 @@ unittest
             "\ttsec: 2, enum8, Mode\tdesc: mode\n" ~
             "\ttsec: 3, u16:0.1V\tdesc: singleTokenVolts\n" ~
             "\ttsec: 4, str8, W\tdesc: name\n" ~
-            "\ttsec: 5, str8/W\tdesc: legacyName\n";
+            "\ttsec: 5, str8/W\tdesc: legacyName\n" ~
+            "\ttsec: 6, enum8, Features\tdesc: features\n";
         Profile* prof = parse_profile(conf_text, "tprof");
         assert(prof !is null);
 
-        import manager.sample : desc_by_index;
+        import manager.sample : desc_by_index, parse_record;
 
         // "0.1V" folds into the unit's decimal scale: records stay u16, exact, in deciVolts
         ref const TDesc cv = prof.get_section!TDesc(tsec, 0);
@@ -758,6 +763,31 @@ unittest
         assert(desc_by_index(md.desc).fmt.enum_info is prof.find_enum_template("Mode"));
         assert(find_enum_info("tprof.Mode") is prof.find_enum_template("Mode"));
 
+        const(VoidEnumInfo)* mode_info = prof.find_enum_template("Mode");
+        assert(mode_info.has_display_names);
+        assert(mode_info.value_for("eco").asLong == 1);
+        assert(mode_info.value_for("_2400").asLong == 2);
+        assert(mode_info.value_for("Eco Mode").isNull);
+        assert(mode_info.value_for_display("Eco Mode").asLong == 1);
+        assert(mode_info.value_for_display("2400").asLong == 2);
+        assert(mode_info.value_for_display("eco").isNull);
+
+        SampleDesc mode_desc = desc_by_index(md.desc);
+        ubyte m;
+        assert(parse_record("eco", mode_desc, (cast(void*)&m)[0 .. 1]) && m == 1);
+        assert(parse_record("Eco Mode", mode_desc, (cast(void*)&m)[0 .. 1]) && m == 1);
+        assert(parse_record("2400", mode_desc, (cast(void*)&m)[0 .. 1]) && m == 2);
+        assert(parse_record("1", mode_desc, (cast(void*)&m)[0 .. 1]) && m == 1);
+        m = 9;
+        assert(!parse_record("nope", mode_desc, (cast(void*)&m)[0 .. 1]));
+        assert(m == 9);
+
+        ref const TDesc fd = prof.get_section!TDesc(tsec, 5);
+        SampleDesc feature_desc = desc_by_index(fd.desc);
+        assert(feature_desc.fmt.enum_info.bitfield);
+        assert(parse_record("2400", feature_desc, (cast(void*)&m)[0 .. 1]) && m == 1);
+        assert(parse_record("fast", feature_desc, (cast(void*)&m)[0 .. 1]) && m == 1);
+
         // the one-token spelling produces the same desc as the two-column form
         ref const TDesc st = prof.get_section!TDesc(tsec, 2);
         assert(st.desc == cv.desc);
@@ -768,7 +798,7 @@ unittest
         assert(prof.get_section!TDesc(tsec, 4).desc == nm.desc);
         assert(prof.elements[4].access == Access.write);
 
-        assert(prof.elements.length == 5);
+        assert(prof.elements.length == 6);
         assert(prof.elements[0].kind == tsec && prof.elements[1].element == 1);
 
         const(void)[] root_data = prof.get_root_section(troot);
@@ -1563,12 +1593,14 @@ VoidEnumInfo* parse_enum(ConfItem conf, bool is_bitfield = false)
     size_t count = conf.sub_items.length;
 
     auto keys = Array!(const(char)[])(Reserve, count);
+    auto displays = Array!(const(char)[])(Reserve, count);
     auto t_vals = Array!long(Reserve, count);
     long min, max;
     foreach (i, ref item; conf.sub_items)
     {
         keys ~= item.name.unQuote;
         const(char)[] val = item.value.split!',';
+        displays ~= item.value.split!','.unQuote;
 
         size_t taken;
         ref long v = t_vals.pushBack(val.parse_int_with_base(&taken));
@@ -1603,24 +1635,24 @@ VoidEnumInfo* parse_enum(ConfItem conf, bool is_bitfield = false)
         auto b_values = cast(byte[])talloc(1 * count);
         foreach (i, v; t_vals)
             b_values[i] = cast(byte)v;
-        info = make_enum_info(enum_name, keys[], b_values[]);
+        info = make_enum_info(enum_name, keys[], b_values[], displays[]);
     }
     else if (min >= short.min && max <= short.max)
     {
         auto s_values = cast(short[])talloc(2 * count);
         foreach (i, v; t_vals)
             s_values[i] = cast(short)v;
-        info = make_enum_info(enum_name, keys[], s_values[]);
+        info = make_enum_info(enum_name, keys[], s_values[], displays[]);
     }
     else if (min >= int.min && max <= int.max)
     {
         auto i_values = cast(int[])talloc(4 * count);
         foreach (i, v; t_vals)
             i_values[i] = cast(int)v;
-        info = make_enum_info(enum_name, keys[], i_values[]);
+        info = make_enum_info(enum_name, keys[], i_values[], displays[]);
     }
     else
-        info = make_enum_info(enum_name, keys[], t_vals[]);
+        info = make_enum_info(enum_name, keys[], t_vals[], displays[]);
     info.bitfield = is_bitfield;
     return info;
 }

--- a/src/manager/sample/package.d
+++ b/src/manager/sample/package.d
@@ -304,24 +304,32 @@ bool parse_record(const(char)[] token, ref const SampleDesc desc, void[] record)
 
         case u8, s8, u16, s16, u32, s32, u64, s64:
         {
+            const(VoidEnumInfo)* ei = fmt.desc == DataFormat.Desc.enum_ ? fmt.enum_info : null;
+
+            if (ei)
+            {
+                Variant ev = ei.value_for(token);
+                if (ev.isNull)
+                    ev = ei.value_for_display(token);
+                if (!ev.isNull)
+                {
+                    store_int(record.ptr, fmt.type, cast(ulong)ev.asLong);
+                    return true;
+                }
+            }
+
             size_t taken;
             int e;
             uint base;
             long v = parse_int_with_exponent_and_base(token, e, base, &taken);
             if (taken != token.length)
             {
-                const(VoidEnumInfo)* ei = fmt.desc == DataFormat.Desc.enum_ ? fmt.enum_info : null;
-                if (!ei)
+                if (!ei || !ei.bitfield)
                     return false;
-                if (ei.bitfield)
-                {
-                    bool ok;
-                    v = ei.parse_flags(token, ok);
-                    if (!ok)
-                        return false;
-                }
-                else
-                    v = ei.value_for(token).asLong;
+                bool ok;
+                v = ei.parse_flags(token, ok);
+                if (!ok)
+                    return false;
             }
             else
             {
@@ -491,6 +499,10 @@ unittest
     assert(m == Mode.eco);
     char[16] txt;
     assert(format_record((cast(const(void)*)&m)[0 .. 2], mode, txt) == 1 && txt[0] == '1');
+
+    ushort keep = m;
+    assert(!parse_record("nonsense", mode, (cast(void*)&m)[0 .. 2]));
+    assert(m == keep);
 
     // dt48 encoding: byte-image path, reading-order canonical
     const(Encoding)* dt48 = find_encoding("yymmddhhmmss");


### PR DESCRIPTION
Depends on urt `f99d8c8` (open-watt/urt#189, #190), which stores display names in their own table and adds `value_for_display`. Submodule bumped here.

## Problem

A profile enum declares three things per member — a number, a key and a display string — and a device may report any of them. Only two were usable.

**The display string was discarded at parse.** In `parse_enum`, `item.value.split!','` takes the number and the quoted remainder is never read, so `make_enum_info` received keys and values only:

```
enum: EnableC2
	always_off: 1, "Always Off"
```

SmartEVSE answers `settings.enable_C2` with `"Always Off"`, and nothing could match it.

**Resolution ran after the integer parse.** `eastron_sdm120.conf:20` declares `_2400: 0, "2400"`, so a reported `"2400"` was consumed whole as a number and stored as a raw `2400` into an enum whose values are `0..5`.

**A miss was silent.** `value_for` returns a null `Variant` when a key is absent, and `.asLong` on that yields `0`, so unmatched text was stored as the zero member — `not_present` for `EnableC2`, "no flags set" for a bitfield.

## Changes

- `parse_enum` passes display names through to `make_enum_info`.
- `parse_record` tries the key, then the display name, then the number. Text matching neither still parses as a number, so underlying values stay writable and `parse_record("1", mode)` is unchanged.
- Unknown text fails the parse and leaves the record untouched.

Keys and display names remain distinct namespaces — a display name is not a key and vice versa. The tests assert both directions of that.

## Verified against the real device

Captured `/settings` from the live SmartEVSE (v3.11.2) and replayed it:

```
├─ status ─ temp              36°C          0.0s
└─ evse ─ config
   ├─ enable_c2               always_off    0.0s
   └─ solar_stop_time         10min         0.0s
```

`enable_c2` was previously unresolvable.

## Tests

Fixture now carries display strings, including the digit case:

```d
"enum: Mode\n\toff: 0, \"Off\"\n\teco: 1, \"Eco Mode\"\n\t_2400: 2, \"2400\"\n"
```

```d
assert(mode_info.has_display_names);
assert(mode_info.value_for("eco").asLong == 1);
assert(mode_info.value_for("_2400").asLong == 2);
assert(mode_info.value_for("Eco Mode").isNull);          // a display name is not a key
assert(mode_info.value_for_display("Eco Mode").asLong == 1);
assert(mode_info.value_for_display("2400").asLong == 2);
assert(mode_info.value_for_display("eco").isNull);       // a key is not a display name

assert(parse_record("eco",      mode_desc, ...) && m == 1);
assert(parse_record("Eco Mode", mode_desc, ...) && m == 1);
assert(parse_record("2400",     mode_desc, ...) && m == 2);
assert(parse_record("1",        mode_desc, ...) && m == 1);
m = 9;
assert(!parse_record("nope", mode_desc, ...));
assert(m == 9);
```

Full suite passes, 109 modules, exit 0 (clean rebuild).

## Behaviour change

A previously-silent failure becomes loud: anything reporting enum text that resolves to neither a key nor a display name will now error rather than quietly decoding to the zero member.