### PR TITLE
Dispatch ESP32 BLE through reactor events

### DIFF
--- a/src/driver/baremetal/ble.d
+++ b/src/driver/baremetal/ble.d
@@ -60,7 +60,15 @@ nothrow @nogc:
     override void service()
     {
         if (_ble.is_open)
-            ble_poll(_ble);
+        {
+            bool pending = ble_service(_ble);
+            account_driver_drops();
+            if (pending)
+            {
+                import protocol.ble : BLEModule;
+                get_module!BLEModule.request_service();
+            }
+        }
         drain_emu_responses();
         super.service();
     }
@@ -90,7 +98,7 @@ protected:
         ble_set_read_callback(_ble, &read_dispatch);
         ble_set_write_callback(_ble, &write_dispatch);
         ble_set_notify_callback(_ble, &notify_dispatch);
-        ble_set_wake_callback(_ble, &wake_dispatch);
+        ble_set_ready_callback(_ble, &ready_dispatch);
 
         _active_radios[_port] = this;
 
@@ -105,6 +113,7 @@ protected:
     {
         if (_ble.is_open)
         {
+            ble_set_ready_callback(_ble, null);
             _active_radios[_ble.port] = null;
             ble_close(_ble);
         }
@@ -172,6 +181,24 @@ private:
     Map!(MACAddress, BLEAdv) _adv_handles;
     Map!(MACAddress, BLEAddrType) _addr_types; // LE address type by device, learnt from adverts
     Array!(Packet*) _emu_responses;
+
+    void account_driver_drops()
+    {
+        uint dropped = ble_take_rx_drops(_ble);
+        if (dropped != 0)
+        {
+            _status.rx_dropped += dropped;
+            mark_set!(typeof(this), "rx-dropped")();
+            log.warning("BLE deferred RX queues dropped ", dropped, " frame", dropped == 1 ? "" : "s");
+        }
+
+        uint event_drops = ble_take_event_drops(_ble);
+        if (event_drops != 0)
+        {
+            log.error("BLE deferred queues dropped ", event_drops, " control or completion event", event_drops == 1 ? "" : "s", "; restarting");
+            restart();
+        }
+    }
 
     BLEConn session_conn(const BLESession* session) const pure
         => BLEConn(cast(ubyte)session.transport);
@@ -667,10 +694,10 @@ private:
                 iface.on_notification(conn, handle, data);
     }
 
-    static void wake_dispatch()
+    static void ready_dispatch()
     {
-        import protocol.ble : BLEModule;
-        get_module!BLEModule.request_service();
+        import protocol.ble : request_ble_service_from_ready;
+        request_ble_service_from_ready();
     }
 
     void on_scan_report(ref const BLEAdvReport report)

--- a/src/protocol/ble/package.d
+++ b/src/protocol/ble/package.d
@@ -42,6 +42,11 @@ nothrow @nogc:
 
     override void init()
     {
+        import urt.atomic : atomicStore, MemoryOrder;
+
+        _ble_module = this;
+        atomicStore!(MemoryOrder.relaxed)(_service_pending, 0u);
+        atomicStore!(MemoryOrder.relaxed)(_service_retry, 0u);
         register_packet_codec!BLEFrame();
         register_frame_handler(PacketType.ble, &on_ble_frame);
 
@@ -112,15 +117,41 @@ nothrow @nogc:
 
     override void update()
     {
+        import urt.atomic : cas;
+
+        // Normal BLE delivery is reactor-dispatched; this recovers a rejected event post.
+        if (cas(&_service_retry, 1u, 0u))
+            service_radios(getTime());
         Collection!BLEClient().update_all();
         expire_devices();
     }
 
     void request_service()
     {
-        import urt.atomic : cas;
+        import urt.atomic : atomicStore, cas, MemoryOrder;
         if (cas(&_service_pending, 0u, 1u))
-            g_app.post_event(&service_radios, getTime(), EventPriority.bulk);
+        {
+            if (!g_app.post_event(&service_radios, getTime(), EventPriority.bulk))
+            {
+                atomicStore!(MemoryOrder.release)(_service_pending, 0u);
+                atomicStore!(MemoryOrder.release)(_service_retry, 1u);
+            }
+        }
+    }
+
+    void request_service_from_ready()
+    {
+        import urt.atomic : atomicStore, cas, MemoryOrder;
+        if (g_app is null || !cas(&_service_pending, 0u, 1u))
+            return;
+
+        bool queued;
+        g_app.post_event_from_isr(&service_radios, EventPriority.bulk, queued);
+        if (!queued)
+        {
+            atomicStore!(MemoryOrder.release)(_service_pending, 0u);
+            atomicStore!(MemoryOrder.release)(_service_retry, 1u);
+        }
     }
 
     void on_ble_frame(ref Packet p, BaseInterface iface)
@@ -283,6 +314,15 @@ private:
 
 // HACK: not a member of BLEModule to avoid weird compile error!
 __gshared shared(uint) _service_pending;
+__gshared shared(uint) _service_retry;
+__gshared BLEModule _ble_module;
+
+void request_ble_service_from_ready()
+{
+    BLEModule module_ = _ble_module;
+    if (module_ !is null)
+        module_.request_service_from_ready();
+}
 
 private:
 


### PR DESCRIPTION
## Summary
- dispatch ESP32 BLE readiness through the main-thread reactor queue
- preserve immediate ISR/task completion notification at the uRT boundary
- drain BLE events asynchronously and retain bounded fallback recovery
- account for deferred BLE queue drops in interface RX status

## Relationship
One feature commit based on #435. It is a sibling of #436 and #437 and uses the common reactor/uRT integration supplied by #435. The effective uRT commit is `9b4ae4db71eab0f82fcb96bec16b09d688ee4160`.

## Validation
- ESP32-S3 release cross-build passes
- `git diff --check` and changed-line audit at approximately 150 columns pass