### PR TITLE
Drive ESP32 WiFi and TCP from reactor events

### DIFF
--- a/src/driver/baremetal/wifi.d
+++ b/src/driver/baremetal/wifi.d
@@ -27,6 +27,9 @@ class BuiltinWiFi : WiFiInterface
 {
 nothrow @nogc:
 
+    version (Espressif) enum bool supports_apsta = true;
+    else enum bool supports_apsta = false;
+
     enum type_name = "wifi";
     enum path = "/interface/wifi";
 
@@ -45,6 +48,7 @@ nothrow @nogc:
         return wifi_get_mac(_wifi, vif, mac);
     }
 
+    bool sta_started;
     uint sta_connected_seq;
     uint sta_disconnected_seq;
     uint ap_started_seq;
@@ -107,7 +111,7 @@ nothrow @nogc:
             return "only one AP per radio";
         if (sta_count > 1)
             return "only one STA per radio";
-        if (sta_count > 0 && ap_count > 0)
+        if (!supports_apsta && sta_count > 0 && ap_count > 0)
             return "concurrent AP+STA is not supported by this BL808 WiFi firmware";
         return null;
     }
@@ -130,7 +134,7 @@ protected:
         // second VIF in both STA-first and AP-first order.
         if (_num_ap > 1 || _num_client > 1)
             return false;
-        if (_num_ap > 0 && _num_client > 0)
+        if (!supports_apsta && _num_ap > 0 && _num_client > 0)
             return false;
         return super.validate();
     }
@@ -141,7 +145,7 @@ protected:
             return "only one AP per radio";
         if (_num_client > 1)
             return "only one STA per radio";
-        if (_num_ap > 0 && _num_client > 0)
+        if (!supports_apsta && _num_ap > 0 && _num_client > 0)
             return "concurrent AP+STA is not supported by this BL808 WiFi firmware";
         return super.status_message();
     }
@@ -328,6 +332,7 @@ private:
         }
         atomicStore!(MemoryOrder.release)(_wifi_pump_pending, 0u);
         atomicStore!(MemoryOrder.release)(_wifi_pump_retry, 0u);
+        sta_started = false;
         _mode_update_pending = false;
         _mode_update_warned = false;
     }
@@ -467,8 +472,8 @@ private:
     {
         final switch (event)
         {
-            case WifiEvent.sta_started:         break;
-            case WifiEvent.sta_stopped:         break;
+            case WifiEvent.sta_started:         sta_started = true; break;
+            case WifiEvent.sta_stopped:         sta_started = false; break;
             case WifiEvent.sta_connected:       ++sta_connected_seq; break;
             case WifiEvent.sta_disconnected:    ++sta_disconnected_seq; break;
             case WifiEvent.ap_started:          ++ap_started_seq; break;
@@ -568,6 +573,17 @@ protected:
         if (!radio)
             return CompletionStatus.error;
 
+        if (radio.mode_update_pending)
+        {
+            _status_detail = "Waiting for STA mode";
+            return CompletionStatus.continue_;
+        }
+        if (!radio.sta_started)
+        {
+            _status_detail = "Waiting for STA start";
+            return CompletionStatus.continue_;
+        }
+
         if (_connect_initiated)
         {
             if (radio.sta_connected_seq != _connect_sta_connected_seq)
@@ -635,7 +651,8 @@ protected:
         if (_connect_initiated && radio)
             wifi_sta_disconnect(radio.wifi);
         _connect_initiated = false;
-        _status_detail = null;
+        if (_state != State.failure)
+            _status_detail = null;
         return super.shutdown();
     }
 
@@ -786,7 +803,7 @@ protected:
                 ap_cfg.auth = urt.driver.wifi.WifiAuth.wpa3_enterprise;
                 break;
         }
-        ap_cfg.channel = radio.active_channel != 0 ? radio.active_channel : radio.channel;
+        ap_cfg.channel = radio.channel != 0 ? radio.channel : radio.active_channel;
         ap_cfg.max_clients = max_clients;
         ap_cfg.hidden = hidden;
 

--- a/src/protocol/ip/package.d
+++ b/src/protocol/ip/package.d
@@ -13,6 +13,7 @@ import manager.console;
 import manager.console.session : Session;
 import manager.plugin;
 import manager.reactor;
+import manager : EventPriority, g_app;
 
 import protocol.ip.address;
 import protocol.ip.pool;
@@ -24,7 +25,7 @@ import protocol.ip.udp_stream;
 version (UseInternalIPStack)
 {
     import protocol.ip.udp;
-    import protocol.ip.tcp : TcpPcb, TcpState, tcp_assign_id, tcp_send_data, tcp_close, free_pcb,
+    import protocol.ip.tcp : TcpPcb, TcpState, tcp_assign_id, tcp_send_data, tcp_consume_data, tcp_close, free_pcb,
         native_tcp_connect = tcp_connect, native_tcp_listen = tcp_listen;
 
     public import protocol.ip.stack : IPStack;
@@ -574,6 +575,9 @@ nothrow @nogc:
     void recv_handler(TCPRecvHandler handler)
     {
         _on_recv = handler;
+        version (UseInternalIPStack)
+            if (handler && _pcb && _pcb.recv_buf.length != 0)
+                queue_service();
     }
 
     void event_handler(TCPEventHandler handler)
@@ -835,12 +839,11 @@ private:
     version (UseInternalIPStack)
     {
         TcpPcb* _pcb;
+        bool _service_pending;
 
         bool reclaimable() const
-            => true;
+            => !_service_pending;
 
-        // RX is pushed inline via deliver(); the pump only observes control-state
-        // transitions (connect completion, peer close, reset) and drains TX.
         void pump()
         {
             if (_closing || _pcb is null)
@@ -856,10 +859,16 @@ private:
                 case Phase.open:
                     if (_pcb.error_event || _pcb.state == TcpState.closed)
                         fail(IPEvent.error);
-                    else if (_pcb.fin_seen)
-                        fail(IPEvent.closed);
                     else
-                        flush_tx();
+                    {
+                        drain_rx();
+                        if (_closing || _pcb is null)
+                            break;
+                        if (_pcb.fin_seen && _pcb.recv_buf.length == 0)
+                            fail(IPEvent.closed);
+                        else
+                            flush_tx();
+                    }
                     break;
                 case Phase.dead:
                     break;
@@ -874,12 +883,32 @@ private:
                 _on_event(&this, IPEvent.connected);
         }
 
-        package(protocol.ip) void deliver(const(ubyte)[] data, MonoTime rx_time)
+        package(protocol.ip) void queue_service()
         {
-            if (_phase == Phase.connecting && _pcb && _pcb.state == TcpState.established)
-                mark_connected();
-            if (_on_recv)
-                _on_recv(&this, data, rx_time);
+            if (_service_pending || _closing || g_app is null)
+                return;
+            _service_pending = true;
+            if (!g_app.post_event(&service_event, getTime(), EventPriority.control))
+                _service_pending = false;
+        }
+
+        void service_event(MonoTime)
+        {
+            _service_pending = false;
+            pump();
+        }
+
+        void drain_rx()
+        {
+            if (_pcb is null || _pcb.recv_buf.length == 0 || _on_recv is null)
+                return;
+
+            TcpPcb* pcb = _pcb;
+            size_t bytes = pcb.recv_buf.length;
+            MonoTime rx_time = pcb.recv_time;
+            _on_recv(&this, pcb.recv_buf[0 .. bytes], rx_time);
+            if (_pcb is pcb)
+                tcp_consume_data(*_stack_ptr, pcb, bytes);
         }
 
         void flush_tx()

--- a/src/protocol/ip/tcp.d
+++ b/src/protocol/ip/tcp.d
@@ -185,6 +185,7 @@ struct TcpPcb
     // — we slide both via Array.remove on consume)
     Array!ubyte send_buf;
     Array!ubyte recv_buf;
+    MonoTime recv_time;
 
     // Flags
     bool fin_sent;          // we've sent FIN (snd_nxt includes its sequence)
@@ -494,6 +495,31 @@ size_t tcp_recv_data(TcpPcb* pcb, ubyte[] buf)
     return n;
 }
 
+void tcp_consume_data(ref IPStack stack, TcpPcb* pcb, size_t bytes)
+{
+    if (bytes > pcb.recv_buf.length)
+        bytes = pcb.recv_buf.length;
+    if (bytes == 0)
+        return;
+
+    uint old_window = pcb.rcv_wnd;
+    pcb.recv_buf.remove(0, bytes);
+    pcb.rcv_wnd = cast(uint)(TcpRecvBufSize - pcb.recv_buf.length);
+    pcb.readable_event = pcb.recv_buf.length != 0;
+    if (pcb.recv_buf.length == 0)
+        pcb.recv_time = MonoTime.init;
+
+    if (pcb.rcv_wnd > old_window &&
+        (pcb.state == TcpState.established ||
+         pcb.state == TcpState.fin_wait_1 ||
+         pcb.state == TcpState.fin_wait_2 ||
+         pcb.state == TcpState.close_wait))
+    {
+        send_segment_at(stack, pcb, TcpFlag.ack, pcb.snd_nxt, null);
+        pcb.ack_pending = false;
+    }
+}
+
 bool tcp_accept(TcpPcb* listener, out TcpPcb* accepted)
 {
     if (!listener.is_listener || listener.accept_queue.length == 0)
@@ -526,16 +552,13 @@ void tcp_shutdown_write(ref IPStack stack, TcpPcb* pcb)
 
 private void tcp_app_deliver(TcpPcb* pcb, const(ubyte)[] bytes, MonoTime rx_time)
 {
-    version (UseInternalIPStack)
-    {
-        if (pcb.conn_owner !is null)
-        {
-            pcb.conn_owner.deliver(bytes, rx_time);
-            return;
-        }
-    }
+    if (pcb.recv_buf.length == 0)
+        pcb.recv_time = rx_time;
     pcb.recv_buf ~= bytes;
     pcb.readable_event = true;
+    version (UseInternalIPStack)
+        if (pcb.conn_owner !is null)
+            pcb.conn_owner.queue_service();
 }
 
 

--- a/src/router/iface/wifi.d
+++ b/src/router/iface/wifi.d
@@ -239,16 +239,22 @@ nothrow @nogc:
         => _ssid[];
     final void ssid(const(char)[] value)
     {
+        if (_ssid[] == value)
+            return;
         _ssid = value.makeString(defaultAllocator);
         mark_set!(typeof(this), "ssid")();
+        restart();
     }
 
     final inout(Secret) secret() inout pure
         => _secret;
     final void secret(Secret value)
     {
+        if (_secret.get is value)
+            return;
         _secret = value;
         mark_set!(typeof(this), "secret")();
+        restart();
     }
 
     final void on_radio_rx(const(ubyte)[] data, MonoTime ts)


### PR DESCRIPTION
## Summary
- complete the ESP32 WiFi frontend's reactor-driven service path
- support ESP32 AP+STA mode and wait for STA start before connecting
- drive the in-tree IP/TCP stack from readiness events with bounded fallback handling
- restart WLAN objects when credentials change

## Relationship
One feature commit based on #435. It is a sibling of #437 and #438 and uses the common reactor/uRT integration supplied by #435. The effective uRT commit is `9b4ae4db71eab0f82fcb96bec16b09d688ee4160`.

## Validation
- ESP32-S3 release cross-build passes
- `git diff --check` and changed-line audit at approximately 150 columns pass