### PR TITLE
energy: an appliance's meter= overrides a profile-declared port meter

### DIFF
--- a/src/apps/energy/topology.d
+++ b/src/apps/energy/topology.d
@@ -915,9 +915,6 @@ private:
     {
         if (a.meter_ref is null)
             return;
-        foreach (ref spec; specs[])
-            if (spec.meter !is null)
-                return;
 
         DevicePort* target;
         foreach (ref spec; specs[])
@@ -935,8 +932,8 @@ private:
         if (target !is null)
         {
             target.meter = a.meter_ref;
-            if (a.meter_sign_set)
-                target.sign = a.meter_sign;
+            target.sign = a.meter_sign_set ? a.meter_sign : MeterSign.normal;
+            target.phase = 0;
         }
     }
 


### PR DESCRIPTION
## Problem

`apply_appliance_meter` bailed out whenever any port the profile declared already carried a meter:

```d
foreach (ref spec; specs[])
    if (spec.meter !is null)
        return;
```

So an explicit `meter=` on the appliance was silently discarded — no warning, no diagnostic, the setting simply had no effect.

This is live. The SmartEVSE profile declares a meter on its `grid` port mapped to `ev_meter.import_active_power`, which is only populated when the charger has an EV meter of its own. The real device reports:

```json
"ev_meter": { "description": "Disabled", "import_active_power": 0, ... }
```

so the port sampled a real, *measured* zero. The site config names the clamp that does measure that circuit:

```
/apps/energy/appliance add name=cabin_evse grid=cabin.carport car=mg_zs \
    device=smartevse meter=cabin_shed_meter.meter_2
```

and it was dropped. The EVSE read 0 W while charging.

The measured zero is worse than a gap: `aggregate_bus` gates on `meter_data.has(power)`, not provenance, so the port counted as instrumented, `cabin.carport` balanced without the load, and the draw disappeared from site accounting instead of surfacing as unaccounted.

## Change

A profile describes what a device *can* report. `meter=` is the operator saying what actually measures this appliance here. The explicit setting wins.

This also makes `meter-sign` reachable for the same case — `COMPONENT_TEMPLATES.md:394-400` already documents both as overridable, and the early return was the only thing preventing it (previously filed as SPEC-9 in `ENERGY_REVIEW.md`).

## Verification

Appliance bound to a profiled device that declares its own port meter, plus an explicit `meter=` naming a different one:

```
/apps/energy/appliance add name=test_evse grid=main device=smartevse meter=smartevse.evse.mains
```

`/apps/energy/topology`, before and after:

| | METER | POWER |
|---|---|---|
| master | `smartevse.grid.meter` | `0W` |
| this PR | `smartevse.evse.mains` | `--` |

`evse.mains` carries currents but no power element, hence `--`; the point is which meter the port binds. Before, the profile's meter won and reported the device's own zero.

Full suite passes, 109 modules, exit 0.

## Blast radius

Only appliances that have both a profiled `device=` and an explicit `meter=`. Device-less appliances (`house_ac`, `cabin_ac`, `cabin_hot_water`) take the `collect_bound_ports` path and are untouched. In the live config that is `cabin_evse` alone.