### PR TITLE
element: links join components, and propagate whole frames

### DIFF
--- a/src/manager/device.d
+++ b/src/manager/device.d
@@ -358,7 +358,7 @@ package:
             if (!source)
                 continue;
             attach_computation(c.target, source.format);
-            c.link = g_app.create_link(c.target, null, source, null);
+            c.link = g_app.create_link(c.target, null, source, null, true);
             c.bound = true;
             ++newly_bound;
         }

--- a/src/manager/element.d
+++ b/src/manager/element.d
@@ -54,6 +54,8 @@ nothrow @nogc:
 // A commit scope defers subscriber delivery: writes between begin_commit and end_commit apply
 // to their elements immediately through the normal write paths, and their updates deliver when
 // the outermost scope closes, so subscribers only ever run against a fully applied frame.
+// Writes made by subscribers during the flush queue into a follow-up wave, so cascades
+// (links, computations) also deliver whole frames.
 // Batch record/time slices written inside a scope are borrowed until the scope closes;
 // single-sample writes travel as their boxed value.
 void begin_commit()
@@ -66,11 +68,7 @@ void end_commit()
     assert(g_commit_depth != 0, "unbalanced end_commit");
     if (--g_commit_depth != 0)
         return;
-    if (g_pending_updates.empty)
-        return;
-    Array!SampleUpdate updates = g_pending_updates.move;
-    foreach (ref update; updates)
-        deliver(update);
+    flush_pending();
 }
 
 struct CommitScope
@@ -1025,7 +1023,22 @@ void submit(ref SampleUpdate update, bool batch)
         g_pending_updates ~= update;
         return;
     }
+    ++g_commit_depth;
     deliver(update);
+    --g_commit_depth;
+    flush_pending();
+}
+
+void flush_pending()
+{
+    while (!g_pending_updates.empty)
+    {
+        Array!SampleUpdate updates = g_pending_updates.move;
+        ++g_commit_depth;
+        foreach (ref update; updates)
+            deliver(update);
+        --g_commit_depth;
+    }
 }
 
 void deliver(ref SampleUpdate update)

--- a/src/manager/package.d
+++ b/src/manager/package.d
@@ -123,10 +123,13 @@ nothrow @nogc:
             dest = b.elem;
         else if (update.element is b.elem)
             dest = a.elem;
-        // the timestamp guard breaks propagation cycles: deferred delivery outlives
-        // `propagating`, but a value that lapped a link mesh arrives carrying the
-        // timestamp it already stamped on this destination
-        if (dest && can_write(dest) && dest.last_update < update.timestamp)
+        // deliver unless the destination already holds this exact update; this breaks
+        // propagation cycles (deferred delivery outlives `propagating`, but a value
+        // that lapped a link mesh arrives equal) without eating legitimate
+        // same-timestamp value changes
+        if (dest && can_write(dest) &&
+            (dest.last_update < update.timestamp ||
+             (dest.last_update == update.timestamp && dest.value != update.value)))
             dest.value(update.value, update.timestamp, &element_updated);
         propagating = false;
     }
@@ -182,6 +185,17 @@ private:
     Endpoint b;
     bool propagating;
     bool alias_link;
+
+    void attach(Element* e, bool is_a)
+    {
+        Endpoint* ep = is_a ? &a : &b;
+        if (!ep.dangling)
+            return;
+        ep.release();
+        ep.set_element(e);
+        if (resolved)
+            resolve();
+    }
 }
 
 // Links two component subtrees by path prefix: one speculative ElementLink per relative
@@ -199,18 +213,18 @@ nothrow @nogc:
         auto commit = open_commit();
         char[256] rel = void;
         if (Component c = resolve_global_component(a_prefix[]))
-            walk(c, rel, 0);
+            walk(c, rel, 0, true);
         if (Component c = resolve_global_component(b_prefix[]))
-            walk(c, rel, 0);
+            walk(c, rel, 0, false);
     }
 
-    void element_created(const(char)[] path)
+    void element_created(const(char)[] path, Element* e)
     {
         // nested links (`dev.a` <-> `dev.a.b`) put a path under both prefixes
         if (under_prefix(path, a_prefix[]))
-            ensure_child(path[a_prefix.length + 1 .. $]);
+            ensure_child(path[a_prefix.length + 1 .. $], e, true);
         if (under_prefix(path, b_prefix[]))
-            ensure_child(path[b_prefix.length + 1 .. $]);
+            ensure_child(path[b_prefix.length + 1 .. $], e, false);
     }
 
 private:
@@ -218,19 +232,19 @@ private:
     static bool under_prefix(const(char)[] path, const(char)[] prefix) pure
         => path.length > prefix.length + 1 && path[0 .. prefix.length] == prefix[] && path[prefix.length] == '.';
 
-    void walk(Component c, ref char[256] buf, size_t len)
+    void walk(Component c, ref char[256] buf, size_t len, bool is_a)
     {
         foreach (Element* e; c.elements)
         {
             size_t l = append_id(buf, len, e.id[]);
             if (l <= buf.length)
-                ensure_child(buf[0 .. l]);
+                ensure_child(buf[0 .. l], e, is_a);
         }
         foreach (Component sub; c.components)
         {
             size_t l = append_id(buf, len, sub.id[]);
             if (l <= buf.length)
-                walk(sub, buf, l);
+                walk(sub, buf, l, is_a);
         }
     }
 
@@ -247,17 +261,23 @@ private:
         return len + id.length;
     }
 
-    void ensure_child(const(char)[] rel)
+    // the concrete element is threaded through rather than resolved by path: during
+    // device materialisation elements notify before the device is registered, so
+    // global path resolution cannot see them
+    void ensure_child(const(char)[] rel, Element* e, bool is_a)
     {
-        if (rel in children)
+        if (ElementLink** l = rel in children)
+        {
+            (*l).attach(e, is_a);
             return;
+        }
         char[256] fa = void, fb = void;
         const(char)[] a_path = make_full(fa, a_prefix[], rel);
         const(char)[] b_path = make_full(fb, b_prefix[], rel);
         if (!a_path || !b_path)
             return;
-        Element* ae = resolve_global_element(a_path);
-        Element* be = resolve_global_element(b_path);
+        Element* ae = is_a ? e : resolve_global_element(a_path);
+        Element* be = is_a ? resolve_global_element(b_path) : e;
         ElementLink* link = g_app.create_link(ae, a_path, be, b_path);
         children.insert(rel.makeString(g_app.allocator), link);
     }
@@ -358,6 +378,16 @@ nothrow @nogc:
 
     Array!(ElementLink*) links;
     Array!(ComponentLink*) component_links;
+
+    // a link whose paths both failed to resolve: element or component intent is
+    // decided by the first element that appears at (element) or under (component)
+    // either path
+    struct UndecidedLink
+    {
+        String a;
+        String b;
+    }
+    Array!UndecidedLink undecided_links;
 
     Map!(String, RegisteredType) types;
 
@@ -1337,8 +1367,24 @@ nothrow @nogc:
                 link.resolve();
         }
 
+        for (size_t i = 0; i < undecided_links.length; )
+        {
+            ref UndecidedLink u = undecided_links[i];
+            if (path[] == u.a[] || path[] == u.b[])
+                create_link(path[] == u.a[] ? e : null, u.a[], path[] == u.b[] ? e : null, u.b[]);
+            else if (ComponentLink.under_prefix(path, u.a[]) || ComponentLink.under_prefix(path, u.b[]))
+                create_component_link(u.a[], u.b[]);
+            else
+            {
+                ++i;
+                continue;
+            }
+            undecided_links.removeSwapLast(i);
+        }
+
+        // after the undecided pass so a link decided by this element also processes it
         foreach (cl; component_links)
-            cl.element_created(path);
+            cl.element_created(path, e);
 
         // any device's pending refs may resolve to the new element via a leading-dot global path
         request_rebind();
@@ -1392,8 +1438,10 @@ nothrow @nogc:
 
         if (ac || bc)
             create_component_link(source, target);
-        else
+        else if (ae || be)
             create_link(ae, source, be, target);
+        else
+            undecided_links ~= UndecidedLink(source.makeString(allocator), target.makeString(allocator));
     }
 
     void link_print(Session session)
@@ -1427,6 +1475,9 @@ nothrow @nogc:
                 l.resolved ? ++bound : ++pending;
             session.write_line(cl.a_prefix, " <-> ", cl.b_prefix, "  [component: ", bound, " linked, ", pending, " pending]");
         }
+
+        foreach (ref u; undecided_links)
+            session.write_line(u.a, " <-> ", u.b, "  [undecided]");
     }
 
 

--- a/src/manager/package.d
+++ b/src/manager/package.d
@@ -83,13 +83,19 @@ nothrow @nogc:
         b.elem.subscribe(&element_updated);
         if (a.elem.last_update > b.elem.last_update)
         {
-            Variant value = a.elem.value;
-            b.elem.value(value, a.elem.last_update);
+            if (can_write(b.elem))
+            {
+                Variant value = a.elem.value;
+                b.elem.value(value, a.elem.last_update);
+            }
         }
         else if (b.elem.last_update > a.elem.last_update)
         {
-            Variant value = b.elem.value;
-            a.elem.value(value, b.elem.last_update);
+            if (can_write(a.elem))
+            {
+                Variant value = b.elem.value;
+                a.elem.value(value, b.elem.last_update);
+            }
         }
     }
 
@@ -114,10 +120,15 @@ nothrow @nogc:
             dest = b.elem;
         else if (update.element is b.elem)
             dest = a.elem;
-        if (dest)
+        if (dest && can_write(dest))
             dest.value(update.value, update.timestamp, &element_updated);
         propagating = false;
     }
+
+    // computed elements propagate out but never accept writes in, except from
+    // the alias link that is itself the element's computation
+    bool can_write(const Element* dest) const pure
+        => alias_link || dest.sampling_mode != SamplingMode.dependent;
 
 private:
     private struct Endpoint
@@ -164,6 +175,96 @@ private:
     Endpoint a;
     Endpoint b;
     bool propagating;
+    bool alias_link;
+}
+
+// Links two component subtrees by path prefix: one speculative ElementLink per relative
+// element path (union of both sides), dangling sides bind through the normal path machinery.
+struct ComponentLink
+{
+nothrow @nogc:
+
+    String a_prefix;
+    String b_prefix;
+    Map!(String, ElementLink*) children;
+
+    void populate()
+    {
+        auto commit = open_commit();
+        char[256] rel = void;
+        if (Component c = resolve_global_component(a_prefix[]))
+            walk(c, rel, 0);
+        if (Component c = resolve_global_component(b_prefix[]))
+            walk(c, rel, 0);
+    }
+
+    void element_created(const(char)[] path)
+    {
+        if (under_prefix(path, a_prefix[]))
+            ensure_child(path[a_prefix.length + 1 .. $]);
+        else if (under_prefix(path, b_prefix[]))
+            ensure_child(path[b_prefix.length + 1 .. $]);
+    }
+
+private:
+
+    static bool under_prefix(const(char)[] path, const(char)[] prefix) pure
+        => path.length > prefix.length + 1 && path[0 .. prefix.length] == prefix[] && path[prefix.length] == '.';
+
+    void walk(Component c, ref char[256] buf, size_t len)
+    {
+        foreach (Element* e; c.elements)
+        {
+            size_t l = append_id(buf, len, e.id[]);
+            if (l <= buf.length)
+                ensure_child(buf[0 .. l]);
+        }
+        foreach (Component sub; c.components)
+        {
+            size_t l = append_id(buf, len, sub.id[]);
+            if (l <= buf.length)
+                walk(sub, buf, l);
+        }
+    }
+
+    static size_t append_id(ref char[256] buf, size_t len, const(char)[] id)
+    {
+        if (len)
+        {
+            if (len < buf.length)
+                buf[len] = '.';
+            ++len;
+        }
+        if (len + id.length <= buf.length)
+            buf[len .. len + id.length] = id[];
+        return len + id.length;
+    }
+
+    void ensure_child(const(char)[] rel)
+    {
+        if (rel in children)
+            return;
+        char[256] fa = void, fb = void;
+        const(char)[] a_path = make_full(fa, a_prefix[], rel);
+        const(char)[] b_path = make_full(fb, b_prefix[], rel);
+        if (!a_path || !b_path)
+            return;
+        Element* ae = resolve_global_element(a_path);
+        Element* be = resolve_global_element(b_path);
+        ElementLink* link = g_app.create_link(ae, a_path, be, b_path);
+        children.insert(rel.makeString(g_app.allocator), link);
+    }
+
+    static const(char)[] make_full(ref char[256] buf, const(char)[] prefix, const(char)[] rel)
+    {
+        size_t len = prefix.length + 1 + rel.length;
+        if (len > buf.length)
+            return null;
+        buf[0 .. prefix.length] = prefix[];
+        buf[prefix.length] = '.';
+        buf[prefix.length + 1 .. len] = rel[];
+        return buf[0 .. len];
+    }
 }
 
 __gshared Application g_app = null;
@@ -249,6 +350,7 @@ nothrow @nogc:
         => _profile_path;
 
     Array!(ElementLink*) links;
+    Array!(ComponentLink*) component_links;
 
     Map!(String, RegisteredType) types;
 
@@ -1168,11 +1270,12 @@ nothrow @nogc:
 
     // element link API
 
-    ElementLink* create_link(Element* a, const(char)[] a_path, Element* b, const(char)[] b_path)
+    ElementLink* create_link(Element* a, const(char)[] a_path, Element* b, const(char)[] b_path, bool alias_link = false)
     {
         assert((a || a_path) && (b || b_path), "Must specify `a` and `b`");
 
         ElementLink* link = allocator.allocT!ElementLink();
+        link.alias_link = alias_link;
 
         if (a)
             link.a.set_element(a);
@@ -1188,6 +1291,16 @@ nothrow @nogc:
             link.resolve();
 
         links ~= link;
+        return link;
+    }
+
+    ComponentLink* create_component_link(const(char)[] a, const(char)[] b)
+    {
+        ComponentLink* link = allocator.allocT!ComponentLink();
+        link.a_prefix = a.makeString(allocator);
+        link.b_prefix = b.makeString(allocator);
+        component_links ~= link;
+        link.populate();
         return link;
     }
 
@@ -1216,6 +1329,9 @@ nothrow @nogc:
             if (link.resolved)
                 link.resolve();
         }
+
+        foreach (cl; component_links)
+            cl.element_created(path);
 
         // any device's pending refs may resolve to the new element via a leading-dot global path
         request_rebind();
@@ -1251,9 +1367,26 @@ nothrow @nogc:
 
     void link_add(Session session, const(char)[] source, const(char)[] target)
     {
-        Element* a = resolve_global_element(source);
-        Element* b = resolve_global_element(target);
-        create_link(a, source, b, target);
+        Element* ae = resolve_global_element(source);
+        Element* be = resolve_global_element(target);
+        Component ac = ae ? null : resolve_global_component(source);
+        Component bc = be ? null : resolve_global_component(target);
+
+        if (ac && be)
+        {
+            session.write_line("Cannot link component '", source, "' to element '", target, "'");
+            return;
+        }
+        if (ae && bc)
+        {
+            session.write_line("Cannot link element '", source, "' to component '", target, "'");
+            return;
+        }
+
+        if (ac || bc)
+            create_component_link(source, target);
+        else
+            create_link(ae, source, be, target);
     }
 
     void link_print(Session session)
@@ -1278,6 +1411,14 @@ nothrow @nogc:
             }
             const(char)[] status = link.resolved ? "linked" : "pending";
             session.write_line(a, " <-> ", b, "  [", status, "]");
+        }
+
+        foreach (cl; component_links)
+        {
+            size_t bound, pending;
+            foreach (l; cl.children.values)
+                l.resolved ? ++bound : ++pending;
+            session.write_line(cl.a_prefix, " <-> ", cl.b_prefix, "  [component: ", bound, " linked, ", pending, " pending]");
         }
     }
 
@@ -1403,6 +1544,21 @@ Element* resolve_global_element(const(char)[] path) nothrow @nogc
         return null;
     if (Device* d = device_id in g_app.devices)
         return (*d).find_element(rest);
+    return null;
+}
+
+Component resolve_global_component(const(char)[] path) nothrow @nogc
+{
+    const(char)[] rest = path;
+    const(char)[] device_id = rest.split!'.';
+    if (device_id.empty)
+        return null;
+    if (Device* d = device_id in g_app.devices)
+    {
+        if (rest.empty)
+            return *d;
+        return (*d).find_component(rest);
+    }
     return null;
 }
 

--- a/src/manager/package.d
+++ b/src/manager/package.d
@@ -218,6 +218,11 @@ nothrow @nogc:
             walk(c, rel, 0, false);
     }
 
+    // an element AT a prefix proves that prefix is not a component: the pair is the
+    // component-to-element mismatch link_add refuses when both sides resolve up front
+    bool mismatched(const(char)[] path) const pure
+        => path == a_prefix[] || path == b_prefix[];
+
     void element_created(const(char)[] path, Element* e)
     {
         // nested links (`dev.a` <-> `dev.a.b`) put a path under both prefixes
@@ -1383,8 +1388,19 @@ nothrow @nogc:
         }
 
         // after the undecided pass so a link decided by this element also processes it
-        foreach (cl; component_links)
+        for (size_t i = 0; i < component_links.length; )
+        {
+            ComponentLink* cl = component_links[i];
+            if (cl.mismatched(path))
+            {
+                writeWarning("Cannot link component to element: '", path, "' is an element; dropping link '",
+                             cl.a_prefix, "' <-> '", cl.b_prefix, "'");
+                destroy_component_link(cl);
+                continue;
+            }
             cl.element_created(path, e);
+            ++i;
+        }
 
         // any device's pending refs may resolve to the new element via a leading-dot global path
         request_rebind();
@@ -1413,6 +1429,14 @@ nothrow @nogc:
     {
         link.unlink();
         links.removeFirstSwapLast(link);
+        allocator.freeT(link);
+    }
+
+    void destroy_component_link(ComponentLink* link)
+    {
+        foreach (child; link.children.values)
+            destroy_link(child);
+        component_links.removeFirstSwapLast(link);
         allocator.freeT(link);
     }
 

--- a/src/manager/package.d
+++ b/src/manager/package.d
@@ -81,22 +81,25 @@ nothrow @nogc:
     {
         a.elem.subscribe(&element_updated);
         b.elem.subscribe(&element_updated);
-        if (a.elem.last_update > b.elem.last_update)
+        Element* from = a.elem, to = b.elem;
+        if (b.elem.last_update > a.elem.last_update)
         {
-            if (can_write(b.elem))
-            {
-                Variant value = a.elem.value;
-                b.elem.value(value, a.elem.last_update);
-            }
+            from = b.elem;
+            to = a.elem;
         }
-        else if (b.elem.last_update > a.elem.last_update)
+        else if (a.elem.last_update == b.elem.last_update)
+            return;
+        if (!can_write(to))
         {
-            if (can_write(a.elem))
-            {
-                Variant value = b.elem.value;
-                a.elem.value(value, b.elem.last_update);
-            }
+            // the computed side is authoritative even when its value is older
+            Element* t = from;
+            from = to;
+            to = t;
+            if (!can_write(to) || from.last_update == SysTime.init)
+                return;
         }
+        Variant value = from.value;
+        to.value(value, from.last_update);
     }
 
     void unlink()
@@ -120,7 +123,10 @@ nothrow @nogc:
             dest = b.elem;
         else if (update.element is b.elem)
             dest = a.elem;
-        if (dest && can_write(dest))
+        // the timestamp guard breaks propagation cycles: deferred delivery outlives
+        // `propagating`, but a value that lapped a link mesh arrives carrying the
+        // timestamp it already stamped on this destination
+        if (dest && can_write(dest) && dest.last_update < update.timestamp)
             dest.value(update.value, update.timestamp, &element_updated);
         propagating = false;
     }
@@ -200,9 +206,10 @@ nothrow @nogc:
 
     void element_created(const(char)[] path)
     {
+        // nested links (`dev.a` <-> `dev.a.b`) put a path under both prefixes
         if (under_prefix(path, a_prefix[]))
             ensure_child(path[a_prefix.length + 1 .. $]);
-        else if (under_prefix(path, b_prefix[]))
+        if (under_prefix(path, b_prefix[]))
             ensure_child(path[b_prefix.length + 1 .. $]);
     }
 

--- a/src/protocol/mqtt/ha_discovery.d
+++ b/src/protocol/mqtt/ha_discovery.d
@@ -938,7 +938,7 @@ private:
         computation.kind = ComputationKind.alias_;
         computation.device = device;
         computation.target = target;
-        computation.link = g_app.create_link(target, null, &source, null);
+        computation.link = g_app.create_link(target, null, &source, null, true);
         computation.bound = true;
         device.computations ~= computation;
     }


### PR DESCRIPTION
Extends `/element/link/add` to accept components, so a whole meter can be mirrored to another datapoint with one command instead of one link per element.

## What changed

**Component links.** The command resolves each operand as an element or a component. Two components mint a `ComponentLink`; a component paired with an element is refused with a message naming both sides. A `ComponentLink` is a pair of path prefixes plus a relative-path map of child `ElementLink`s, so it holds no component pointers and needs no lifetime tracking.

**Speculative membership.** Creation walks whichever subtrees exist and mints one link per relative path across the union of both sides, leaving the absent side dangling; element creation under either prefix mints links the initial walk could not see. Bindings materialise asynchronously (profiles vary by model, Zigbee devices interview over time), so a snapshot at link time would silently miss everything arriving later. Dangling children bind through the existing `notify_element_created` path machinery, and a link whose operands both fail to resolve still falls through to today's dangling element link.

**Computed elements never accept writes in.** A mirrored meter typically contains expression and sum elements (`power = @voltage * @current`, `import` as a trapezoid integral). Without a rule, linking two such trees gives every computed element two writers. Delivery into a `SamplingMode.dependent` element is now suppressed at both initial sync and propagation, so computed elements relay outward but stay locally authoritative. The check is per-delivery rather than cached at resolve time, since computations bind lazily and an element can become dependent after the link resolves.

This surfaced a real interaction: profile aliases are themselves implemented as `ElementLink`s into a dependent target, in `manager.device` and again in `mqtt.ha_discovery`. There the link *is* the element's computation, not a second writer, so `create_link` takes a flag that exempts it.

**Whole-frame propagation.** `end_commit`'s flush delivered at depth zero, so a link writing its destination delivered immediately, mid-flush, and the destination's subscribers observed a partially applied frame. `flush_pending()` now holds the commit depth during delivery, queueing subscriber-triggered writes into a follow-up wave; writes still apply immediately and only delivery defers, so each wave's subscribers see a fully applied frame. `submit()` uses the same path, so bare writes outside a commit scope get it too. A component link consequently lands as a single atomic update rather than an element-at-a-time trickle.

## Testing

Unit tests pass on this base (69 modules, exit 0).

Verified live over a telnet console against an isolated instance:

- linking `dev1.meter` to `dev2.meter` expands to `power` and `voltage` child links, both reported linked
- `/element/set` on either side propagates to the other
- linking a component to an element prints `Cannot link component 'dev1.meter' to element 'dev2.meter.power'`
- linking to a not-yet-existing `mirror.meter` reports 2 pending children, which bind the moment the device is added
- a link with both sides unresolvable still registers as a pending element link

Windows console I/O is `WriteConsoleA`/`ReadConsoleInputA` only, so the documented fifo REPL cannot drive it here; the telnet console works.

## Notes

There is no `/element/link/remove` yet, matching the existing element-link behaviour. Element lifetime handling is deliberately out of scope: `SeriesEvent` already reserves `online`/`offline` slots with no emit sites, and re-dangling a link endpoint on element destruction is the natural future shape, but elements are effectively immortal today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)