### PR TITLE
record: recording is opt-in, and filter changes reconcile in place

### DIFF
--- a/src/manager/base.d
+++ b/src/manager/base.d
@@ -427,28 +427,27 @@ protected:
 
     void mark_set(T, string[] props)() nothrow @nogc
     {
-        enum mask = () {
-            ulong m = 0;
-            static foreach (p; props)
-            {{
-                enum i = prop_index!(T, p);
-                static assert(i >= 0, "Invalid property name '" ~ p ~ "' in mark_set!() for type " ~ T.stringof);
-                m |= ulong(1) << i;
-            }}
-            return m;
-        }();
+        enum mask = prop_mask!(T, props);
         _props_set |= mask;
         _mark_dirty(mask);
     }
-
     void mark_set(T, string prop)() nothrow @nogc
     {
-        mark_set!(T, [ prop ])();
+        return mark_set!(T, [ prop ])();
+    }
+
+    void mark_assigned(T, string[] props)() nothrow @nogc
+    {
+        _props_set |= prop_mask!(T, props);
+    }
+    void mark_assigned(T, string prop)() nothrow @nogc
+    {
+        return mark_assigned!(T, [ prop ])();
     }
 
     final void mark_dirty(size_t prop_index) nothrow @nogc
     {
-        _mark_dirty(ulong(1) << prop_index);
+        return _mark_dirty(ulong(1) << prop_index);
     }
 
     final void _mark_dirty(ulong mask) nothrow @nogc
@@ -461,11 +460,6 @@ protected:
         }
     }
 
-    // Property-delta subscriber. Attaches a slot to this object's dirty fan-out
-    // chain: _mark_dirty then ORs every property change into the slot's
-    // props_dirty, and the owner drains/clears it at its own cadence. Sync peers
-    // are one kind of owner; the Linux kernel mirror is another. `owner` is an
-    // opaque identity; the caller keeps the returned slot index for drain/detach.
     public final ushort attach_delta_slot(Object owner) nothrow @nogc
     {
         ushort slot = sync_state_alloc(owner);
@@ -984,6 +978,16 @@ template prop_index(T, string prop)
     }
 }
 
+enum prop_mask(T, string[] props) = () {
+    ulong m = 0;
+    static foreach (p; props)
+    {{
+        enum i = prop_index!(T, p);
+        static assert(i >= 0, "Invalid property name '" ~ p ~ "' for type " ~ T.stringof);
+        m |= ulong(1) << i;
+    }}
+    return m;
+}();
 
 const(Property*)[] all_properties(Type)()
 {

--- a/src/manager/record.d
+++ b/src/manager/record.d
@@ -270,21 +270,48 @@ nothrow @nogc:
     final void dir(const(char)[] value)
     {
         if (_dir[] == value)
+        {
+            mark_assigned!(typeof(this), "dir")();
             return;
+        }
         _dir = value.makeString(g_app.allocator);
         mark_set!(typeof(this), "dir")();
-        restart();
+
+        // A restart would drop every cursor, and a cursor reopened at index 0
+        // re-ships the standing RAM history.
+        if (running)
+        {
+            import urt.file : create_directory;
+            create_directory(_dir[]);
+            foreach (rs; _streams.values)
+                rs.container.close_();
+        }
     }
 
     final const(char)[] filter() const pure
         => _filter[];
-    final void filter(const(char)[] value)
+    final void filter(const(char)[][] value...)
     {
-        if (_filter[] == value)
+        MutableString!0 joined;
+        foreach (i, pattern; value)
+        {
+            if (i)
+                joined ~= ',';
+            joined ~= pattern;
+        }
+        if (_filter[] == joined[])
+        {
+            mark_assigned!(typeof(this), "filter")();
             return;
-        _filter = value.makeString(g_app.allocator);
+        }
+        _filter = joined[].makeString(g_app.allocator);
         mark_set!(typeof(this), "filter")();
-        restart();
+
+        if (running)
+        {
+            drop_unmatched();
+            scan();
+        }
     }
 
     // API
@@ -315,17 +342,15 @@ protected:
         create_directory(_dir[]); // best effort; the db warns if writes later fail
         scan();
         _last_scan = getTime();
+        if (_filter.empty)
+            log.info("recorder '", name, "': no filter, recording nothing");
         return CompletionStatus.complete;
     }
 
     override CompletionStatus shutdown()
     {
         foreach (rs; _streams.values)
-        {
-            rs.close();
-            database().close_series(rs.series);
-            defaultAllocator().freeT(rs);
-        }
+            release(rs);
         _streams.clear();
         return CompletionStatus.complete;
     }
@@ -348,14 +373,45 @@ protected:
 
 private:
     String _dir = StringLit!"records";
-    String _filter = StringLit!"*";
+    String _filter;
 
     Map!(const(char)[], RecordStream*) _streams; // keyed by the stream's own path string
     MonoTime _last_scan;
 
+    // a leading '!' excludes, and an exclusion vetoes regardless of where it sits in the list
+    bool matches(const(char)[] path)
+    {
+        import urt.string : wildcard_match;
+
+        bool included = false;
+        const(char)[] rest = _filter[];
+        while (!rest.empty)
+        {
+            const(char)[] tok = rest.split!',';
+            if (tok.empty)
+                continue;
+            if (tok[0] == '!')
+            {
+                if (wildcard_match(tok[1 .. $], path))
+                    return false;
+            }
+            else if (!included && wildcard_match(tok, path))
+                included = true;
+        }
+        return included;
+    }
+
     void scan()
     {
-        Array!(Element*) elements = g_app.find_elements(_filter[]);
+        Array!(Element*) elements;
+        const(char)[] rest = _filter[];
+        while (!rest.empty)
+        {
+            const(char)[] tok = rest.split!',';
+            if (!tok.empty && tok[0] != '!')
+                g_app.find_elements(tok, elements);
+        }
+
         char[256] buf = void;
         foreach (e; elements[])
         {
@@ -363,9 +419,30 @@ private:
             if (len <= 0 || len > buf.length)
                 continue;
             const(char)[] path = buf[0 .. len];
-            if (path !in _streams)
+            if (path !in _streams && matches(path))
                 attach(e, path);
         }
+    }
+
+    void drop_unmatched()
+    {
+        Array!(RecordStream*) dropped;
+        foreach (rs; _streams.values)
+            if (!matches(rs.path[]))
+                dropped ~= rs;
+        foreach (rs; dropped[])
+        {
+            _streams.remove(rs.path[]);
+            release(rs);
+        }
+    }
+
+    void release(RecordStream* rs)
+    {
+        rs.flush(); // ship what is still pending before the container closes
+        rs.close();
+        database().close_series(rs.series);
+        defaultAllocator().freeT(rs);
     }
 
     void attach(Element* e, const(char)[] path)
@@ -751,7 +828,7 @@ nothrow @nogc:
         uint h = height ? height.value : 16;
 
         auto cmd = defaultAllocator().allocT!RecordGraphCommand(session, w, h, opt);
-        cmd.fetch.begin(this, path, t0, t1, w * 2, QueryMode.graph, false);
+        cmd.fetch.begin(this, path, t0, t1, w * 2, QueryMode.graph, true);
         return cmd;
     }
 
@@ -762,7 +839,7 @@ nothrow @nogc:
         uint max_points = max ? max.value : 24;
 
         auto cmd = defaultAllocator().allocT!RecordQueryCommand(session, path);
-        cmd.fetch.begin(this, (&path)[0 .. 1], now > span ? now - span : 0, now, max_points, QueryMode.raw, false);
+        cmd.fetch.begin(this, (&path)[0 .. 1], now > span ? now - span : 0, now, max_points, QueryMode.raw, true);
         return cmd;
     }
 }


### PR DESCRIPTION
Recording defaulted to `filter=*`, so every `Recorder` captured every numeric element in the tree — runtime reasoning state and debug trees alongside the device samples worth archiving. On the reference site that is ~2000 series and hundreds of megabytes, which is why the Pi's config had the recorder commented out entirely to protect its SD card.

A recorder with no filter now configures storage and captures nothing, so every recorded class is named deliberately, and it says so at startup rather than sitting in `Running` looking identical to a broken one. The filter is a comma list of path patterns where a leading `!` excludes, which is what lets a device archive say `*,!energy.*` rather than enumerating every device; an exclusion vetoes wherever it sits in the list.

### Bugs fixed along the way

**Static queries always returned empty.** `/record/query` and `/record/graph` passed `allow_local=false`, so every static fetch interrogated the legacy db series, which has no ingest path — nothing calls `push_sample` or `push_block`. They now use the same local path the live graph already did: RAM retention plus the owsig container, falling through to the db only when local coverage does not reach the requested window.

**Unquoted comma filters silently matched nothing.** The console parses `filter=a,b` as an array, and converting that to the string the setter took produced JSON-decorated text (`["a","b"]`). Every pattern then carried a bracket and a quote. A single pattern or a quoted list worked, which made the failure easy to miss. The setter takes the variadic array form instead, which accepts both spellings from the console and single-item or list calls from D.

**Reconfiguration duplicated records.** Changing `filter` or `dir` restarted the object, closing every stream and reopening each cursor at index 0 — re-shipping the standing RAM history of streams the change never touched and appending duplicates to their containers. The cursor is the only record of how far a container has consumed its element and it lives in memory, so it has to survive reconfiguration. Both setters reconcile in place now: matching moved into `matches()`, shared by `scan()` and a new `drop_unmatched()`, so a filter change attaches what it newly selects and releases what it no longer does; a dir change just reopens containers at the new path.

Resuming by stored index was considered and rejected — `SeriesStore.head` restarts at 0 each process, so it would skip a new run's early records.

### `mark_assigned`

`base.d` gains `mark_assigned` alongside `mark_set`. A setter handed its current value has still been explicitly configured — which is what config export and initial sync consult — but there is nothing for peers to fetch, so recording that intent should not also mark the property dirty. The mask computation both share is factored into `prop_mask`.

### Verification

Builds clean; 112/112 unit tests pass.

Verified live against the reference site: static queries return data where they previously returned "0 samples"; unquoted and quoted comma lists both attach streams (previously only quoted did); narrowing a filter stops the dropped series dead while the kept one continues, and 121 samples spanning a narrow *and* a widen come back unique and monotonic, proving no cursor reset.

Not yet verified live: the startup notice for a filter-less recorder, and the `dir`-change path. Both are straightforward, but I would rather flag them than claim them.
