### PR TITLE
energy: boundary-edge accounting

### DIFF
--- a/conf/startup.conf
+++ b/conf/startup.conf
@@ -111,7 +111,7 @@ add name=goodwe_can stream=can.1 protocol=ebyte
 
 # Zigbee/Thread radio
 
-/protocol/ezsp/client/add name=zbdongle ash_stream=com3
+/protocol/ezsp/client/add name=zbdongle ash-stream=com3
 /interface/zigbee/add name=zb ezsp-client=zbdongle
 /protocol/zigbee/coordinator/add name=zb-coordinator interface=zb channel=auto
 /protocol/zigbee/endpoint/add name=zb-manager node=zb-coordinator endpoint-id=1 profile=ha device=0x0007 in-clusters=0,3,0xA,0xB05,0xEF00  out-clusters=3,4,5,6,8,0x101,0x102,0x201,0x202,0x300,0x400,0x402,0x405,0x403,0x702,0xB04,0xEF00
@@ -171,23 +171,31 @@ add name=cabin_shed_meter device=cabin_shed_meter node=mb slave=cabin_shed_meter
 
 #------------------------------------------------------------------------------------------
 # Configure energy manager
-/apps/energy/link add name=main kind=breaker parent=grid child=main meter=se_meter.meter capacity=63 meter-phase=1
+/apps/energy/link add name=main kind=breaker parent=grid child=main meter=se_meter.meter capacity=63A meter-phase=1
 /apps/energy/link add name=sub_main kind=meter parent=main child=sub_main meter=goodwe_meter.meter1 meter-sign=inverted
-/apps/energy/link add name=house kind=breaker parent=sub_main child=house meter=vue2.mains_a capacity=50
-/apps/energy/link add name=house_backup kind=breaker parent=house.backup_feed child=house.backup meter=goodwe_ems.backup.meter capacity=50
-/apps/energy/link add name=house_gpo kind=breaker parent=house.backup child=house.gpo meter=vue2.circuit_7 capacity=20
-/apps/energy/link add name=house_lights kind=breaker parent=house.backup child=house.lights meter=vue2.circuit_5 capacity=10
-/apps/energy/link add name=annex_gpo kind=breaker parent=house.backup child=annex.gpo meter=vue2.circuit_6 capacity=20
-/apps/energy/link add name=shed kind=breaker parent=house child=shed capacity=50
-/apps/energy/link add name=carport kind=breaker parent=main child=carport capacity=32
-/apps/energy/link add name=cabin kind=breaker parent=sub_main child=cabin meter=cabin_solar.inverter.export_meter meter-sign=inverted capacity=20
-/apps/energy/link add name=cabin_backup kind=breaker parent=cabin.backup_feed child=cabin.backup meter=cabin_solar.backup.meter capacity=20
-/apps/energy/link add name=cabin_gpo1 kind=breaker parent=cabin.backup child=cabin.gpo1 capacity=20
-/apps/energy/link add name=cabin_gpo2 kind=breaker parent=cabin.backup child=cabin.gpo2 capacity=20
-/apps/energy/link add name=cabin_laundry kind=breaker parent=cabin child=cabin.laundry meter=cabin_meter.meter_3 capacity=20
-/apps/energy/link add name=cabin_carport kind=breaker parent=cabin child=cabin.carport capacity=50
-/apps/energy/link add name=cabin_carport_gpo kind=breaker parent=cabin.carport child=cabin.carport.gpo meter=cabin_shed_meter.meter_1 capacity=20
-/apps/energy/link add name=caravan kind=breaker parent=cabin.carport child=caravan meter=cabin_shed_meter.meter_3 capacity=20
+/apps/energy/link add name=house kind=breaker parent=sub_main child=house meter=vue2.mains_a capacity=50A
+/apps/energy/link add name=house_backup kind=breaker parent=house.backup_feed child=house.backup meter=goodwe_ems.backup.meter capacity=50A
+/apps/energy/link add name=house_gpo kind=breaker parent=house.backup child=house.gpo meter=vue2.circuit_7 capacity=20A
+/apps/energy/link add name=house_lights kind=breaker parent=house.backup child=house.lights meter=vue2.circuit_5 capacity=10A
+/apps/energy/link add name=annex_gpo kind=breaker parent=house.backup child=annex.gpo meter=vue2.circuit_6 capacity=20A
+/apps/energy/link add name=shed kind=breaker parent=house child=shed capacity=50A
+/apps/energy/link add name=carport kind=breaker parent=main child=carport capacity=32A
+/apps/energy/link add name=cabin kind=breaker parent=sub_main child=cabin meter=cabin_solar.inverter.export_meter meter-sign=inverted capacity=20A
+/apps/energy/link add name=cabin_backup kind=breaker parent=cabin.backup_feed child=cabin.backup meter=cabin_solar.backup.meter capacity=20A
+/apps/energy/link add name=cabin_gpo1 kind=breaker parent=cabin.backup child=cabin.gpo1 capacity=20A
+/apps/energy/link add name=cabin_gpo2 kind=breaker parent=cabin.backup child=cabin.gpo2 capacity=20A
+/apps/energy/link add name=cabin_laundry kind=breaker parent=cabin child=cabin.laundry meter=cabin_meter.meter_3 capacity=20A
+/apps/energy/link add name=cabin_carport kind=breaker parent=cabin child=cabin.carport capacity=50A
+/apps/energy/link add name=cabin_carport_gpo kind=breaker parent=cabin.carport child=cabin.carport.gpo meter=cabin_shed_meter.meter_1 capacity=20A
+/apps/energy/link add name=caravan kind=breaker parent=cabin.carport child=caravan meter=cabin_shed_meter.meter_3 capacity=20A
+
+# Parent-only links are diffuse-load sinks: unenumerated socket loads on these
+# circuits account under the link's name.
+/apps/energy/link add name=house_gpo_outlets parent=house.gpo
+/apps/energy/link add name=annex_gpo_outlets parent=annex.gpo
+/apps/energy/link add name=cabin_gpo1_outlets parent=cabin.gpo1
+/apps/energy/link add name=cabin_gpo2_outlets parent=cabin.gpo2
+/apps/energy/link add name=cabin_carport_gpo_outlets parent=cabin.carport.gpo
 
 /apps/energy/appliance add name=solaredge grid=house device=se10000h
 /apps/energy/appliance add name=goodwe grid=house backup=house.backup_feed battery=dc_bus device=goodwe_ems

--- a/conf/startup.conf
+++ b/conf/startup.conf
@@ -258,7 +258,12 @@ add name=cabin_ev_surplus target=cabin_evse tier=opportunistic goal="soc(100)"
 #------------------------------------------------------------------------------------------
 # Other runtime stuff
 
-/record add dir=db
+# Device archive: raw samples from the data-source devices
+/record add name=devices dir=db filter="*,!energy.*,!config.*"
+# Long history: the presentation set (accounts, boundary flows/counters/soc, group loss)
+/record add name=presentation dir=db filter="energy.islands.*.account.*,energy.boundary.*,energy.appliance.*.loss_power,energy.topology.link.*.loss_power,energy.topology.link.*.mismatch"
+# Short history: local-reasoning state (planner budget, allocation decisions)
+/record add name=reasoning dir=db filter="energy.islands.*.budget.*,energy.allocation.*"
 
 /protocol/http/server add name=webserver port=8080
 /protocol/http/static add name=site http-server=webserver uri=/ root="../openwatt-web"

--- a/conf/startup.conf
+++ b/conf/startup.conf
@@ -1,5 +1,6 @@
 # Startup script
 
+/system/set-hostname hostname=ow-win-test
 /system/update-rate rate=20
 /system/log-level severity=trace
 
@@ -110,20 +111,13 @@ add name=goodwe_can stream=can.1 protocol=ebyte
 
 # Zigbee/Thread radio
 
-/protocol/ezsp/client/add name=zbdongle ash-stream=com3
+/protocol/ezsp/client/add name=zbdongle ash_stream=com3
 /interface/zigbee/add name=zb ezsp-client=zbdongle
 /protocol/zigbee/coordinator/add name=zb-coordinator interface=zb channel=auto
 /protocol/zigbee/endpoint/add name=zb-manager node=zb-coordinator endpoint-id=1 profile=ha device=0x0007 in-clusters=0,3,0xA,0xB05,0xEF00  out-clusters=3,4,5,6,8,0x101,0x102,0x201,0x202,0x300,0x400,0x402,0x405,0x403,0x702,0xB04,0xEF00
 /protocol/zigbee/controller/add name=zb-controller endpoint=zb-manager auto-create=true
 
-#/protocol/ezsp/client/add name=zbrouter ash-stream=com4
-#/interface/zigbee/add name=zbrt ezsp-client=zbrouter
-#/protocol/zigbee/router/add name=zb-router interface=zbrt channel=auto
-#/protocol/zigbee/coordinator/add name=zb-coord2 interface=zbrt channel=auto
-
-/interface/cpc/add name=cpc0 stream=com5
-/interface/cpc/endpoint/add name=wpan-154 cpc=cpc0 endpoint=ieee802_15_4
-/protocol/spinel/client/add name=spinel0 interface=wpan-154 iid=1
+#/protocol/spinel/client/add name=zbgw04 stream=com5
 
 # HTTP/REST devices
 /protocol/http/client add name=evse_http remote="http://192.168.3.100"
@@ -156,7 +150,7 @@ add name=cabin_shed_meter device=cabin_shed_meter node=mb slave=cabin_shed_meter
 
 # Tesla TWCs
 #/binding/tesla/twc/add name=carport_twc device=carport_twc slave_id=0x6914
-/binding/tesla/twc/add name=shed_twc device=shed_twc slave_id=0x6820
+#/binding/tesla/twc/add name=shed_twc device=shed_twc slave_id=0x6820
 
 # CAN devices (BMS)
 /binding/can/add name=house_bms device=house_bms interface=goodwe_can profile=pylon
@@ -170,49 +164,93 @@ add name=cabin_shed_meter device=cabin_shed_meter node=mb slave=cabin_shed_meter
 #------------------------------------------------------------------------------------------
 # Link elements between meters and EVSE
 
-/element/link/add source=se_meter.meter.current1 target=smartevse.mains.current1
-/element/link/add source=se_meter.meter.current2 target=smartevse.mains.current2
-/element/link/add source=se_meter.meter.current3 target=smartevse.mains.current3
+/element/link/add source=se_meter.meter.current1 target=smartevse.evse.mains.current1
+/element/link/add source=se_meter.meter.current2 target=smartevse.evse.mains.current2
+/element/link/add source=se_meter.meter.current3 target=smartevse.evse.mains.current3
 
 
 #------------------------------------------------------------------------------------------
 # Configure energy manager
-/apps/energy/circuit add name=main meter=se_meter.meter max-current=63 type=single_phase meter-phase=1
-/apps/energy/circuit add name=house parent=main meter=vue2.mains_a max-current=50
-/apps/energy/circuit add name=house.backup parent=house meter=goodwe_ems.backup.meter max-current=50
-/apps/energy/circuit add name=house.gpo parent=house.backup meter=vue2.circuit_7 max-current=20
-/apps/energy/circuit add name=house.lights parent=house.backup meter=vue2.circuit_5 max-current=10
-/apps/energy/circuit add name=annex.gpo parent=house.backup meter=vue2.circuit_6 max-current=20
-/apps/energy/circuit add name=shed parent=house max-current=50
-/apps/energy/circuit add name=carport parent=main max-current=32
-/apps/energy/circuit add name=cabin parent=main meter=cabin_solar.inverter.export_meter max-current=20
-/apps/energy/circuit add name=cabin.backup parent=cabin meter=cabin_solar.backup.meter max-current=20
-/apps/energy/circuit add name=cabin.gpo1 parent=cabin.backup max-current=20
-/apps/energy/circuit add name=cabin.gpo2 parent=cabin.backup max-current=20
-/apps/energy/circuit add name=cabin.laundry parent=cabin meter=cabin_meter.meter_3 max-current=20
-/apps/energy/circuit add name=cabin.carport parent=cabin max-current=50
-/apps/energy/circuit add name=cabin.carport.gpo parent=cabin.carport meter=cabin_shed_meter.meter_1 max-current=50
-/apps/energy/circuit add name=caravan parent=cabin.carport meter=cabin_shed_meter.meter_3 max-current=20
+/apps/energy/link add name=main kind=breaker parent=grid child=main meter=se_meter.meter capacity=63 meter-phase=1
+/apps/energy/link add name=sub_main kind=meter parent=main child=sub_main meter=goodwe_meter.meter1 meter-sign=inverted
+/apps/energy/link add name=house kind=breaker parent=sub_main child=house meter=vue2.mains_a capacity=50
+/apps/energy/link add name=house_backup kind=breaker parent=house.backup_feed child=house.backup meter=goodwe_ems.backup.meter capacity=50
+/apps/energy/link add name=house_gpo kind=breaker parent=house.backup child=house.gpo meter=vue2.circuit_7 capacity=20
+/apps/energy/link add name=house_lights kind=breaker parent=house.backup child=house.lights meter=vue2.circuit_5 capacity=10
+/apps/energy/link add name=annex_gpo kind=breaker parent=house.backup child=annex.gpo meter=vue2.circuit_6 capacity=20
+/apps/energy/link add name=shed kind=breaker parent=house child=shed capacity=50
+/apps/energy/link add name=carport kind=breaker parent=main child=carport capacity=32
+/apps/energy/link add name=cabin kind=breaker parent=sub_main child=cabin meter=cabin_solar.inverter.export_meter meter-sign=inverted capacity=20
+/apps/energy/link add name=cabin_backup kind=breaker parent=cabin.backup_feed child=cabin.backup meter=cabin_solar.backup.meter capacity=20
+/apps/energy/link add name=cabin_gpo1 kind=breaker parent=cabin.backup child=cabin.gpo1 capacity=20
+/apps/energy/link add name=cabin_gpo2 kind=breaker parent=cabin.backup child=cabin.gpo2 capacity=20
+/apps/energy/link add name=cabin_laundry kind=breaker parent=cabin child=cabin.laundry meter=cabin_meter.meter_3 capacity=20
+/apps/energy/link add name=cabin_carport kind=breaker parent=cabin child=cabin.carport capacity=50
+/apps/energy/link add name=cabin_carport_gpo kind=breaker parent=cabin.carport child=cabin.carport.gpo meter=cabin_shed_meter.meter_1 capacity=20
+/apps/energy/link add name=caravan kind=breaker parent=cabin.carport child=caravan meter=cabin_shed_meter.meter_3 capacity=20
 
-/apps/energy/appliance add id=solaredge circuit=house meter=vue2.circuit_1 type=inverter
-/apps/energy/appliance add id=goodwe circuit=house device=goodwe_ems priority=1
-/apps/energy/appliance add id=cabin_solar circuit=cabin device=cabin_solar meter=cabin_meter.meter_1 priority=1
-/apps/energy/appliance add id=carport_evse circuit=carport device=carport_twc priority=5
-/apps/energy/appliance add id=shed_evse circuit=shed device=shed_twc priority=5
-/apps/energy/appliance add id=cabin_evse circuit=cabin.carport meter=cabin_shed_meter.meter_2 type=evse priority=5
-/apps/energy/appliance add id=house_ac circuit=house meter=vue2.circuit_4 type=hvac
-/apps/energy/appliance add id=cabin_ac circuit=cabin.backup meter=cabin_meter.meter_2 type=hvac
-/apps/energy/appliance add id=cabin_hot_water circuit=cabin.laundry type=water-heater priority=6
-/apps/energy/appliance add id=annex_univ_gpo circuit=annex.gpo device=annex_univ_gpo priority=7
+/apps/energy/appliance add name=solaredge grid=house device=se10000h
+/apps/energy/appliance add name=goodwe grid=house backup=house.backup_feed battery=dc_bus device=goodwe_ems
+/apps/energy/appliance add name=house_battery connection=dc_bus device=house_bms
+/apps/energy/appliance add name=cabin_solar grid=cabin backup=cabin.backup_feed battery=cabin.dc solar.mppt1=cabin.pv1 solar.mppt2=cabin.pv2 device=cabin_solar
+/apps/energy/appliance add name=carport_evse grid=carport device=carport_twc
+/apps/energy/appliance add name=shed_evse grid=shed device=shed_twc
+/apps/energy/appliance add name=cabin_evse grid=cabin.carport car=mg_zs device=smartevse meter=cabin_shed_meter.meter_2
+/apps/energy/appliance add name=house_ac connection=house meter=vue2.circuit_4 kind=hvac
+/apps/energy/appliance add name=cabin_ac connection=cabin.backup meter=cabin_meter.meter_2 kind=hvac
+/apps/energy/appliance add name=cabin_hot_water connection=cabin.laundry kind=water-heater
+/apps/energy/appliance add name=annex_univ_gpo grid=annex.gpo outlet1=annex.gpo.1 outlet2=annex.gpo.2 device=annex_univ_gpo
 
-/apps/energy/appliance add id=evie name=Evie type=car vin=LRW3F7EKXMC392131 priority=3
-/apps/energy/appliance add id=zephyr name=Zephyr type=car vin=5YJ3F7EC8LF488644 priority=2
-/apps/energy/appliance add id=mg_zs type=car circuit=cabin.carport priority=4 # we can't read the vin for this yet...
+/apps/energy/appliance add name=evie kind=car vin=LRW3F7EKXMC392131
+/apps/energy/appliance add name=zephyr kind=car vin=5YJ3F7EC8LF488644
+/apps/energy/appliance add name=mg_zs kind=car connection=mg_zs # we can't read the vin for this yet...
 
-#/apps/energy/management/strategy add
+# Energy policy: layered intent that the allocator services each tick.
+#
+# Tiers (highest priority first):
+#   floor          must always hold; infinite priority; may pull grid.
+#   essential      must reach goal by deadline; high priority, decays toward urgent as slack runs out.
+#   important      try to reach; yields to floor/essential; solar+battery only, no grid buy.
+#   opportunistic  consume surplus only; gated on battery/solar pressure.
+# Goals: on, off, soc(N), temp(N). deadline=HH:MM feeds the slack boost on essential/important.
+# shape=window marks intent for a charge window (parsed and published; not yet wired into ranking).
+# A target may carry several policies at different tiers; read each block top-to-bottom as intent.
+# Inspect live decisions with:  /apps/energy/why   and   /apps/energy/control/print
+
+/apps/energy/policy
+
+# Cars: target the car, not the charger. The allocator drives whichever EVSE the
+# car is paired to (matched by VIN). VIN pairing and the TWC control surface are
+# still being wired, so these report "no control" in /why for now; they define the
+# intent so the rest of the model can be exercised against them.
+add name=evie_reserve    target=evie   tier=floor         goal="soc(20)"
+add name=evie_ready      target=evie   tier=important     goal="soc(40)" deadline=11:00 shape=window
+add name=evie_topup      target=evie   tier=opportunistic goal="soc(90)"
+add name=zephyr_reserve  target=zephyr tier=floor         goal="soc(20)"
+add name=zephyr_ready    target=zephyr tier=essential     goal="soc(50)" deadline=08:00 shape=window
+add name=zephyr_topup    target=zephyr tier=opportunistic goal="soc(90)"
+
+# Cabin EVSE has no paired car (mg_zs reports no VIN) and very low use, so just soak
+# surplus into whatever is plugged in. smartevse exposes a continuous amps control, so
+# this one actually drives charge_current (headroom-clamped) whenever pressure allows.
+add name=cabin_ev_surplus target=cabin_evse tier=opportunistic goal="soc(100)"
+
+# The GoodWe EMS battery is autonomous (PowerControl kind=autonomous, track_meter):
+# the inverter manages its own reserve, so it takes no setpoint and needs no policy.
+# A commandable battery would carry a reserve floor + fill-on-surplus pair, e.g.:
+#add name=battery_reserve target=goodwe tier=floor         goal="soc(30)"
+#add name=battery_full    target=goodwe tier=opportunistic goal="soc(100)"
+
+# Cabin hot water (no ThermalStore device bound yet: intent anchor, reports "no control").
+#add name=hotwater_min     target=cabin_hot_water tier=floor         goal="temp(40)"
+#add name=hotwater_morning target=cabin_hot_water tier=essential     goal="temp(45)" deadline=06:30 shape=window
+#add name=hotwater_super   target=cabin_hot_water tier=opportunistic goal="temp(70)"
+
 
 #------------------------------------------------------------------------------------------
 # Other runtime stuff
+
+/record add dir=db
 
 /protocol/http/server add name=webserver port=8080
 /protocol/http/static add name=site http-server=webserver uri=/ root="../openwatt-web"
@@ -223,12 +261,6 @@ add name=cabin_shed_meter device=cabin_shed_meter node=mb slave=cabin_shed_meter
 /protocol/dns/server add name=dns protocols=mdns#,llmnr,wins,dns,dot,doh doh-server=webserver doh-uri=/dns-query
 
 /tools/pcap/server add name=rpcap port=2002 allow-anonymous=true
-
-#------------------------------------------------------------------------------------------
-# Automations
-
-# Front door drives the gang1 light switch: the switch follows the door contact state.
-/automation/add name=door-light on="@zb_71057949f238c1a4.contact.open" do={ /element/set element=zb_6e88a9348538c1a4.gang1.switch value=$value }
 
 #------------------------------------------------------------------------------------------
 # mark the heap for leak tracking...

--- a/src/apps/energy/accounts.d
+++ b/src/apps/energy/accounts.d
@@ -107,6 +107,8 @@ struct IslandTotals
     float generation_power = 0;
     float load_power = 0;
 
+    float local_fraction = float.nan;
+
     double solar_today_kwh = 0;
     double battery_charge_today_kwh = 0;
     double battery_discharge_today_kwh = 0;
@@ -128,6 +130,7 @@ nothrow @nogc:
     AccountFloatCell rogue_load_power;
     AccountFloatCell generation_power;
     AccountFloatCell load_power;
+    AccountFloatCell local_fraction;
     AccountFloatCell solar_today_energy;
     AccountFloatCell battery_today_charge;
     AccountFloatCell battery_today_discharge;
@@ -146,6 +149,7 @@ nothrow @nogc:
         rogue_load_power.bind(account_element!float(energy_device, island_id, "account.rogue.load.power"));
         generation_power.bind(account_element!float(energy_device, island_id, "account.generation.power"));
         load_power.bind(account_element!float(energy_device, island_id, "account.load.total.power"));
+        local_fraction.bind(account_element!float(energy_device, island_id, "account.local_fraction"));
         solar_today_energy.bind(account_element!float(energy_device, island_id, "account.solar.today.energy"));
         battery_today_charge.bind(account_element!float(energy_device, island_id, "account.battery.today.charge"));
         battery_today_discharge.bind(account_element!float(energy_device, island_id, "account.battery.today.discharge"));
@@ -235,6 +239,7 @@ void update_island_accounts(ref IslandAccountPublisher publisher, Island* island
     publisher.rogue_load_power.publish(t.rogue_load_power, ts);
     publisher.generation_power.publish(t.generation_power, ts);
     publisher.load_power.publish(t.load_power, ts);
+    publisher.local_fraction.publish(t.local_fraction, ts);
 
     publisher.solar_today_energy.publish(cast(float)t.solar_today_kwh, ts);
     publisher.battery_today_charge.publish(cast(float)t.battery_charge_today_kwh, ts);
@@ -253,7 +258,7 @@ IslandTotals compute_island_totals(Island* island, ref TopologyGraph graph, ref 
     foreach (ref f; graph.boundary_flows[])
     {
         Bus* b = boundary_bus(f.port);
-        if (b is null || !circuit_in_island(island, b.id[]))
+        if (b is null || !island_contains(island, b))
             continue;
         float net = f.power_into_graph - f.power_out_of_graph;
         final switch (f.kind)
@@ -295,6 +300,14 @@ IslandTotals compute_island_totals(Island* island, ref TopologyGraph graph, ref 
     if (t.load_power < 0)
         t.load_power = 0;
 
+    // Battery discharge counts as local regardless of what charged it; when
+    // exporting, consumption is fully locally served.
+    if (t.load_power > 0)
+    {
+        float f = t.generation_power / t.load_power;
+        t.local_fraction = f < 0 ? 0 : (f > 1 ? 1 : f);
+    }
+
     return t;
 }
 
@@ -303,7 +316,7 @@ void add_boundary_energy(ref IslandTotals t, Island* island, ref TopologyGraph g
     foreach (p; graph.boundaries[])
     {
         Bus* b = boundary_bus(p);
-        if (b is null || !circuit_in_island(island, b.id[]))
+        if (b is null || !island_contains(island, b))
             continue;
         BoundaryEnergy e = boundary_energy(p);
         final switch (boundary_kind(p))
@@ -392,6 +405,15 @@ void add_production_today(ref IslandTotals t, ref TopologyGraph graph, Island* i
     }
 }
 
+bool island_contains(Island* island, Bus* bus)
+{
+    foreach (b; island.members[])
+        if (b is bus)
+            return true;
+    return false;
+}
+
+// Production contributions carry circuit names, not bus pointers.
 bool circuit_in_island(Island* island, const(char)[] circuit)
 {
     foreach (b; island.members[])

--- a/src/apps/energy/accounts.d
+++ b/src/apps/energy/accounts.d
@@ -296,6 +296,14 @@ IslandTotals compute_island_totals(Island* island, ref TopologyGraph graph, ref 
 // places and only support bus balance and cross-checks. An implicit terminal
 // represents equipment declared by a boundary until the real equipment is
 // modelled. Keep this selection aligned with topology.rebuild_productions.
+//
+// TODO(MET-5, docs/SOURCE_SURVEY.draft.md): replace this account-specific
+//      selection with the generic boundary-edge model. Retain all declared
+//      ports, solve point-meter observations once, and account exactly the
+//      connected port of a one-port group or a dangling port of a multi-port
+//      group. Keep Port power in its Bus -> Port frame; boundary orientation is
+//      a separate accounting transform. Implement the spec rather than patching
+//      PV signs here.
 void add_island_battery(ref IslandTotals t, Island* island, ref DailySnapshot daily)
 {
     foreach (bus; island.members[])

--- a/src/apps/energy/accounts.d
+++ b/src/apps/energy/accounts.d
@@ -253,7 +253,7 @@ IslandTotals compute_island_totals(Island* island, ref TopologyGraph graph, ref 
     foreach (ref f; graph.boundary_flows[])
     {
         Bus* b = boundary_bus(f.port);
-        if (b is null || !island_contains(island, b))
+        if (b is null || !circuit_in_island(island, b.id[]))
             continue;
         float net = f.power_into_graph - f.power_out_of_graph;
         final switch (f.kind)
@@ -303,7 +303,7 @@ void add_boundary_energy(ref IslandTotals t, Island* island, ref TopologyGraph g
     foreach (p; graph.boundaries[])
     {
         Bus* b = boundary_bus(p);
-        if (b is null || !island_contains(island, b))
+        if (b is null || !circuit_in_island(island, b.id[]))
             continue;
         BoundaryEnergy e = boundary_energy(p);
         final switch (boundary_kind(p))
@@ -392,15 +392,6 @@ void add_production_today(ref IslandTotals t, ref TopologyGraph graph, Island* i
     }
 }
 
-bool island_contains(Island* island, Bus* bus)
-{
-    foreach (b; island.members[])
-        if (b is bus)
-            return true;
-    return false;
-}
-
-// Production contributions carry circuit names, not bus pointers.
 bool circuit_in_island(Island* island, const(char)[] circuit)
 {
     foreach (b; island.members[])

--- a/src/apps/energy/accounts.d
+++ b/src/apps/energy/accounts.d
@@ -243,47 +243,53 @@ void update_island_accounts(ref IslandAccountPublisher publisher, Island* island
     publisher.grid_today_export.publish(cast(float)t.grid_export_today_kwh, ts);
 }
 
+// Every account is a projection of the one boundary reduction: each solved
+// boundary edge contributes once, classified by metadata, oriented by shape.
 IslandTotals compute_island_totals(Island* island, ref TopologyGraph graph, ref DailySnapshot daily)
 {
     IslandTotals t;
+    float generator_power = 0;
 
-    // The root is deliberately anchored to the utility bus for on-grid islands.
-    if (island.root && island.root.contains_grid && island.root.balance.has(MeterField.power))
+    foreach (ref f; graph.boundary_flows[])
     {
-        t.grid_power = island.root.balance.active[0].value;
-        // When utility inlets are modelled, other grid-bus counters belong to
-        // local consumers or generators rather than the utility exchange.
-        bool inlets = bus_has_grid_inlet(island.root);
-        foreach (p; island.root.ports[])
+        Bus* b = boundary_bus(f.port);
+        if (b is null || !island_contains(island, b))
+            continue;
+        float net = f.power_into_graph - f.power_out_of_graph;
+        final switch (f.kind)
         {
-            if (!p.meter)
-                continue;
-            if (inlets)
-            {
-                if (!is_grid_inlet_port(p))
-                    continue;
-            }
-            // A class terminal measures its equipment, not the utility exchange.
-            else if (class_terminal(p) || p.role == PortRole.pv || p.role == PortRole.battery)
-                continue;
-            t.grid_import_today_kwh += today_delta_value(daily, p.meter.find_element("import"),
-                                                         p.meter_data.total_import_active[0]);
-            t.grid_export_today_kwh += today_delta_value(daily, p.meter.find_element("export"),
-                                                         p.meter_data.total_export_active[0]);
+            case BoundaryKind.grid:
+                t.grid_power += net;
+                break;
+            case BoundaryKind.solar:
+                t.solar_power += net;
+                break;
+            case BoundaryKind.generator:
+                generator_power += net;
+                break;
+            case BoundaryKind.battery:
+                t.battery_power += net;
+                break;
+            case BoundaryKind.load:
+                break;
+            case BoundaryKind.unclassified:
+                t.rogue_generation_power += f.power_into_graph;
+                t.rogue_load_power += f.power_out_of_graph;
+                break;
         }
     }
 
-    foreach (ref production; graph.productions[])
-        if (production_belongs_to_island(production, graph, island) &&
-            production.data.has(MeterField.power))
-            t.solar_power += production.data.active[0].value;
+    add_boundary_energy(t, island, graph, daily);
+
+    // Solar daily counters still reconcile through productions: an inferred
+    // boundary (implicit pv terminal) has no counter of its own, but its bus's
+    // interior mppt meters count the same energy.
     add_production_today(t, graph, island, daily);
 
-    add_island_battery(t, island, daily);
     add_island_rogue(t, island);
 
     // Keep grid separate so load = generation + grid before the zero clamp.
-    t.generation_power = t.solar_power + t.battery_power + t.rogue_generation_power;
+    t.generation_power = t.solar_power + generator_power + t.battery_power + t.rogue_generation_power;
 
     t.load_power = t.generation_power + t.grid_power;
     if (t.load_power < 0)
@@ -292,51 +298,29 @@ IslandTotals compute_island_totals(Island* island, ref TopologyGraph graph, ref 
     return t;
 }
 
-// Terminals measure equipment and define its account. Boundary ports measure
-// places and only support bus balance and cross-checks. An implicit terminal
-// represents equipment declared by a boundary until the real equipment is
-// modelled. Keep this selection aligned with topology.rebuild_productions.
-//
-// TODO(MET-5, docs/SOURCE_SURVEY.draft.md): replace this account-specific
-//      selection with the generic boundary-edge model. Retain all declared
-//      ports, solve point-meter observations once, and account exactly the
-//      connected port of a one-port group or a dangling port of a multi-port
-//      group. Keep Port power in its Bus -> Port frame; boundary orientation is
-//      a separate accounting transform. Implement the spec rather than patching
-//      PV signs here.
-void add_island_battery(ref IslandTotals t, Island* island, ref DailySnapshot daily)
+void add_boundary_energy(ref IslandTotals t, Island* island, ref TopologyGraph graph, ref DailySnapshot daily)
 {
-    foreach (bus; island.members[])
+    foreach (p; graph.boundaries[])
     {
-        bool implicit_terminal;
-        foreach (p; bus.ports[])
-            if (p.role == PortRole.battery && p.implicit)
-                implicit_terminal = true;
-
-        foreach (p; bus.ports[])
+        Bus* b = boundary_bus(p);
+        if (b is null || !island_contains(island, b))
+            continue;
+        BoundaryEnergy e = boundary_energy(p);
+        final switch (boundary_kind(p))
         {
-            if (p.role != PortRole.battery)
-                continue;
-            if (class_terminal(p))
-            {
-                if (p.meter_data.has(MeterField.power))
-                    t.battery_power += -p.meter_data.active[0].value;
-                if (p.meter)
-                {
-                    t.battery_charge_today_kwh += today_delta_value(daily, p.meter.find_element("import"),
-                                                                    p.meter_data.total_import_active[0]);
-                    t.battery_discharge_today_kwh += today_delta_value(daily, p.meter.find_element("export"),
-                                                                       p.meter_data.total_export_active[0]);
-                }
-            }
-            else if (implicit_terminal && p.meter)
-            {
-                // The implicit bank is visible only in the boundary's opposite frame.
-                t.battery_charge_today_kwh += today_delta_value(daily, p.meter.find_element("export"),
-                                                                p.meter_data.total_export_active[0]);
-                t.battery_discharge_today_kwh += today_delta_value(daily, p.meter.find_element("import"),
-                                                                   p.meter_data.total_import_active[0]);
-            }
+            case BoundaryKind.grid:
+                t.grid_import_today_kwh += today_delta_value(daily, e.into_key, e.into_total);
+                t.grid_export_today_kwh += today_delta_value(daily, e.out_key, e.out_total);
+                break;
+            case BoundaryKind.battery:
+                t.battery_discharge_today_kwh += today_delta_value(daily, e.into_key, e.into_total);
+                t.battery_charge_today_kwh += today_delta_value(daily, e.out_key, e.out_total);
+                break;
+            case BoundaryKind.solar:
+            case BoundaryKind.generator:
+            case BoundaryKind.load:
+            case BoundaryKind.unclassified:
+                break;
         }
     }
 }
@@ -408,6 +392,15 @@ void add_production_today(ref IslandTotals t, ref TopologyGraph graph, Island* i
     }
 }
 
+bool island_contains(Island* island, Bus* bus)
+{
+    foreach (b; island.members[])
+        if (b is bus)
+            return true;
+    return false;
+}
+
+// Production contributions carry circuit names, not bus pointers.
 bool circuit_in_island(Island* island, const(char)[] circuit)
 {
     foreach (b; island.members[])

--- a/src/apps/energy/allocator.d
+++ b/src/apps/energy/allocator.d
@@ -360,7 +360,7 @@ float appliance_draw_watts(ref TopologyGraph graph, Appliance target)
     if (target is null)
         return float.nan;
     foreach (p; graph.ports[])
-        if (p.owner is target && p.meter_data.has(MeterField.power))
+        if (p.owner is target && p.bus !is null && p.meter_data.has(MeterField.power))
             return absf(p.meter_data.active[0].value);
     return float.nan;
 }

--- a/src/apps/energy/attribution.d
+++ b/src/apps/energy/attribution.d
@@ -61,20 +61,12 @@ nothrow @nogc:
             a = TerminalAttribution.init;
 
         Map!(Bus*, int) bus_index;
-        Map!(Port*, bool) branch_terminal;
         foreach (i, b; graph.bus_list[])
             bus_index.insert(b, cast(int)i);
-        foreach (link; graph.links[])
-        {
-            if (link.port_a)
-                branch_terminal.insert(link.port_a, true);
-            if (link.port_b)
-                branch_terminal.insert(link.port_b, true);
-        }
 
         partition_islands(graph, bus_index);
         build_grid_spanning_tree(graph, bus_index);
-        attribute_source_mix(graph, bus_index, branch_terminal);
+        attribute_source_mix(graph, bus_index);
     }
 
     int terminal_index(ref TopologyGraph graph, Port* p)
@@ -172,8 +164,7 @@ private:
         }
     }
 
-    void attribute_source_mix(ref TopologyGraph graph, ref Map!(Bus*, int) bus_index,
-                              ref Map!(Port*, bool) branch_terminal)
+    void attribute_source_mix(ref TopologyGraph graph, ref Map!(Bus*, int) bus_index)
     {
         size_t nb = graph.bus_list.length;
         Array!float local;
@@ -185,10 +176,10 @@ private:
         next_local.resize(nb);
         next_grid.resize(nb);
 
-        seed_source_mix(graph, branch_terminal, local, grid);
+        seed_source_mix(graph, bus_index, local, grid);
         foreach (_; 0 .. nb + graph.links.length + 1)
         {
-            seed_source_mix(graph, branch_terminal, next_local, next_grid);
+            seed_source_mix(graph, bus_index, next_local, next_grid);
 
             foreach (link; graph.links[])
             {
@@ -287,28 +278,36 @@ private:
         }
     }
 
-    void seed_source_mix(ref TopologyGraph graph, ref Map!(Port*, bool) branch_terminal,
+    // Seeds are the solved boundary in-flows: grid-kind seeds grid, everything
+    // else seeds local (diffuse/unclassified supply is local by nature; battery
+    // discharge is local regardless of what charged it). Residuals never seed:
+    // error is not energy. A grid bus no grid boundary reported on falls back
+    // to the load-shortfall heuristic.
+    void seed_source_mix(ref TopologyGraph graph, ref Map!(Bus*, int) bus_index,
                          ref Array!float local, ref Array!float grid)
     {
-        foreach (i, b; graph.bus_list[])
+        foreach (i; 0 .. local.length)
         {
-            local[][i] = local_terminal_source(b, branch_terminal);
-            grid[][i] = b.contains_grid ? grid_terminal_source(b, local[][i]) : 0;
+            local[][i] = 0;
+            grid[][i] = float.nan;
         }
-    }
-
-    float local_terminal_source(Bus* bus, ref Map!(Port*, bool) branch_terminal)
-    {
-        float source = 0;
-        foreach (p; bus.ports[])
+        foreach (ref f; graph.boundary_flows[])
         {
-            if (p in branch_terminal || !p.meter_data.has(MeterField.power))
+            int* bi = boundary_bus(f.port) in bus_index;
+            if (bi is null)
                 continue;
-            float power = p.meter_data.active[0].value;
-            if (power == power && power < 0)
-                source += -power;
+            if (f.kind == BoundaryKind.grid)
+            {
+                if (grid[][cast(size_t)*bi] != grid[][cast(size_t)*bi])
+                    grid[][cast(size_t)*bi] = 0;
+                grid[][cast(size_t)*bi] += f.power_into_graph;
+            }
+            else
+                local[][cast(size_t)*bi] += f.power_into_graph;
         }
-        return source;
+        foreach (i, b; graph.bus_list[])
+            if (grid[][i] != grid[][i])
+                grid[][i] = b.contains_grid ? grid_terminal_source(b, local[][i]) : 0;
     }
 
     float terminal_load(Bus* bus)
@@ -374,4 +373,52 @@ float bus_local_fraction(float local, float grid, bool contains_grid)
     if (total > 0)
         return local / total;
     return contains_grid ? 0 : float.nan;
+}
+
+unittest
+{
+    // grid import and a local pv boundary blend by classification, not sign:
+    // 1000 W import + 500 W pv serving 1500 W load = one-third local
+    TopologyGraph g;
+    Bus* gridb = g.ensure_bus("grid");
+    Bus* house = g.ensure_bus("house");
+
+    Port* gp = g.add_port(null, gridb, PortRole.parent, FlowDomain.bidirectional, null, 0, MeterSign.normal, "parent", "main");
+    gp.meter_data.write_value(MeterField.power, 0, 1000);
+    gp.meter_data.mark(MeterField.power, 0, Provenance.measured);
+    Port* hp = g.add_port(null, house, PortRole.child, FlowDomain.bidirectional, null, 0, MeterSign.normal, "child", "main");
+    hp.meter_data.write_value(MeterField.power, 0, -1000);
+    hp.meter_data.mark(MeterField.power, 0, Provenance.measured);
+    Link* ml = g.add_link(null, gridb, house, gp, hp, 63, true, "main");
+    PortGroup* main_g = g.add_group("main", PortGroupKind.switchgear, null, ml);
+    g.add_to_group(main_g, gp);
+    g.add_to_group(main_g, hp);
+
+    Port* pv = g.add_port(null, house, PortRole.pv, FlowDomain.supply, null, 0, MeterSign.normal, "pv");
+    pv.meter_data.write_value(MeterField.power, 0, -500);
+    pv.meter_data.mark(MeterField.power, 0, Provenance.measured);
+    g.add_to_group(g.add_group("pv", PortGroupKind.appliance), pv);
+
+    Port* load = g.add_port(null, house, PortRole.connection, FlowDomain.consume, null, 0, MeterSign.normal, "heater");
+    load.meter_data.write_value(MeterField.power, 0, 1500);
+    load.meter_data.mark(MeterField.power, 0, Provenance.measured);
+    g.add_to_group(g.add_group("heater", PortGroupKind.appliance), load);
+
+    g.rebuild_boundaries();
+    g.reduce_boundary_flows();
+    g.attribution.compute(g);
+
+    size_t gi = g.bus_list[].findFirst(gridb);
+    size_t hi = g.bus_list[].findFirst(house);
+    assert(g.attribution.buses[gi].local_fraction == 0);
+    assert(absf(g.attribution.buses[hi].local_source_power - 500) <= 0.01f);
+    assert(absf(g.attribution.buses[hi].grid_source_power - 1000) <= 0.01f);
+    assert(absf(g.attribution.buses[hi].local_fraction - 1.0f / 3) <= 0.001f);
+
+    size_t li = g.ports[].findFirst(load);
+    assert(absf(g.attribution.terminals[li].consumed_power - 1500) <= 0.01f);
+    assert(absf(g.attribution.terminals[li].local_power - 500) <= 0.01f);
+    assert(absf(g.attribution.terminals[li].grid_power - 1000) <= 0.01f);
+
+    g.clear();
 }

--- a/src/apps/energy/link.d
+++ b/src/apps/energy/link.d
@@ -5,6 +5,7 @@ import urt.meta : AliasSeq;
 import urt.string;
 
 import apps.energy : EnergyAppModule;
+import apps.energy.meter : MeterAmps;
 import apps.energy.model;
 import apps.energy.reference;
 
@@ -100,12 +101,12 @@ nothrow @nogc:
         restart();
     }
 
-    uint capacity() const pure { return _capacity; }
-    void capacity(uint value)
+    MeterAmps capacity() const pure { return MeterAmps(_capacity); }
+    void capacity(MeterAmps value)
     {
-        if (_capacity == value)
+        if (_capacity == value.value)
             return;
-        _capacity = value;
+        _capacity = value.value;
         mark_set!(typeof(this), [ "capacity", "kind" ])();
         restart();
     }
@@ -192,7 +193,7 @@ private:
     String _child_circuit;
     String _circuit;
     String _role;
-    uint _capacity;
+    float _capacity = 0;
     bool _closed;
     ubyte _meter_phase;
     MeterSign _meter_sign;

--- a/src/apps/energy/package.d
+++ b/src/apps/energy/package.d
@@ -742,7 +742,7 @@ nothrow @nogc:
         Port* primary_port(Appliance a)
         {
             foreach (p; this.manager.graph.ports[])
-                if (p.owner is a)
+                if (p.owner is a && p.bus !is null)
                     return p;
             return null;
         }

--- a/src/apps/energy/package.d
+++ b/src/apps/energy/package.d
@@ -993,7 +993,7 @@ nothrow @nogc:
                     continue;
                 ++emitted;
                 bool last = emitted == total;
-                if (link.closed && visited[].findFirst(link.b) >= visited.length)
+                if (link.b !is null && link.closed && visited[].findFirst(link.b) >= visited.length)
                     add_bus_tree(link.b, link, child_prefix, last ? "└─ " : "├─ ", visited);
                 else
                     add_link_row(link, child_prefix.text, last ? "└─ " : "├─ ");

--- a/src/apps/energy/package.d
+++ b/src/apps/energy/package.d
@@ -107,7 +107,7 @@ nothrow @nogc:
             last_topology_rebuild = getTime();
         log_slow_phase("manager.update", getTime() - t);
         t = getTime();
-        topology_publisher.publish(energy_device, manager.graph, rebuild_topology);
+        topology_publisher.publish(energy_device, manager.graph, manager.islands, rebuild_topology);
         log_slow_phase("publish_topology", getTime() - t);
         t = getTime();
         registry.resync_all(manager.graph);

--- a/src/apps/energy/session.d
+++ b/src/apps/energy/session.d
@@ -113,7 +113,7 @@ private:
         Port* car_port;
         foreach (p; graph.ports[])
         {
-            if (p.owner is car)
+            if (p.owner is car && p.bus !is null)
             {
                 car_port = p;
                 break;
@@ -128,7 +128,8 @@ private:
                 continue;
             foreach (p2; graph.ports[])
             {
-                if (p2.owner is p.owner && p2 !is p && p2.meter_data.has(MeterField.total_import_active))
+                if (p2.owner is p.owner && p2 !is p && p2.bus !is null &&
+                    p2.meter_data.has(MeterField.total_import_active))
                     return p2.meter_data.total_import_active[0];
             }
         }

--- a/src/apps/energy/state.d
+++ b/src/apps/energy/state.d
@@ -280,7 +280,7 @@ private void publish_topology_layout(Device energy, ref TopologyGraph graph)
         energy.set_element(tconcat(base, "child_port"), (link.port_b ? link.port_b.id[] : "").makeString(defaultAllocator()));
         const(char)[] kind = link.kind.length ? link.kind : link.owner ? "appliance" : "link";
         energy.set_element(tconcat(base, "kind"), kind.makeString(defaultAllocator()));
-        energy.set_element(tconcat(base, "capacity"), cast(int)link.capacity_amps);
+        energy.set_element(tconcat(base, "capacity"), link.capacity_amps);
     }
 }
 
@@ -873,7 +873,7 @@ private void publish_circuit_branch(Device energy, uint generation, ref Topology
         (link.kind.length ? link.kind : link.owner ? "appliance" : "link").makeString(defaultAllocator()));
     energy.set_element(tconcat(base, "parent"), (link.a ? link.a.id[] : "").makeString(defaultAllocator()));
     energy.set_element(tconcat(base, "child"), (link.b ? link.b.id[] : "").makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "capacity"), cast(int)link.capacity_amps);
+    energy.set_element(tconcat(base, "capacity"), link.capacity_amps);
     energy.set_element(tconcat(base, "conducting"), link.closed);
     energy.set_element(tconcat(base, "parent_terminal"), graph.attribution.terminal_index(graph, link.port_a));
     energy.set_element(tconcat(base, "child_terminal"), graph.attribution.terminal_index(graph, link.port_b));
@@ -934,8 +934,7 @@ private void publish_control_path(Device energy, ref TopologyGraph graph, Applia
         (path.limiting_link ? path.limiting_link.id[] : "").makeString(defaultAllocator()));
     energy.set_element(tconcat(base, "limiting_kind"),
         (path.limiting_link ? path.limiting_link.kind : "").makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "limiting_capacity_amps"),
-        cast(int)path.limiting_capacity_amps);
+    energy.set_element(tconcat(base, "limiting_capacity_amps"), path.limiting_capacity_amps);
     energy.set_element(tconcat(base, "limiting_current_amps"),
         path.limiting_current_amps);
 }

--- a/src/apps/energy/state.d
+++ b/src/apps/energy/state.d
@@ -58,6 +58,7 @@ nothrow @nogc:
     Array!TopologyBusPublishCache topology_buses;
     Array!TopologyPortPublishCache topology_ports;
     Array!TopologyLinkPublishCache topology_links;
+    Array!GroupLossPublishCache group_losses;
     Array!BoundaryPublishEntry boundaries;
 
     void publish(Device energy, ref TopologyGraph graph, ref Islands islands, bool rebuild_layout)
@@ -82,6 +83,7 @@ nothrow @nogc:
             && topology_buses.length == graph.bus_list.length
             && topology_ports.length == graph.ports.length
             && topology_links.length == graph.links.length
+            && group_losses.length == graph.groups.length
             && boundaries.length == graph.boundaries.length;
     }
 
@@ -131,6 +133,10 @@ nothrow @nogc:
             topology_links ~= c;
         }
 
+        group_losses.resize(graph.groups.length);
+        foreach (i, g; graph.groups[])
+            group_losses[i].bind(energy, g);
+
         boundaries.resize(graph.boundaries.length);
         foreach (i, p; graph.boundaries[])
             boundaries[i].bind(energy, p);
@@ -179,6 +185,8 @@ nothrow @nogc:
             topology_ports[i].publish(port, graph.generation);
         foreach (i, link; graph.links[])
             topology_links[i].publish(link, graph.generation);
+        foreach (i, g; graph.groups[])
+            group_losses[i].publish(g);
     }
 }
 
@@ -415,6 +423,40 @@ nothrow @nogc:
             last = s;
             seen = true;
         }
+    }
+}
+
+// Appliance loss is self-consumption/conversion loss; on switchgear the same
+// sum is a two-sides-disagree wiring/calibration alarm.
+private struct GroupLossPublishCache
+{
+nothrow @nogc:
+    FloatPublishCell loss;
+    BoolPublishCell mismatch;
+
+    void bind(Device energy, PortGroup* g)
+    {
+        loss = FloatPublishCell();
+        mismatch = BoolPublishCell();
+        if (g.kind == PortGroupKind.appliance)
+        {
+            if (g.owner !is null && g.ports.length >= 2)
+                loss.bind(energy, tconcat("appliance.", g.owner.name[], "."), "loss_power");
+        }
+        else if (g.link !is null && g.link.id.length != 0)
+        {
+            const(char)[] base = tconcat("topology.link.", g.link.id[], ".");
+            loss.bind(energy, base, "loss_power");
+            mismatch.bind(energy, base, "mismatch");
+        }
+    }
+
+    void publish(PortGroup* g)
+    {
+        if (loss.element)
+            loss.publish(g.loss_power);
+        if (mismatch.element)
+            mismatch.publish(g.mismatch);
     }
 }
 

--- a/src/apps/energy/state.d
+++ b/src/apps/energy/state.d
@@ -257,7 +257,7 @@ private void publish_topology_layout(Device energy, ref TopologyGraph graph)
         const(char)[] port_id = port.path.length ? port.path[] : port_role_name(port.role);
         const(char)[] base = tconcat("topology.appliance.", port.owner.name[], ".", port_id, ".");
         energy.set_element(tconcat(base, "owner"), port.owner.name[].makeString(defaultAllocator()));
-        energy.set_element(tconcat(base, "bus"), port.bus.id[].makeString(defaultAllocator()));
+        energy.set_element(tconcat(base, "bus"), (port.bus ? port.bus.id[] : "").makeString(defaultAllocator()));
         energy.set_element(tconcat(base, "port_role"), port_role_name(port.role).makeString(defaultAllocator()));
         energy.set_element(tconcat(base, "port"), port_id.makeString(defaultAllocator()));
         energy.set_element(tconcat(base, "flow"), flow_domain_name(port.flow).makeString(defaultAllocator()));
@@ -995,7 +995,7 @@ private void publish_port(Device energy, Port* port)
     energy.set_element(tconcat(base, "id"), port.id[].makeString(defaultAllocator()));
     energy.set_element(tconcat(base, "owner"), (port.owner ? port.owner.name[] : "").makeString(defaultAllocator()));
     energy.set_element(tconcat(base, "label"), port.label.makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "bus"), port.bus.id[].makeString(defaultAllocator()));
+    energy.set_element(tconcat(base, "bus"), (port.bus ? port.bus.id[] : "").makeString(defaultAllocator()));
     energy.set_element(tconcat(base, "port"), port_name.makeString(defaultAllocator()));
     energy.set_element(tconcat(base, "port_role"), port_role_name(port.role).makeString(defaultAllocator()));
     energy.set_element(tconcat(base, "flow"), flow_domain_name(port.flow).makeString(defaultAllocator()));

--- a/src/apps/energy/state.d
+++ b/src/apps/energy/state.d
@@ -237,7 +237,7 @@ private void publish_topology_layout(Device energy, ref TopologyGraph graph)
         energy.set_element(tconcat(base, "label"), link.label.makeString(defaultAllocator()));
         energy.set_element(tconcat(base, "owner"), (link.owner ? link.owner.name[] : "").makeString(defaultAllocator()));
         energy.set_element(tconcat(base, "parent"), link.a.id[].makeString(defaultAllocator()));
-        energy.set_element(tconcat(base, "child"), link.b.id[].makeString(defaultAllocator()));
+        energy.set_element(tconcat(base, "child"), (link.b ? link.b.id[] : "").makeString(defaultAllocator()));
         energy.set_element(tconcat(base, "parent_port"), (link.port_a ? link.port_a.id[] : "").makeString(defaultAllocator()));
         energy.set_element(tconcat(base, "child_port"), (link.port_b ? link.port_b.id[] : "").makeString(defaultAllocator()));
         const(char)[] kind = link.kind.length ? link.kind : link.owner ? "appliance" : "link";
@@ -726,6 +726,8 @@ private struct TopologyPortPublishCache
 {
 nothrow @nogc:
     Element* generation;
+    FloatPublishCell soc;
+    Component soc_source;
 
     MeterPublishCache meter;
 
@@ -734,14 +736,38 @@ nothrow @nogc:
         const(char)[] base = tconcat("topology.port.", port.id[], ".");
         generation = elem!int(energy, base, "generation");
 
+        // The device's own gauge at this port; the reconciled store value
+        // lives on the battery boundary entry.
+        soc = FloatPublishCell();
+        soc_source = port_soc_source(port);
+        if (soc_source !is null)
+            soc.bind(energy, base, "soc");
+
         meter.bind(energy, base);
     }
 
     void publish(Port* port, uint gen)
     {
         generation.value = cast(int)gen;
+        if (soc.element)
+            soc.publish(read_battery_soc(soc_source));
         meter.publish(port.meter_data);
     }
+}
+
+// A port carries soc only when the component behind it can answer: mirrors
+// read_battery_soc's resolution, gating on element presence rather than the
+// current value so an offline device keeps its field.
+private Component port_soc_source(Port* port)
+{
+    Component c = battery_store_source(port);
+    if (c is null)
+        return null;
+    if (c.find_element("soc"))
+        return c;
+    if (c.template_[] == "Battery")
+        return null;
+    return c.find_first_component_by_template_recursive("Battery") ? c : null;
 }
 
 private struct TopologyLinkPublishCache

--- a/src/apps/energy/state.d
+++ b/src/apps/energy/state.d
@@ -139,7 +139,12 @@ nothrow @nogc:
 
         boundaries.resize(graph.boundaries.length);
         foreach (i, p; graph.boundaries[])
+        {
+            foreach (q; graph.boundaries[0 .. i])
+                if (boundary_key(q)[] == boundary_key(p)[])
+                    writeWarning("energy: boundary key '", boundary_key(p), "' is not unique; an appliance and a link share the name and their publishes will collide");
             boundaries[i].bind(energy, p);
+        }
         publish_appliance_index_list(energy, graph);
         log_slow_topology_publish("cache_bind", getTime() - t);
 
@@ -508,7 +513,7 @@ nothrow @nogc:
 
     void publish(Port* p, ref TopologyGraph graph, ref Islands islands, SysTime ts)
     {
-        float pw_in = 0, pw_out = 0;
+        float pw_in = float.nan, pw_out = float.nan;
         bool have = p.meter_data.has(MeterField.power);
         if (have)
         {

--- a/src/apps/energy/state.d
+++ b/src/apps/energy/state.d
@@ -202,7 +202,7 @@ private void publish_topology_layout(Device energy, ref TopologyGraph graph)
 {
     publish_circuit(energy, graph);
 
-    energy.set_element("topology.schema_version", 1);
+    energy.set_element("topology.schema_version", 2);
     energy.set_element("topology.generation", cast(int)graph.generation);
 
     foreach (bus; graph.bus_list[])
@@ -813,7 +813,7 @@ private Element* elem(T)(Device energy, const(char)[] base, const(char)[] name)
 
 void publish_circuit(Device energy, ref TopologyGraph graph)
 {
-    energy.set_element("circuit.schema_version", 1);
+    energy.set_element("circuit.schema_version", 2);
     energy.set_element("circuit.generation", cast(int)graph.attribution.generation);
     energy.set_element("circuit.buses", cast(int)graph.bus_list.length);
     energy.set_element("circuit.islands", graph.attribution.island_count);

--- a/src/apps/energy/state.d
+++ b/src/apps/energy/state.d
@@ -50,22 +50,14 @@ nothrow @nogc:
 
     Element* circuit_generation;
     Element* circuit_buses_count;
-    Element* circuit_terminals_count;
-    Element* circuit_branches_count;
     Element* circuit_islands_count;
     Element* circuit_grid_island;
     Element* topology_generation;
-    Element* productions_count;
-    Element* production_contributions_count;
 
     Array!CircuitBusPublishCache circuit_buses;
-    Array!CircuitTerminalPublishCache circuit_terminals;
     Array!TopologyBusPublishCache topology_buses;
     Array!TopologyPortPublishCache topology_ports;
-    Array!TopologyAppliancePublishCache topology_appliances;
     Array!TopologyLinkPublishCache topology_links;
-    Array!ProductionPublishCache productions;
-    Array!ProductionContributionPublishCache production_contributions;
     Array!BoundaryPublishEntry boundaries;
 
     void publish(Device energy, ref TopologyGraph graph, ref Islands islands, bool rebuild_layout)
@@ -87,13 +79,9 @@ nothrow @nogc:
     bool shape_matches(ref TopologyGraph graph) const pure
     {
         return circuit_buses.length == graph.bus_list.length
-            && circuit_terminals.length == graph.ports.length
             && topology_buses.length == graph.bus_list.length
             && topology_ports.length == graph.ports.length
-            && topology_appliances.length == graph.ports.length
             && topology_links.length == graph.links.length
-            && productions.length == graph.productions.length
-            && production_contributions.length == graph.production_contributions.length
             && boundaries.length == graph.boundaries.length;
     }
 
@@ -107,14 +95,9 @@ nothrow @nogc:
         FormatId int_format = register_value_format!int();
         circuit_generation = energy.find_or_create_element("circuit.generation", int_format);
         circuit_buses_count = energy.find_or_create_element("circuit.buses", int_format);
-        circuit_terminals_count = energy.find_or_create_element("circuit.terminals", int_format);
-        circuit_branches_count = energy.find_or_create_element("circuit.branches", int_format);
         circuit_islands_count = energy.find_or_create_element("circuit.islands", int_format);
         circuit_grid_island = energy.find_or_create_element("circuit.grid_island", int_format);
         topology_generation = energy.find_or_create_element("topology.generation", int_format);
-        productions_count = energy.find_or_create_element("circuit.productions", int_format);
-        production_contributions_count = energy.find_or_create_element(
-            "circuit.production_contributions", int_format);
 
         circuit_buses.clear();
         foreach (bus; graph.bus_list[])
@@ -122,14 +105,6 @@ nothrow @nogc:
             CircuitBusPublishCache c;
             c.bind(energy, bus);
             circuit_buses ~= c;
-        }
-
-        circuit_terminals.clear();
-        foreach (port; graph.ports[])
-        {
-            CircuitTerminalPublishCache c;
-            c.bind(energy, port);
-            circuit_terminals ~= c;
         }
 
         topology_buses.clear();
@@ -148,36 +123,12 @@ nothrow @nogc:
             topology_ports ~= c;
         }
 
-        topology_appliances.clear();
-        foreach (port; graph.ports[])
-        {
-            TopologyAppliancePublishCache c;
-            c.bind(energy, port);
-            topology_appliances ~= c;
-        }
-
         topology_links.clear();
         foreach (link; graph.links[])
         {
             TopologyLinkPublishCache c;
             c.bind(energy, link);
             topology_links ~= c;
-        }
-
-        productions.clear();
-        foreach (ref production; graph.productions[])
-        {
-            ProductionPublishCache c;
-            c.bind(energy, production);
-            productions ~= c;
-        }
-
-        production_contributions.clear();
-        foreach (i, ref contribution; graph.production_contributions[])
-        {
-            ProductionContributionPublishCache c;
-            c.bind(energy, cast(uint)i);
-            production_contributions ~= c;
         }
 
         boundaries.resize(graph.boundaries.length);
@@ -206,6 +157,8 @@ nothrow @nogc:
                     break;
                 }
             energy.set_element(tconcat(base, "boundary"), key.makeString(defaultAllocator()));
+            energy.set_element(tconcat(base, "device"), a.device.makeString(defaultAllocator()));
+            energy.set_element(tconcat(base, "vin"), a.vin.makeString(defaultAllocator()));
             energy.set_element(tconcat(base, "connected"), anchor !is null);
         }
     }
@@ -214,31 +167,18 @@ nothrow @nogc:
     {
         circuit_generation.value = cast(int)graph.attribution.generation;
         circuit_buses_count.value = cast(int)graph.bus_list.length;
-        circuit_terminals_count.value = cast(int)graph.ports.length;
-        circuit_branches_count.value = cast(int)graph.links.length;
         circuit_islands_count.value = graph.attribution.island_count;
         circuit_grid_island.value = graph.attribution.grid_island;
         topology_generation.value = cast(int)graph.generation;
-        productions_count.value = cast(int)graph.productions.length;
-        production_contributions_count.value = cast(int)graph.production_contributions.length;
 
         foreach (i, bus; graph.bus_list[])
             circuit_buses[i].publish(bus, graph.attribution.buses[i], graph.attribution.generation);
-        foreach (i, port; graph.ports[])
-            circuit_terminals[i].publish(port, graph.attribution.terminals[i], graph.attribution.generation);
         foreach (i, bus; graph.bus_list[])
             topology_buses[i].publish(bus, graph.generation);
         foreach (i, port; graph.ports[])
-        {
             topology_ports[i].publish(port, graph.generation);
-            topology_appliances[i].publish(port, graph.generation);
-        }
         foreach (i, link; graph.links[])
             topology_links[i].publish(link, graph.generation);
-        foreach (i, ref production; graph.productions[])
-            productions[i].publish(production, graph.generation);
-        foreach (i, ref contribution; graph.production_contributions[])
-            production_contributions[i].publish(contribution, graph.generation);
     }
 }
 
@@ -253,8 +193,6 @@ private void log_slow_topology_publish(const(char)[] phase, Duration d)
 private void publish_topology_layout(Device energy, ref TopologyGraph graph)
 {
     publish_circuit(energy, graph);
-    publish_productions(energy, graph.generation,
-                        graph.productions, graph.production_contributions);
 
     energy.set_element("topology.schema_version", 1);
     energy.set_element("topology.generation", cast(int)graph.generation);
@@ -278,23 +216,7 @@ private void publish_topology_layout(Device energy, ref TopologyGraph graph)
     {
         if (port.owner is null || !is_first_owner_port(graph, port))
             continue;
-        publish_appliance_index(energy, graph, port.owner);
         publish_control_path(energy, graph, port.owner);
-    }
-
-    foreach (port; graph.ports[])
-    {
-        if (port.owner is null)
-            continue;
-        const(char)[] port_id = port.path.length ? port.path[] : port_role_name(port.role);
-        const(char)[] base = tconcat("topology.appliance.", port.owner.name[], ".", port_id, ".");
-        energy.set_element(tconcat(base, "owner"), port.owner.name[].makeString(defaultAllocator()));
-        energy.set_element(tconcat(base, "bus"), (port.bus ? port.bus.id[] : "").makeString(defaultAllocator()));
-        energy.set_element(tconcat(base, "port_role"), port_role_name(port.role).makeString(defaultAllocator()));
-        energy.set_element(tconcat(base, "port"), port_id.makeString(defaultAllocator()));
-        energy.set_element(tconcat(base, "flow"), flow_domain_name(port.flow).makeString(defaultAllocator()));
-        energy.set_element(tconcat(base, "meter_sign"), meter_sign_name(port.meter_sign).makeString(defaultAllocator()));
-        energy.set_element(tconcat(base, "root"), port.root);
     }
 
     foreach (link; graph.links[])
@@ -507,6 +429,7 @@ nothrow @nogc:
     FloatPublishCell energy_in;
     FloatPublishCell energy_out;
     FloatPublishCell soc;
+    BoolPublishCell mismatch;
     String last_circuit;
     String last_island;
     Provenance last_prov;
@@ -533,6 +456,9 @@ nothrow @nogc:
         soc = FloatPublishCell();
         if (boundary_kind(p) == BoundaryKind.battery)
             soc.bind(energy, base, "soc");
+        mismatch = BoolPublishCell();
+        if (boundary_kind(p) == BoundaryKind.solar && p.owner !is null)
+            mismatch.bind(energy, base, "mismatch");
         last_circuit = String();
         last_island = String();
         prov_seen = false;
@@ -590,6 +516,19 @@ nothrow @nogc:
             last_prov = prov;
             prov_seen = true;
         }
+
+        // Aggregate-vs-member disagreement from the production reconciliation.
+        if (mismatch.element)
+        {
+            bool flag = false;
+            foreach (ref prod; graph.productions[])
+                if (prod.owner == p.owner.name[] && prod.group == production_group_of(p))
+                {
+                    flag = prod.mismatch;
+                    break;
+                }
+            mismatch.publish(flag);
+        }
     }
 
     const(char)[] island_id_of(Bus* b, ref Islands islands)
@@ -609,6 +548,14 @@ nothrow @nogc:
             return;
         last = value.makeString(defaultAllocator());
         e.value(last, ts);
+    }
+
+    const(char)[] production_group_of(Port* p)
+    {
+        if (p.path.length == 0)
+            return "pv";
+        size_t dot = p.path[].findLast('.');
+        return dot < p.path.length ? p.path[0 .. dot] : p.path[];
     }
 }
 
@@ -686,44 +633,6 @@ nothrow @nogc:
     }
 }
 
-private struct CircuitTerminalPublishCache
-{
-nothrow @nogc:
-    Element* generation;
-    FloatPublishCell consumed_power;
-    FloatPublishCell supplied_power;
-    FloatPublishCell local_power;
-    FloatPublishCell grid_power;
-    FloatPublishCell local_fraction;
-    FloatPublishCell soc;
-    MeterPublishCache meter;
-
-    void bind(Device energy, Port* port)
-    {
-        const(char)[] base = tconcat("circuit.terminal.", port.id[], ".");
-        generation = elem!int(energy, base, "generation");
-        consumed_power.bind(energy, base, "consumed_power");
-        supplied_power.bind(energy, base, "supplied_power");
-        local_power.bind(energy, base, "local_power");
-        grid_power.bind(energy, base, "grid_power");
-        local_fraction.bind(energy, base, "local_fraction");
-        soc.bind(energy, base, "soc");
-        meter.bind(energy, base);
-    }
-
-    void publish(Port* port, ref const TerminalAttribution attr, uint gen)
-    {
-        generation.value = cast(int)gen;
-        consumed_power.publish(attr.consumed_power);
-        supplied_power.publish(attr.supplied_power);
-        local_power.publish(attr.local_power);
-        grid_power.publish(attr.grid_power);
-        local_fraction.publish(attr.local_fraction);
-        soc.publish(read_battery_soc(battery_store_source(port)));
-        meter.publish(port.meter_data);
-    }
-}
-
 private struct TopologyBusPublishCache
 {
 nothrow @nogc:
@@ -793,38 +702,13 @@ nothrow @nogc:
     }
 }
 
-private struct TopologyAppliancePublishCache
-{
-nothrow @nogc:
-    Element* generation;
-
-    MeterPublishCache meter;
-
-    void bind(Device energy, Port* port)
-    {
-        if (port.owner is null)
-            return;
-        const(char)[] port_id = port.path.length ? port.path[] : port_role_name(port.role);
-        const(char)[] base = tconcat("topology.appliance.", port.owner.name[], ".", port_id, ".");
-        generation = elem!int(energy, base, "generation");
-
-        meter.bind(energy, base);
-    }
-
-    void publish(Port* port, uint gen)
-    {
-        if (generation is null)
-            return;
-        generation.value = cast(int)gen;
-        meter.publish(port.meter_data);
-    }
-}
-
 private struct TopologyLinkPublishCache
 {
 nothrow @nogc:
     Element* generation;
     Element* closed;
+    FloatPublishCell current;
+    FloatPublishCell utilisation;
     MeterPublishCache meter;
 
     void bind(Device energy, Link* link)
@@ -834,6 +718,8 @@ nothrow @nogc:
         const(char)[] base = tconcat("topology.link.", link.id[], ".");
         generation = elem!int(energy, base, "generation");
         closed = elem!bool(energy, base, "closed");
+        current.bind(energy, base, "current");
+        utilisation.bind(energy, base, "utilisation");
         meter.bind(energy, base);
     }
 
@@ -843,68 +729,11 @@ nothrow @nogc:
             return;
         generation.value = cast(int)gen;
         closed.value = link.closed;
+        float amps = link_current_amps(link);
+        current.publish(amps);
+        utilisation.publish(link.capacity_amps > 0 ? amps / link.capacity_amps : float.nan);
         if (Port* measuring = link_measuring_port(link))
             meter.publish(measuring.meter_data);
-    }
-}
-
-private struct ProductionPublishCache
-{
-nothrow @nogc:
-    Element* generation;
-    Element* aggregate_power;
-    Element* member_power;
-    Element* aggregate_count;
-    Element* member_count;
-    Element* calculated;
-    Element* mismatch;
-    MeterPublishCache meter;
-
-    void bind(Device energy, ref const Production production)
-    {
-        const(char)[] base = tconcat("circuit.production.", production.owner, ".", production.group, ".");
-        generation = elem!int(energy, base, "generation");
-        aggregate_power = elem!float(energy, base, "aggregate_power");
-        member_power = elem!float(energy, base, "member_power");
-        aggregate_count = elem!int(energy, base, "aggregate_count");
-        member_count = elem!int(energy, base, "member_count");
-        calculated = elem!bool(energy, base, "calculated");
-        mismatch = elem!bool(energy, base, "mismatch");
-        meter.bind(energy, base);
-    }
-
-    void publish(ref const Production production, uint gen)
-    {
-        generation.value = cast(int)gen;
-        aggregate_power.value = production.aggregate_power;
-        member_power.value = production.member_power;
-        aggregate_count.value = cast(int)production.aggregate_count;
-        member_count.value = cast(int)production.member_count;
-        calculated.value = production.calculated;
-        mismatch.value = production.mismatch;
-        meter.publish(production.data);
-    }
-}
-
-private struct ProductionContributionPublishCache
-{
-nothrow @nogc:
-    Element* generation;
-
-    MeterPublishCache meter;
-
-    void bind(Device energy, uint index)
-    {
-        const(char)[] base = tconcat("circuit.production_contribution.", index, ".");
-        generation = elem!int(energy, base, "generation");
-
-        meter.bind(energy, base);
-    }
-
-    void publish(ref const ProductionContribution contribution, uint gen)
-    {
-        generation.value = cast(int)gen;
-        meter.publish(contribution.meter);
     }
 }
 
@@ -919,17 +748,11 @@ void publish_circuit(Device energy, ref TopologyGraph graph)
     energy.set_element("circuit.schema_version", 1);
     energy.set_element("circuit.generation", cast(int)graph.attribution.generation);
     energy.set_element("circuit.buses", cast(int)graph.bus_list.length);
-    energy.set_element("circuit.terminals", cast(int)graph.ports.length);
-    energy.set_element("circuit.branches", cast(int)graph.links.length);
     energy.set_element("circuit.islands", graph.attribution.island_count);
     energy.set_element("circuit.grid_island", graph.attribution.grid_island);
 
     foreach (i, bus; graph.bus_list[])
         publish_circuit_bus(energy, graph.attribution.generation, bus, graph.attribution.buses[i]);
-    foreach (i, port; graph.ports[])
-        publish_circuit_terminal(energy, graph.attribution.generation, port, graph.attribution.terminals[i]);
-    foreach (link; graph.links[])
-        publish_circuit_branch(energy, graph.attribution.generation, graph, link);
 }
 
 private const(char)[] circuit_domain_name(FlowDomain f) pure
@@ -941,18 +764,6 @@ private const(char)[] circuit_domain_name(FlowDomain f) pure
         case FlowDomain.supply:        return "source";
         case FlowDomain.bidirectional: return "bidirectional";
     }
-}
-
-void publish_productions(Device energy, uint generation, ref Array!Production productions,
-                         ref Array!ProductionContribution contributions)
-{
-    energy.set_element("circuit.productions", cast(int)productions.length);
-    energy.set_element("circuit.production_contributions", cast(int)contributions.length);
-
-    foreach (ref production; productions[])
-        publish_production(energy, generation, production);
-    foreach (i, ref contribution; contributions[])
-        publish_production_contribution(energy, generation, cast(uint)i, contribution);
 }
 
 private void publish_circuit_bus(Device energy, uint generation, apps.energy.topology.Bus* bus,
@@ -982,80 +793,6 @@ private void publish_circuit_bus(Device energy, uint generation, apps.energy.top
     energy.set_element(tconcat(base, "depth"), attr.depth);
     energy.set_element(tconcat(base, "parent"), attr.parent);
     publish_meter(energy, base, bus.balance);
-}
-
-private void publish_circuit_terminal(Device energy, uint generation, Port* port,
-                                      ref const TerminalAttribution attr)
-{
-    const(char)[] base = tconcat("circuit.terminal.", port.id[], ".");
-    energy.set_element(tconcat(base, "generation"), cast(int)generation);
-    energy.set_element(tconcat(base, "id"), port.id[].makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "owner"), (port.owner ? port.owner.name[] : "").makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "owner_kind"), (port.owner ? port.owner.kind[] : "").makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "owner_device"), (port.owner ? port.owner.device[] : "").makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "port"),
-        (port.path.length ? port.path[] : port_role_name(port.role)).makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "label"), port.label.makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "circuit"), (port.bus ? port.bus.id[] : "").makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "role"), port_role_name(port.role).makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "domain"), circuit_domain_name(port.flow).makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "consumed_power"), attr.consumed_power);
-    energy.set_element(tconcat(base, "supplied_power"), attr.supplied_power);
-    energy.set_element(tconcat(base, "local_power"), attr.local_power);
-    energy.set_element(tconcat(base, "grid_power"), attr.grid_power);
-    energy.set_element(tconcat(base, "local_fraction"), attr.local_fraction);
-    energy.set_element(tconcat(base, "soc"), read_battery_soc(battery_store_source(port)));
-    energy.set_element(tconcat(base, "root"), port.root);
-    energy.set_element(tconcat(base, "implicit"), port.implicit);
-    publish_meter(energy, base, port.meter_data);
-}
-
-private void publish_circuit_branch(Device energy, uint generation, ref TopologyGraph graph, Link* link)
-{
-    const(char)[] base = tconcat("circuit.branch.", link.id[], ".");
-    energy.set_element(tconcat(base, "generation"), cast(int)generation);
-    energy.set_element(tconcat(base, "id"), link.id[].makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "owner"), (link.owner ? link.owner.name[] : "").makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "label"), link.label.makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "kind"),
-        (link.kind.length ? link.kind : link.owner ? "appliance" : "link").makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "parent"), (link.a ? link.a.id[] : "").makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "child"), (link.b ? link.b.id[] : "").makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "capacity"), link.capacity_amps);
-    energy.set_element(tconcat(base, "conducting"), link.closed);
-    energy.set_element(tconcat(base, "parent_terminal"), graph.attribution.terminal_index(graph, link.port_a));
-    energy.set_element(tconcat(base, "child_terminal"), graph.attribution.terminal_index(graph, link.port_b));
-}
-
-private void publish_production(Device energy, uint generation, ref const Production production)
-{
-    const(char)[] base = tconcat("circuit.production.", production.owner, ".", production.group, ".");
-    energy.set_element(tconcat(base, "generation"), cast(int)generation);
-    energy.set_element(tconcat(base, "owner"), production.owner.makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "group"), production.group.makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "aggregate_power"), production.aggregate_power);
-    energy.set_element(tconcat(base, "member_power"), production.member_power);
-    energy.set_element(tconcat(base, "aggregate_count"), cast(int)production.aggregate_count);
-    energy.set_element(tconcat(base, "member_count"), cast(int)production.member_count);
-    energy.set_element(tconcat(base, "calculated"), production.calculated);
-    energy.set_element(tconcat(base, "mismatch"), production.mismatch);
-    publish_meter(energy, base, production.data);
-}
-
-private void publish_production_contribution(Device energy, uint generation, uint index,
-                                             ref const ProductionContribution contribution)
-{
-    const(char)[] base = tconcat("circuit.production_contribution.", index, ".");
-    energy.set_element(tconcat(base, "generation"), cast(int)generation);
-    energy.set_element(tconcat(base, "owner"), contribution.owner.makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "group"), contribution.group.makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "port"), contribution.port.makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "circuit"), contribution.circuit.makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "kind"),
-        production_contribution_kind_name(contribution.kind).makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "component"),
-        (contribution.component ? contribution.component.id[] : "").makeString(defaultAllocator()));
-    publish_meter(energy, base, contribution.meter);
 }
 
 private void publish_control_path(Device energy, ref TopologyGraph graph, Appliance owner)
@@ -1109,30 +846,6 @@ private bool is_first_owner_port(ref TopologyGraph graph, Port* port)
             return false;
     }
     return true;
-}
-
-private void publish_appliance_index(Device energy, ref TopologyGraph graph, Appliance owner)
-{
-    const(char)[] base = tconcat("topology.appliance_index.", owner.name[], ".");
-    uint port_count;
-    bool explicit_root;
-    foreach (port; graph.ports[])
-    {
-        if (port.owner !is owner)
-            continue;
-        ++port_count;
-        explicit_root = explicit_root || port.root;
-    }
-
-    energy.set_element(tconcat(base, "generation"), cast(int)graph.generation);
-    energy.set_element(tconcat(base, "id"), owner.name[].makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "kind"), owner.kind.makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "root"), explicit_root || owner.root);
-    energy.set_element(tconcat(base, "device"), owner.device.makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "meter"), owner.meter.makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "state"), owner.state.makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "vin"), owner.vin.makeString(defaultAllocator()));
-    energy.set_element(tconcat(base, "ports"), cast(int)port_count);
 }
 
 private void publish_port(Device energy, Port* port)

--- a/src/apps/energy/state.d
+++ b/src/apps/energy/state.d
@@ -6,7 +6,7 @@ import urt.log;
 import urt.mem;
 import urt.mem.temp : tconcat;
 import urt.string;
-import urt.time : Duration, getTime;
+import urt.time : Duration, getTime, getSysTime, SysTime;
 
 import apps.energy.appliance;
 import apps.energy.attribution;
@@ -16,6 +16,7 @@ import apps.energy.production;
 import apps.energy.topology;
 
 import manager;
+import manager.collection;
 import manager.component;
 import manager.device;
 import manager.element;
@@ -65,8 +66,9 @@ nothrow @nogc:
     Array!TopologyLinkPublishCache topology_links;
     Array!ProductionPublishCache productions;
     Array!ProductionContributionPublishCache production_contributions;
+    Array!BoundaryPublishEntry boundaries;
 
-    void publish(Device energy, ref TopologyGraph graph, bool rebuild_layout)
+    void publish(Device energy, ref TopologyGraph graph, ref Islands islands, bool rebuild_layout)
     {
         auto t = getTime();
         if (rebuild_layout || !bound || !shape_matches(graph))
@@ -76,6 +78,9 @@ nothrow @nogc:
             t = getTime();
         }
         publish_values(graph);
+        SysTime now = getSysTime();
+        foreach (i, p; graph.boundaries[])
+            boundaries[i].publish(p, graph, islands, now);
         log_slow_topology_publish("values", getTime() - t);
     }
 
@@ -88,7 +93,8 @@ nothrow @nogc:
             && topology_appliances.length == graph.ports.length
             && topology_links.length == graph.links.length
             && productions.length == graph.productions.length
-            && production_contributions.length == graph.production_contributions.length;
+            && production_contributions.length == graph.production_contributions.length
+            && boundaries.length == graph.boundaries.length;
     }
 
     void bind(Device energy, ref TopologyGraph graph)
@@ -173,9 +179,35 @@ nothrow @nogc:
             c.bind(energy, cast(uint)i);
             production_contributions ~= c;
         }
+
+        boundaries.resize(graph.boundaries.length);
+        foreach (i, p; graph.boundaries[])
+            boundaries[i].bind(energy, p);
+        publish_appliance_index_list(energy, graph);
         log_slow_topology_publish("cache_bind", getTime() - t);
 
         bound = true;
+    }
+
+    void publish_appliance_index_list(Device energy, ref TopologyGraph graph)
+    {
+        foreach (a; Collection!Appliance().values)
+        {
+            const(char)[] base = tconcat("appliance.", a.name[], ".");
+            energy.set_element(tconcat(base, "kind"), (a.kind.length ? a.kind : "").makeString(defaultAllocator()));
+            Port* anchor = graph.anchor_port_for_appliance(a);
+            energy.set_element(tconcat(base, "circuit"),
+                               (anchor && anchor.bus ? anchor.bus.id[] : "").makeString(defaultAllocator()));
+            const(char)[] key;
+            foreach (p; graph.boundaries[])
+                if (p.owner is a)
+                {
+                    key = boundary_key(p);
+                    break;
+                }
+            energy.set_element(tconcat(base, "boundary"), key.makeString(defaultAllocator()));
+            energy.set_element(tconcat(base, "connected"), anchor !is null);
+        }
     }
 
     void publish_values(ref TopologyGraph graph)
@@ -461,6 +493,122 @@ nothrow @nogc:
             last = s;
             seen = true;
         }
+    }
+}
+
+private struct BoundaryPublishEntry
+{
+nothrow @nogc:
+    Element* circuit_e;
+    Element* island_e;
+    Element* provenance_e;
+    FloatPublishCell power_in;
+    FloatPublishCell power_out;
+    FloatPublishCell energy_in;
+    FloatPublishCell energy_out;
+    FloatPublishCell soc;
+    String last_circuit;
+    String last_island;
+    Provenance last_prov;
+    bool prov_seen;
+
+    void bind(Device energy, Port* p)
+    {
+        const(char)[] base = tconcat("boundary.", boundary_key(p), ".");
+        energy.set_element(tconcat(base, "kind"),
+                           boundary_kind_name(boundary_kind(p)).makeString(defaultAllocator()));
+        energy.set_element(tconcat(base, "owner"),
+                           (p.owner ? p.owner.name[] : "").makeString(defaultAllocator()));
+        energy.set_element(tconcat(base, "origin"),
+                           (p.group ? port_group_kind_name(p.group.kind) : "").makeString(defaultAllocator()));
+        energy.set_element(tconcat(base, "port"), p.id[].makeString(defaultAllocator()));
+        FormatId string_format = register_value_format!String();
+        circuit_e = energy.find_or_create_element(tconcat(base, "circuit"), string_format);
+        island_e = energy.find_or_create_element(tconcat(base, "island"), string_format);
+        provenance_e = energy.find_or_create_element(tconcat(base, "provenance"), string_format);
+        power_in.bind(energy, base, "power_in");
+        power_out.bind(energy, base, "power_out");
+        energy_in.bind(energy, base, "energy_in");
+        energy_out.bind(energy, base, "energy_out");
+        soc = FloatPublishCell();
+        if (boundary_kind(p) == BoundaryKind.battery)
+            soc.bind(energy, base, "soc");
+        last_circuit = String();
+        last_island = String();
+        prov_seen = false;
+    }
+
+    void publish(Port* p, ref TopologyGraph graph, ref Islands islands, SysTime ts)
+    {
+        float pw_in = 0, pw_out = 0;
+        bool have = p.meter_data.has(MeterField.power);
+        if (have)
+        {
+            float power = p.meter_data.active[0].value;
+            if (external_boundary(p))
+            {
+                pw_in = power > 0 ? power : 0;
+                pw_out = power < 0 ? -power : 0;
+            }
+            else
+            {
+                pw_in = power < 0 ? -power : 0;
+                pw_out = power > 0 ? power : 0;
+            }
+        }
+        power_in.publish(pw_in);
+        power_out.publish(pw_out);
+
+        BoundaryEnergy e = boundary_energy(p);
+        if (e.into_total == e.into_total)
+            energy_in.publish(cast(float)e.into_total);
+        if (e.out_total == e.out_total)
+            energy_out.publish(cast(float)e.out_total);
+
+        Bus* b = boundary_bus(p);
+        publish_string(circuit_e, last_circuit, b ? b.id[] : "", ts);
+        publish_string(island_e, last_island, island_id_of(b, islands), ts);
+
+        // The reconciled store value, not this port's own view of it.
+        if (soc.element)
+        {
+            float value = float.nan;
+            if (b)
+                foreach (ref store; graph.battery_stores[])
+                    if (store.circuit == b.id[])
+                    {
+                        value = store.reading.soc;
+                        break;
+                    }
+            soc.publish(value);
+        }
+
+        Provenance prov = have ? p.meter_data.source(MeterField.power) : Provenance.missing;
+        if (!prov_seen || prov != last_prov)
+        {
+            provenance_e.value(provenance_name(prov).makeString(defaultAllocator()), ts);
+            last_prov = prov;
+            prov_seen = true;
+        }
+    }
+
+    const(char)[] island_id_of(Bus* b, ref Islands islands)
+    {
+        if (b is null)
+            return "";
+        foreach (island; islands[])
+            foreach (m; island.members[])
+                if (m is b)
+                    return island.id[];
+        return "";
+    }
+
+    void publish_string(Element* e, ref String last, const(char)[] value, SysTime ts)
+    {
+        if (last[] == value)
+            return;
+        last = value.makeString(defaultAllocator());
+        e.value(last, ts);
     }
 }
 

--- a/src/apps/energy/topology.d
+++ b/src/apps/energy/topology.d
@@ -64,6 +64,7 @@ nothrow @nogc:
     String path;
     const(char)[] label;
     Bus* bus;
+    PortGroup* group;
     PortRole role;
     FlowDomain flow;
     Component component;
@@ -73,6 +74,73 @@ nothrow @nogc:
     MeterData meter_data;
     bool root;
     bool implicit;
+}
+
+enum PortGroupKind : ubyte
+{
+    appliance,
+    switchgear,
+    transfer,
+    handover,
+    sink,
+}
+
+// The thing whose declared terminals these are; transient per topology build.
+struct PortGroup
+{
+nothrow @nogc:
+    this(this) @disable;
+
+    String id;
+    PortGroupKind kind;
+    Appliance owner;
+    Link* link;
+    Array!(Port*) ports;
+    bool closed = true;
+}
+
+// The connected port of a one-port group, or any dangling port, is a boundary
+// edge of the modeled graph; interior ports support balance and cross-checks.
+bool is_boundary(Port* p) pure
+{
+    if (p is null || p.group is null)
+        return false;
+    return p.group.ports.length == 1 || p.bus is null;
+}
+
+// Appliances are unconditional energy junctions; switchgear connectivity
+// follows live contact state.
+bool ports_connected(PortGroup* g, Port* a, Port* b)
+{
+    if (g is null || a is b || a.group !is g || b.group !is g)
+        return false;
+    final switch (g.kind)
+    {
+        case PortGroupKind.appliance:
+        case PortGroupKind.handover:
+            return true;
+        case PortGroupKind.switchgear:
+        case PortGroupKind.sink:
+            return g.link ? g.link.closed : g.closed;
+        case PortGroupKind.transfer:
+            assert(false, "TODO: transfer switch connectivity needs a declaration surface");
+    }
+}
+
+// The island a dangling boundary belongs to: the bus reached through its
+// group's active internal connections, or null when isolated.
+Bus* boundary_bus(Port* p)
+{
+    if (p is null)
+        return null;
+    if (p.bus !is null)
+        return p.bus;
+    if (p.group is null)
+        return null;
+    foreach (q; p.group.ports[])
+        if (q.bus !is null && ports_connected(p.group, p, q))
+            return q.bus;
+    return null;
 }
 
 // Terminals represent equipment and source accounts; boundary ports represent
@@ -378,6 +446,7 @@ nothrow @nogc:
     Array!(Bus*) bus_list;
     Array!(Port*) ports;
     Array!(Link*) links;
+    Array!(PortGroup*) groups;
     Array!(Element*) shape_elements;
     bool shape_dirty;
     CircuitAttribution attribution;
@@ -397,12 +466,15 @@ nothrow @nogc:
         production_contributions.clear();
         productions.clear();
         production_strings.clear();
+        foreach (g; groups[])
+            defaultAllocator.freeT(g);
         foreach (p; ports[])
             defaultAllocator.freeT(p);
         foreach (l; links[])
             defaultAllocator.freeT(l);
         foreach (b; bus_list[])
             defaultAllocator.freeT(b);
+        groups.clear();
         ports.clear();
         links.clear();
         bus_list.clear();
@@ -456,9 +528,27 @@ nothrow @nogc:
         p.meter_data.reset_to_missing();
         if (meter)
             p.meter_data = get_port_meter_data(meter, phase, sign);
-        bus.ports ~= p;
+        if (bus)
+            bus.ports ~= p;
         ports ~= p;
         return p;
+    }
+
+    PortGroup* add_group(const(char)[] id, PortGroupKind kind, Appliance owner = null, Link* link = null)
+    {
+        PortGroup* g = defaultAllocator.allocT!PortGroup();
+        g.id = id.makeString(defaultAllocator());
+        g.kind = kind;
+        g.owner = owner;
+        g.link = link;
+        groups ~= g;
+        return g;
+    }
+
+    void add_to_group(PortGroup* g, Port* p)
+    {
+        p.group = g;
+        g.ports ~= p;
     }
 
     const(char)[] make_port_id(Appliance owner, Bus* bus, PortRole role, const(char)[] path, const(char)[] label)
@@ -521,7 +611,7 @@ nothrow @nogc:
         Port* fallback;
         foreach (p; ports[])
         {
-            if (p.owner !is a)
+            if (p.owner !is a || p.bus is null)
                 continue;
             if (fallback is null)
                 fallback = p;
@@ -628,7 +718,7 @@ nothrow @nogc:
         {
             Array!DevicePort device_ports;
             collect_device_ports(a, device_ports);
-            if (device_ports.length != 0)
+            if (any_connected(device_ports))
             {
                 apply_appliance_meter(a, device_ports);
                 warn_unmatched_bindings(a, device_ports);
@@ -681,6 +771,7 @@ nothrow @nogc:
             return;
         Port* p = add_port(null, b, role, flow, null, 0, MeterSign.normal, null, b.id[]);
         p.implicit = true;
+        add_to_group(add_group(p.id[], PortGroupKind.handover), p);
     }
 
     void refresh()
@@ -790,26 +881,57 @@ private:
             }
             Port* pa = add_port(null, ba, PortRole.parent, FlowDomain.bidirectional, meter, link.meter_phase, link.meter_sign, "parent", link.name[]);
             Port* pb = add_port(null, bb, child_role, FlowDomain.bidirectional, null, 0, MeterSign.normal, "child", link.name[]);
-            add_link(null, ba, bb, pa, pb, link.capacity, link.closed, link.name[], link.kind);
+            Link* l = add_link(null, ba, bb, pa, pb, link.capacity, link.closed, link.name[], link.kind);
+            PortGroup* g = add_group(link.name[], PortGroupKind.switchgear, null, l);
+            add_to_group(g, pa);
+            add_to_group(g, pb);
         }
         else
         {
+            // A parent-only link dangles toward unenumerated attachments; its
+            // far endpoint is the boundary (the sink).
             Bus* b = ensure_bus(left.length ? left : "unassigned");
-            add_port(null, b, PortRole.connection, flow_for(link.kind), meter, link.meter_phase, link.meter_sign, "connection", link.name[]);
+            Port* pa = add_port(null, b, PortRole.connection, flow_for(link.kind), meter, link.meter_phase, link.meter_sign, "connection", link.name[]);
+            PortRole dangling_role = link.role.length ? port_role_from_name(link.role) : PortRole.child;
+            Port* pb = add_port(null, null, dangling_role, flow_for_role(dangling_role), null, 0, MeterSign.normal, "child", link.name[]);
+            PortGroup* g = add_group(link.name[], PortGroupKind.sink);
+            g.closed = link.closed;
+            add_to_group(g, pa);
+            add_to_group(g, pb);
         }
+    }
+
+    FlowDomain flow_for_role(PortRole role) pure
+    {
+        if (role == PortRole.pv)
+            return FlowDomain.supply;
+        if (role == PortRole.battery || role == PortRole.grid || role == PortRole.backup)
+            return FlowDomain.bidirectional;
+        return FlowDomain.consume;
     }
 
     void add_device_ports(Appliance a, ref Array!DevicePort specs)
     {
+        size_t connected;
+        foreach (ref spec; specs[])
+            if (spec.circuit.length != 0)
+                ++connected;
+
+        PortGroup* group = add_group(a.name[], PortGroupKind.appliance, a);
         Array!(Port*) added;
+        Array!(DevicePort*) added_specs;
         foreach (ref spec; specs[])
         {
-            Bus* b = ensure_bus(spec.circuit);
+            Bus* b = spec.circuit.length ? ensure_bus(spec.circuit) : null;
             Port* p = add_port(a, b, spec.role, spec.flow, spec.meter, spec.phase, spec.sign, spec.path[], null, spec.component);
-            p.root = a.root && (spec.flow != FlowDomain.consume || specs.length == 1);
+            add_to_group(group, p);
+            if (b is null)
+                continue;
+            p.root = a.root && (spec.flow != FlowDomain.consume || connected == 1);
             if (p.root)
                 b.explicit_root = true;
             added ~= p;
+            added_specs ~= &spec;
         }
 
         if (added.length >= 2)
@@ -817,7 +939,7 @@ private:
             Port* first = added[0];
             foreach (i; 1 .. added.length)
             {
-                DevicePort* spec = &specs[i];
+                DevicePort* spec = added_specs[i];
                 Link* l = add_link(a, first.bus, added[i].bus, first, added[i], spec.capacity_amps, spec.closed, null, "appliance");
                 // With 3+ ports the star shares `first` across every leg, so its
                 // meter is the appliance aggregate, not this leg's flow.
@@ -860,14 +982,21 @@ private:
             spec.sign = read_meter_sign(c);
             spec.capacity_amps = read_port_capacity(c);
             spec.closed = read_port_closed(c);
-            if (spec.circuit.length != 0)
-                into ~= spec;
+            into ~= spec;
         }
         foreach (child; c.components[])
         {
             const(char)[] child_path = path.length ? tconcat(path, ".", child.id[]) : child.id[];
             collect_device_ports(a, child, child_path, into);
         }
+    }
+
+    bool any_connected(ref Array!DevicePort specs) pure
+    {
+        foreach (ref spec; specs[])
+            if (spec.circuit.length != 0)
+                return true;
+        return false;
     }
 
     void collect_bound_ports(Appliance a, ref Array!DevicePort into)
@@ -917,8 +1046,13 @@ private:
             return;
 
         DevicePort* target;
+        DevicePort* first_connected;
         foreach (ref spec; specs[])
         {
+            if (spec.circuit.length == 0)
+                continue;
+            if (first_connected is null)
+                first_connected = &spec;
             if (spec.role == PortRole.grid || spec.role == PortRole.connection || spec.role == PortRole.parent)
             {
                 target = &spec;
@@ -927,8 +1061,8 @@ private:
             if (target is null && spec.flow == FlowDomain.consume)
                 target = &spec;
         }
-        if (target is null && specs.length != 0)
-            target = &specs[0];
+        if (target is null)
+            target = first_connected;
         if (target !is null)
         {
             target.meter = a.meter_ref;
@@ -1037,7 +1171,7 @@ private:
     Port* last_port_for(Appliance a)
     {
         for (size_t i = ports.length; i-- > 0; )
-            if (ports[i].owner is a)
+            if (ports[i].owner is a && ports[i].bus !is null)
                 return ports[i];
         return null;
     }
@@ -1082,7 +1216,7 @@ private:
     void infer_graph()
     {
         // Infer only a single dark port, alternating with link mirroring.
-        foreach (_; 0 .. bus_list.length + links.length + 1)
+        foreach (_; 0 .. bus_list.length + links.length + groups.length + 1)
         {
             bool changed = infer_link_endpoints();
             foreach (b; bus_list[])
@@ -1095,12 +1229,50 @@ private:
                     changed = true;
                     break;
                 }
+            foreach (g; groups[])
+                if (infer_group_single_unknown(g))
+                {
+                    changed = true;
+                    break;
+                }
             if (!changed)
                 break;
         }
 
         foreach (b; bus_list[])
             aggregate_bus(b);
+    }
+
+    // Zero-loss group conservation: sum of all declared port powers is zero,
+    // solvable when exactly one port (connected or dangling) is unknown.
+    bool infer_group_single_unknown(PortGroup* g)
+    {
+        if (g.ports.length < 2)
+            return false;
+        if ((g.kind == PortGroupKind.switchgear || g.kind == PortGroupKind.sink) &&
+            !(g.link ? g.link.closed : g.closed))
+            return false;
+
+        Port* dark;
+        float sum = 0;
+        foreach (p; g.ports[])
+        {
+            if (p.meter_data.has(MeterField.power))
+                sum += p.meter_data.active[0].value;
+            else
+            {
+                if (dark !is null)
+                    return false;
+                dark = p;
+            }
+        }
+        if (dark is null)
+            return false;
+
+        dark.meter_data.reset_to_missing();
+        dark.meter_data.write_value(MeterField.power, 0, -sum);
+        dark.meter_data.mark(MeterField.power, 0, Provenance.inferred_subtraction);
+        return true;
     }
 
     void rebuild_stores()
@@ -1338,11 +1510,12 @@ private:
     }
 
     // Only a two-port appliance conserves power across one unambiguous link.
+    // Dangling ports do not carry inferred flow yet, so they do not disqualify.
     bool is_passthrough(Appliance a)
     {
         size_t n;
         foreach (p; ports[])
-            if (p.owner is a)
+            if (p.owner is a && p.bus !is null)
                 ++n;
         return n == 2;
     }
@@ -1501,4 +1674,96 @@ private:
     }
 
 
+}
+
+unittest
+{
+    TopologyGraph graph;
+
+    // one-port appliance on a bus: the connected port is the boundary
+    Bus* house = graph.ensure_bus("house");
+    PortGroup* dish = graph.add_group("dishwasher", PortGroupKind.appliance);
+    Port* dish_p = graph.add_port(null, house, PortRole.connection, FlowDomain.consume, null, 0);
+    graph.add_to_group(dish, dish_p);
+    assert(is_boundary(dish_p));
+
+    // two-port sink group: connected upstream interior, dangling downstream boundary
+    Port* up = graph.add_port(null, house, PortRole.connection, FlowDomain.consume, null, 0, MeterSign.normal, "connection", "gpo");
+    Port* down = graph.add_port(null, null, PortRole.child, FlowDomain.consume, null, 0, MeterSign.normal, "child", "gpo");
+    PortGroup* gpo = graph.add_group("gpo", PortGroupKind.sink);
+    graph.add_to_group(gpo, up);
+    graph.add_to_group(gpo, down);
+    assert(up.bus is house && house.ports[].findFirst(up) < house.ports.length);
+    assert(down.bus is null && house.ports[].findFirst(down) == house.ports.length);
+    assert(!is_boundary(up));
+    assert(is_boundary(down));
+    assert(ports_connected(gpo, up, down));
+    assert(boundary_bus(down) is house);
+    gpo.closed = false;
+    assert(!ports_connected(gpo, up, down));
+    assert(boundary_bus(down) is null);
+    gpo.closed = true;
+
+    // multi-port appliance: connected ports interior, dangling MPPT boundary
+    Bus* battery = graph.ensure_bus("battery");
+    PortGroup* inverter = graph.add_group("inverter", PortGroupKind.appliance);
+    Port* grid_p = graph.add_port(null, house, PortRole.grid, FlowDomain.bidirectional, null, 0, MeterSign.normal, "grid");
+    Port* batt_p = graph.add_port(null, battery, PortRole.battery, FlowDomain.bidirectional, null, 0, MeterSign.normal, "battery");
+    Port* mppt = graph.add_port(null, null, PortRole.pv, FlowDomain.supply, null, 0, MeterSign.normal, "pv.mppt1");
+    graph.add_to_group(inverter, grid_p);
+    graph.add_to_group(inverter, batt_p);
+    graph.add_to_group(inverter, mppt);
+    assert(!is_boundary(grid_p));
+    assert(!is_boundary(batt_p));
+    assert(is_boundary(mppt));
+    assert(ports_connected(inverter, grid_p, batt_p));
+    assert(boundary_bus(mppt) is house || boundary_bus(mppt) is battery);
+
+    // switchgear with both ends connected: neither endpoint is a boundary
+    Bus* outlet = graph.ensure_bus("outlet");
+    Port* bra = graph.add_port(null, house, PortRole.parent, FlowDomain.bidirectional, null, 0, MeterSign.normal, "parent", "breaker");
+    Port* brb = graph.add_port(null, outlet, PortRole.child, FlowDomain.bidirectional, null, 0, MeterSign.normal, "child", "breaker");
+    Link* brl = graph.add_link(null, house, outlet, bra, brb, 20, true, "breaker");
+    PortGroup* breaker = graph.add_group("breaker", PortGroupKind.switchgear, null, brl);
+    graph.add_to_group(breaker, bra);
+    graph.add_to_group(breaker, brb);
+    assert(!is_boundary(bra));
+    assert(!is_boundary(brb));
+    assert(ports_connected(breaker, bra, brb));
+    brl.closed = false;
+    assert(!ports_connected(breaker, bra, brb));
+    brl.closed = true;
+
+    graph.clear();
+    assert(graph.ports.length == 0 && graph.groups.length == 0 && graph.bus_list.length == 0);
+
+    // sink absorption: the bus residual solves the connected port, group
+    // conservation pushes it out the dangling boundary
+    {
+        TopologyGraph g2;
+        Bus* site = g2.ensure_bus("site");
+
+        Port* main_p = g2.add_port(null, site, PortRole.connection, FlowDomain.bidirectional, null, 0, MeterSign.normal, "main");
+        main_p.meter_data.write_value(MeterField.power, 0, -1000);
+        main_p.meter_data.mark(MeterField.power, 0, Provenance.measured);
+        g2.add_to_group(g2.add_group("main", PortGroupKind.handover), main_p);
+
+        Port* dish_p2 = g2.add_port(null, site, PortRole.connection, FlowDomain.consume, null, 0, MeterSign.normal, "dish");
+        dish_p2.meter_data.write_value(MeterField.power, 0, 400);
+        dish_p2.meter_data.mark(MeterField.power, 0, Provenance.measured);
+        g2.add_to_group(g2.add_group("dish", PortGroupKind.appliance), dish_p2);
+
+        Port* sink_up = g2.add_port(null, site, PortRole.connection, FlowDomain.consume, null, 0, MeterSign.normal, "connection", "outlets");
+        Port* sink_down = g2.add_port(null, null, PortRole.child, FlowDomain.consume, null, 0, MeterSign.normal, "child", "outlets");
+        PortGroup* outlets = g2.add_group("outlets", PortGroupKind.sink);
+        g2.add_to_group(outlets, sink_up);
+        g2.add_to_group(outlets, sink_down);
+
+        g2.infer_graph();
+        assert(absf(sink_up.meter_data.active[0].value - 600) <= 0.01f);
+        assert(absf(sink_down.meter_data.active[0].value + 600) <= 0.01f);
+        assert(sink_down.meter_data.source(MeterField.power) == Provenance.inferred_subtraction);
+        assert(is_boundary(sink_down) && boundary_bus(sink_down) is site);
+        g2.clear();
+    }
 }

--- a/src/apps/energy/topology.d
+++ b/src/apps/energy/topology.d
@@ -85,6 +85,18 @@ enum PortGroupKind : ubyte
     sink,
 }
 
+const(char)[] port_group_kind_name(PortGroupKind k) pure
+{
+    final switch (k)
+    {
+        case PortGroupKind.appliance:  return "appliance";
+        case PortGroupKind.switchgear: return "switchgear";
+        case PortGroupKind.transfer:   return "transfer";
+        case PortGroupKind.handover:   return "handover";
+        case PortGroupKind.sink:       return "sink";
+    }
+}
+
 // The thing whose declared terminals these are; transient per topology build.
 struct PortGroup
 {
@@ -242,6 +254,23 @@ BoundaryEnergy boundary_energy(Port* p)
         e.out_total = p.meter_data.total_import_active[0];
     }
     return e;
+}
+
+// Stable presentation key for a boundary: the group's declared name when it
+// carries a single boundary, qualified by port path when it carries several.
+const(char)[] boundary_key(Port* p)
+{
+    if (p is null)
+        return "";
+    if (p.group is null)
+        return p.id[];
+    size_t n;
+    foreach (q; p.group.ports[])
+        if (is_boundary(q))
+            ++n;
+    if (n <= 1)
+        return p.group.id[];
+    return tconcat(p.group.id[], ".", p.path.length ? p.path[] : port_role_name(p.role));
 }
 
 // The island a dangling boundary belongs to: the bus reached through its
@@ -1384,14 +1413,13 @@ private:
 
     void infer_graph()
     {
-        // Infer only a single dark port, alternating with link mirroring.
+        // One assignment per pass lets a solved value reach the far side of
+        // its group before that neighborhood independently infers other ends.
         foreach (_; 0 .. bus_list.length + links.length + groups.length + 1)
         {
-            bool changed = infer_link_endpoints();
+            bool changed;
             foreach (b; bus_list[])
                 aggregate_bus(b);
-            // One assignment per pass lets its mirrored value reach the far bus
-            // before that bus independently infers the other end.
             foreach (b; bus_list[])
                 if (infer_single_dark_port(b))
                 {
@@ -1441,6 +1469,18 @@ private:
         dark.meter_data.reset_to_missing();
         dark.meter_data.write_value(MeterField.power, 0, -sum);
         dark.meter_data.mark(MeterField.power, 0, Provenance.inferred_subtraction);
+
+        // A closed contact is one electrical node, so voltage carries across;
+        // appliance ports may sit on different domains and never share it.
+        if (g.ports.length == 2 && g.kind != PortGroupKind.appliance)
+        {
+            Port* known = g.ports[0] is dark ? g.ports[1] : g.ports[0];
+            if (known.meter_data.has(MeterField.voltage))
+            {
+                dark.meter_data.voltage[0] = known.meter_data.voltage[0];
+                dark.meter_data.mark(MeterField.voltage, 0, Provenance.inferred_subtraction);
+            }
+        }
         return true;
     }
 
@@ -1569,55 +1609,6 @@ private:
             return "pv";
         size_t dot = path.findLast('.');
         return dot < path.length ? path[0 .. dot] : path;
-    }
-
-    bool infer_link_endpoints()
-    {
-        bool changed;
-        foreach (link; links[])
-        {
-            if (!link.closed)
-                continue;
-            if (link.owner !is null && !is_passthrough(link.owner))
-                continue;
-            if (copy_inferred_meter_data(link.port_b, link.port_a))
-                changed = true;
-            if (copy_inferred_meter_data(link.port_a, link.port_b))
-                changed = true;
-        }
-        return changed;
-    }
-
-    // Only a two-port appliance conserves power across one unambiguous link.
-    // Dangling ports do not carry inferred flow yet, so they do not disqualify.
-    bool is_passthrough(Appliance a)
-    {
-        size_t n;
-        foreach (p; ports[])
-            if (p.owner is a && p.bus !is null)
-                ++n;
-        return n == 2;
-    }
-
-    bool copy_inferred_meter_data(Port* dst, Port* src)
-    {
-        if (dst is null || src is null)
-            return false;
-        if (dst.meter_data.has(MeterField.power) || !src.meter_data.has(MeterField.power))
-            return false;
-
-        dst.meter_data = src.meter_data;
-        apply_meter_sign(dst.meter_data, MeterSign.inverted);
-        mark_meter_data(dst.meter_data, Provenance.inferred_subtraction);
-        return true;
-    }
-
-    void mark_meter_data(ref MeterData data, Provenance provenance) pure
-    {
-        foreach (i; 0 .. num_fields)
-            foreach (phase; 0 .. 4)
-                if (data.provenance[i][phase] != Provenance.missing)
-                    data.provenance[i][phase] = provenance;
     }
 
     bool infer_single_dark_port(Bus* b)

--- a/src/apps/energy/topology.d
+++ b/src/apps/energy/topology.d
@@ -839,6 +839,9 @@ nothrow @nogc:
                 continue;
             }
 
+            if (device_ports.length != 0 && a.port_bindings.length != 0)
+                log.warning("appliance '", a.name[], "': no port binding matched a device port; falling back to virtual ports");
+
             Array!DevicePort virtual_ports;
             collect_bound_ports(a, virtual_ports);
             if (virtual_ports.length == 0)

--- a/src/apps/energy/topology.d
+++ b/src/apps/energy/topology.d
@@ -332,7 +332,7 @@ float link_headroom_amps(Link* link) pure
     float current = link_current_amps(link);
     if (current != current)
         return float.nan;
-    return cast(float)link.capacity_amps - current;
+    return link.capacity_amps - current;
 }
 
 Component battery_store_source(Port* p) pure
@@ -356,7 +356,7 @@ nothrow @nogc:
     Bus* b;
     Port* port_a;
     Port* port_b;
-    uint capacity_amps;
+    float capacity_amps = 0;
     bool closed;
     // port_a is an appliance's shared hub port, carrying the aggregate of every
     // leg rather than this link's flow; only port_b measures this link.
@@ -374,7 +374,7 @@ nothrow @nogc:
     Component meter;
     ubyte phase;
     MeterSign sign;
-    uint capacity_amps;
+    float capacity_amps = 0;
     bool closed = true;
 }
 
@@ -390,7 +390,7 @@ nothrow @nogc:
     float headroom_watts = float.nan;
     float voltage = float.nan;
     float limiting_current_amps = float.nan;
-    uint limiting_capacity_amps;
+    float limiting_capacity_amps = 0;
     bool complete;
 }
 
@@ -667,7 +667,7 @@ nothrow @nogc:
     }
 
     Link* add_link(Appliance owner, Bus* a, Bus* b, Port* port_a, Port* port_b,
-                   uint capacity_amps, bool closed = true, const(char)[] label = null,
+                   float capacity_amps, bool closed = true, const(char)[] label = null,
                    const(char)[] kind = null, const(char)[] id = null)
     {
         Link* l = defaultAllocator.allocT!Link();
@@ -1066,7 +1066,7 @@ private:
             }
             Port* pa = add_port(null, ba, PortRole.parent, FlowDomain.bidirectional, meter, link.meter_phase, link.meter_sign, "parent", link.name[]);
             Port* pb = add_port(null, bb, child_role, FlowDomain.bidirectional, null, 0, MeterSign.normal, "child", link.name[]);
-            Link* l = add_link(null, ba, bb, pa, pb, link.capacity, link.closed, link.name[], link.kind);
+            Link* l = add_link(null, ba, bb, pa, pb, link.capacity.value, link.closed, link.name[], link.kind);
             PortGroup* g = add_group(link.name[], PortGroupKind.switchgear, null, l);
             add_to_group(g, pa);
             add_to_group(g, pb);
@@ -1337,11 +1337,11 @@ private:
         return MeterSign.normal;
     }
 
-    uint read_port_capacity(Component c)
+    float read_port_capacity(Component c)
     {
         if (Element* e = c.find_element("capacity"))
             if (e.value.isNumber)
-                return cast(uint)e.value.asFloat;
+                return e.value.asFloat;
         return 0;
     }
 

--- a/src/apps/energy/topology.d
+++ b/src/apps/energy/topology.d
@@ -96,6 +96,8 @@ nothrow @nogc:
     Appliance owner;
     Link* link;
     Array!(Port*) ports;
+    float loss_power = float.nan;
+    bool mismatch;
     bool closed = true;
 }
 
@@ -125,6 +127,106 @@ bool ports_connected(PortGroup* g, Port* a, Port* b)
         case PortGroupKind.transfer:
             assert(false, "TODO: transfer switch connectivity needs a declaration surface");
     }
+}
+
+enum BoundaryKind : ubyte
+{
+    unclassified,
+    grid,
+    generator,
+    solar,
+    battery,
+    load,
+}
+
+const(char)[] boundary_kind_name(BoundaryKind k) pure
+{
+    final switch (k)
+    {
+        case BoundaryKind.unclassified: return "unclassified";
+        case BoundaryKind.grid:         return "grid";
+        case BoundaryKind.generator:    return "generator";
+        case BoundaryKind.solar:        return "solar";
+        case BoundaryKind.battery:      return "battery";
+        case BoundaryKind.load:         return "load";
+    }
+}
+
+// Classification is metadata stamped on a boundary, independent of sign:
+// declared role first, then owner kind, then sink default, never flow alone.
+BoundaryKind boundary_kind(Port* p) pure
+{
+    switch (p.role)
+    {
+        case PortRole.pv:      return BoundaryKind.solar;
+        case PortRole.battery: return BoundaryKind.battery;
+        case PortRole.grid:    return BoundaryKind.grid;
+        case PortRole.car:
+        case PortRole.outlet:  return BoundaryKind.load;
+        default: break;
+    }
+    if (p.owner !is null)
+    {
+        const(char)[] kind = p.owner.kind;
+        if (kind == "pv" || kind == "solar")
+            return BoundaryKind.solar;
+        if (kind == "battery")
+            return BoundaryKind.battery;
+        if (kind == "generator")
+            return BoundaryKind.generator;
+        if (kind == "grid")
+            return BoundaryKind.grid;
+        if (p.flow == FlowDomain.consume)
+            return BoundaryKind.load;
+        return BoundaryKind.unclassified;
+    }
+    if (p.group !is null && p.group.kind == PortGroupKind.sink)
+        return BoundaryKind.load;
+    return BoundaryKind.unclassified;
+}
+
+// Transient solved/accounting view of one boundary edge; not topology state.
+struct BoundaryFlow
+{
+    Port* port;
+    BoundaryKind kind;
+    float power_into_graph = 0;
+    float power_out_of_graph = 0;
+}
+
+// Corrected cumulative counters for one boundary, with the Element keys that
+// accounts use for reset-safe daily deltas. Counter direction follows
+// boundary shape: a dangling port's import counts into the graph.
+struct BoundaryEnergy
+{
+    Element* into_key;
+    Element* out_key;
+    double into_total = double.nan;
+    double out_total = double.nan;
+}
+
+BoundaryEnergy boundary_energy(Port* p)
+{
+    BoundaryEnergy e;
+    if (p is null || p.meter is null)
+        return e;
+    Element* import_e = p.meter.find_element("import");
+    Element* export_e = p.meter.find_element("export");
+    if (p.bus is null)
+    {
+        e.into_key = import_e;
+        e.out_key = export_e;
+        e.into_total = p.meter_data.total_import_active[0];
+        e.out_total = p.meter_data.total_export_active[0];
+    }
+    else
+    {
+        e.into_key = export_e;
+        e.out_key = import_e;
+        e.into_total = p.meter_data.total_export_active[0];
+        e.out_total = p.meter_data.total_import_active[0];
+    }
+    return e;
 }
 
 // The island a dangling boundary belongs to: the bus reached through its
@@ -447,6 +549,8 @@ nothrow @nogc:
     Array!(Port*) ports;
     Array!(Link*) links;
     Array!(PortGroup*) groups;
+    Array!(Port*) boundaries;
+    Array!BoundaryFlow boundary_flows;
     Array!(Element*) shape_elements;
     bool shape_dirty;
     CircuitAttribution attribution;
@@ -466,6 +570,8 @@ nothrow @nogc:
         production_contributions.clear();
         productions.clear();
         production_strings.clear();
+        boundaries.clear();
+        boundary_flows.clear();
         foreach (g; groups[])
             defaultAllocator.freeT(g);
         foreach (p; ports[])
@@ -740,8 +846,17 @@ nothrow @nogc:
         }
 
         synthesise_implicit_terminals();
+        rebuild_boundaries();
 
         refresh();
+    }
+
+    void rebuild_boundaries()
+    {
+        boundaries.clear();
+        foreach (p; ports[])
+            if (is_boundary(p))
+                boundaries ~= p;
     }
 
     // A boundary role declares equipment on the facing bus. Represent missing
@@ -779,9 +894,79 @@ nothrow @nogc:
         ++sample_generation;
         refresh_meters();
         infer_graph();
+        reduce_group_losses();
+        reduce_boundary_flows();
         attribution.compute(this);
         rebuild_stores();
         rebuild_productions();
+    }
+
+    // A fully-solved group's port sum is its self-consumption/conversion loss;
+    // for switchgear, which conserves, a sum beyond meter noise is a mismatch.
+    void reduce_group_losses()
+    {
+        foreach (g; groups[])
+        {
+            g.loss_power = float.nan;
+            g.mismatch = false;
+            if (g.ports.length < 2)
+                continue;
+            if ((g.kind == PortGroupKind.switchgear || g.kind == PortGroupKind.sink) &&
+                !(g.link ? g.link.closed : g.closed))
+                continue;
+
+            float sum = 0;
+            float scale = 0;
+            bool complete = true;
+            foreach (p; g.ports[])
+            {
+                if (!p.meter_data.has(MeterField.power))
+                {
+                    complete = false;
+                    break;
+                }
+                float power = p.meter_data.active[0].value;
+                sum += power;
+                if (absf(power) > scale)
+                    scale = absf(power);
+            }
+            if (!complete)
+                continue;
+
+            g.loss_power = sum;
+            if (g.kind != PortGroupKind.appliance)
+            {
+                float noise_floor_w = scale * 0.02f > 50 ? scale * 0.02f : 50;
+                g.mismatch = absf(sum) > noise_floor_w;
+            }
+        }
+    }
+
+    // Boundary orientation is an accounting transform; Port.power always keeps
+    // the Bus -> Port frame (for a dangling port, the external bus).
+    void reduce_boundary_flows()
+    {
+        boundary_flows.clear();
+        foreach (p; boundaries[])
+        {
+            if (!p.meter_data.has(MeterField.power))
+                continue;
+            BoundaryFlow f;
+            f.port = p;
+            f.kind = boundary_kind(p);
+            float power = p.meter_data.active[0].value;
+            if (p.bus is null)
+            {
+                f.power_into_graph = power > 0 ? power : 0;
+                f.power_out_of_graph = power < 0 ? -power : 0;
+            }
+            else
+            {
+                f.power_into_graph = power < 0 ? -power : 0;
+                f.power_out_of_graph = power > 0 ? power : 0;
+            }
+            boundary_flows ~= f;
+        }
     }
 
 private:
@@ -1764,6 +1949,28 @@ unittest
         assert(absf(sink_down.meter_data.active[0].value + 600) <= 0.01f);
         assert(sink_down.meter_data.source(MeterField.power) == Provenance.inferred_subtraction);
         assert(is_boundary(sink_down) && boundary_bus(sink_down) is site);
+
+        g2.reduce_group_losses();
+        assert(absf(outlets.loss_power) <= 0.01f);
+        assert(!outlets.mismatch);
+
+        g2.rebuild_boundaries();
+        assert(g2.boundaries.length == 3);
+        assert(g2.boundaries[].findFirst(sink_up) == g2.boundaries.length);
+
+        g2.reduce_boundary_flows();
+        float into = 0, out_of = 0;
+        foreach (ref f; g2.boundary_flows[])
+        {
+            into += f.power_into_graph;
+            out_of += f.power_out_of_graph;
+            if (f.port is main_p)
+                assert(absf(f.power_into_graph - 1000) <= 0.01f && f.power_out_of_graph == 0);
+            if (f.port is sink_down)
+                assert(f.power_into_graph == 0 && absf(f.power_out_of_graph - 600) <= 0.01f &&
+                       f.kind == BoundaryKind.load);
+        }
+        assert(absf(into - out_of) <= 0.01f);
         g2.clear();
     }
 }

--- a/src/apps/energy/topology.d
+++ b/src/apps/energy/topology.d
@@ -103,11 +103,24 @@ nothrow @nogc:
 
 // The connected port of a one-port group, or any dangling port, is a boundary
 // edge of the modeled graph; interior ports support balance and cross-checks.
+// A bus named grid is the conceptual external domain, so non-appliance ports
+// on it are upstream handover boundaries.
 bool is_boundary(Port* p) pure
 {
     if (p is null || p.group is null)
         return false;
-    return p.group.ports.length == 1 || p.bus is null;
+    if (p.group.ports.length == 1 || p.bus is null)
+        return true;
+    return p.bus.contains_grid && p.group.kind != PortGroupKind.appliance;
+}
+
+// External boundaries face away from the modeled graph: their Bus in the
+// Bus -> Port frame is the unmodeled world, flipping account orientation.
+bool external_boundary(Port* p) pure
+{
+    if (p.bus is null)
+        return true;
+    return p.bus.contains_grid && p.group !is null && p.group.kind != PortGroupKind.appliance;
 }
 
 // Appliances are unconditional energy junctions; switchgear connectivity
@@ -180,6 +193,8 @@ BoundaryKind boundary_kind(Port* p) pure
             return BoundaryKind.load;
         return BoundaryKind.unclassified;
     }
+    if (p.bus !is null && p.bus.contains_grid)
+        return BoundaryKind.grid;
     if (p.group !is null && p.group.kind == PortGroupKind.sink)
         return BoundaryKind.load;
     return BoundaryKind.unclassified;
@@ -212,7 +227,7 @@ BoundaryEnergy boundary_energy(Port* p)
         return e;
     Element* import_e = p.meter.find_element("import");
     Element* export_e = p.meter.find_element("export");
-    if (p.bus is null)
+    if (external_boundary(p))
     {
         e.into_key = import_e;
         e.out_key = export_e;
@@ -245,21 +260,6 @@ Bus* boundary_bus(Port* p)
     return null;
 }
 
-// Terminals represent equipment and source accounts; boundary ports represent
-// places and support only balance and cross-checks.
-bool class_terminal(Port* p) pure
-{
-    if (p.implicit)
-        return true;
-    if (p.owner is null)
-        return false;
-    if (p.role == PortRole.battery)
-        return p.owner.kind == "battery";
-    if (p.role == PortRole.pv)
-        return p.owner.kind == "pv" || p.owner.kind == "solar";
-    return false;
-}
-
 float meter_current_amps(ref const MeterData data) pure
 {
     if (data.has(MeterField.current))
@@ -271,28 +271,6 @@ float meter_current_amps(ref const MeterData data) pure
             return absf(data.active[0].value / volts);
     }
     return float.nan;
-}
-
-// Utility ingress is an unowned link into the grid bus, distinct from local
-// consumers and generators on that bus.
-bool is_grid_inlet_port(Port* p) pure
-{
-    if (p is null || p.bus is null || !p.bus.contains_grid)
-        return false;
-    foreach (l; p.bus.links[])
-        if (l.owner is null && l.a is p.bus && l.b !is null && l.port_a is p)
-            return true;
-    return false;
-}
-
-bool bus_has_grid_inlet(Bus* b) pure
-{
-    if (b is null)
-        return false;
-    foreach (p; b.ports[])
-        if (is_grid_inlet_port(p))
-            return true;
-    return false;
 }
 
 // A shared hub meter is an appliance aggregate, not a reading for one link.
@@ -871,6 +849,8 @@ nothrow @nogc:
         }
     }
 
+    // A boundary role declaration stands in for unmodeled equipment; modeled
+    // equipment of the same class on the bus displaces the stand-in.
     void synthesise_class_terminal(Bus* b, PortRole role, FlowDomain flow)
     {
         bool declared;
@@ -878,7 +858,11 @@ nothrow @nogc:
         {
             if (p.role != role)
                 continue;
-            if (class_terminal(p))
+            if (p.implicit)
+                return;
+            const(char)[] kind = p.owner ? p.owner.kind : null;
+            if (role == PortRole.battery ? kind == "battery"
+                                         : kind == "pv" || kind == "solar")
                 return;
             declared = true;
         }
@@ -955,7 +939,7 @@ nothrow @nogc:
             f.port = p;
             f.kind = boundary_kind(p);
             float power = p.meter_data.active[0].value;
-            if (p.bus is null)
+            if (external_boundary(p))
             {
                 f.power_into_graph = power > 0 ? power : 0;
                 f.power_out_of_graph = power < 0 ? -power : 0;
@@ -1400,14 +1384,13 @@ private:
 
     void infer_graph()
     {
-        // Infer only a single dark port, alternating with link mirroring.
+        // One assignment per pass lets a solved value reach the far side of
+        // its group before that neighborhood independently infers other ends.
         foreach (_; 0 .. bus_list.length + links.length + groups.length + 1)
         {
-            bool changed = infer_link_endpoints();
+            bool changed;
             foreach (b; bus_list[])
                 aggregate_bus(b);
-            // One assignment per pass lets its mirrored value reach the far bus
-            // before that bus independently infers the other end.
             foreach (b; bus_list[])
                 if (infer_single_dark_port(b))
                 {
@@ -1457,6 +1440,18 @@ private:
         dark.meter_data.reset_to_missing();
         dark.meter_data.write_value(MeterField.power, 0, -sum);
         dark.meter_data.mark(MeterField.power, 0, Provenance.inferred_subtraction);
+
+        // A closed contact is one electrical node, so voltage carries across;
+        // appliance ports may sit on different domains and never share it.
+        if (g.ports.length == 2 && g.kind != PortGroupKind.appliance)
+        {
+            Port* known = g.ports[0] is dark ? g.ports[1] : g.ports[0];
+            if (known.meter_data.has(MeterField.voltage))
+            {
+                dark.meter_data.voltage[0] = known.meter_data.voltage[0];
+                dark.meter_data.mark(MeterField.voltage, 0, Provenance.inferred_subtraction);
+            }
+        }
         return true;
     }
 
@@ -1487,6 +1482,9 @@ private:
         return BatteryStoreContributionKind.view;
     }
 
+    // Productions are a presentation/reconciliation projection over pv
+    // observations; boundary geometry, not selection rules, decides which
+    // ports carry them.
     void rebuild_productions()
     {
         production_contributions.clear();
@@ -1494,30 +1492,36 @@ private:
         production_strings.clear();
         foreach (p; ports[])
         {
-            if (p.bus is null || p.role != PortRole.pv || p.implicit)
+            if (p.role != PortRole.pv || p.implicit)
                 continue;
-
-            // A real PV terminal displaces a boundary declaration.
-            if (!class_terminal(p) && bus_has_real_class_terminal(p.bus, PortRole.pv))
+            if (p.meter is null && !is_boundary(p))
                 continue;
 
             const(char)[] owner_name = p.owner ? p.owner.name[] : p.label;
             if (owner_name.length == 0)
                 continue;
 
+            Bus* b = boundary_bus(p);
             const(char)[] group = production_group(p);
             ProductionContribution member;
             member.owner = retain_production_string(owner_name);
             member.group = retain_production_string(group);
             member.port = retain_production_string(p.path.length ? p.path[] : port_role_name(p.role));
-            member.circuit = retain_production_string(p.bus.id[]);
+            member.circuit = retain_production_string(b ? b.id[] : "");
             member.kind = ProductionContributionKind.member;
             member.component = p.component;
             member.meter = p.meter_data;
-            if (p.owner is null && member.meter.has(MeterField.power) && member.meter.active[0].value < 0)
+            if (member.meter.has(MeterField.power))
             {
-                // A net-metered child cannot prove generation while net-consuming.
-                member.meter.write_value(MeterField.power, 0, 0);
+                // Present in the generation-positive frame: a connected
+                // boundary generates negative in its Bus -> Port frame.
+                if (is_boundary(p) && !external_boundary(p))
+                    member.meter.write_value(MeterField.power, 0, -member.meter.active[0].value);
+                else if (p.owner is null && !is_boundary(p) && member.meter.active[0].value < 0)
+                {
+                    // A net-metered child cannot prove generation while net-consuming.
+                    member.meter.write_value(MeterField.power, 0, 0);
+                }
             }
             production_contributions ~= member;
 
@@ -1525,106 +1529,7 @@ private:
                 add_production_aggregate_once(p.owner, group);
         }
 
-        foreach (a; Collection!Appliance().values)
-            add_unbound_device_productions(a);
         reconcile_productions(production_contributions, productions);
-    }
-
-    void add_unbound_device_productions(Appliance owner)
-    {
-        if (owner is null || owner.device_ref is null)
-            return;
-
-        Array!DevicePort production_ports;
-        collect_device_production_ports(owner, owner.device_ref, null, production_ports);
-        foreach (ref spec; production_ports[])
-        {
-            if (production_contribution_exists(owner, spec.path[]))
-                continue;
-            if (spec.circuit.length == 0)
-                spec.circuit = primary_owner_circuit(owner);
-            if (spec.circuit.length == 0)
-                continue;
-
-            add_production_member(owner, spec);
-            add_production_aggregate_once(owner, production_group(spec.path[]));
-        }
-    }
-
-    void collect_device_production_ports(Appliance owner, Component c, const(char)[] path,
-                                         ref Array!DevicePort into)
-    {
-        if (c.template_[] == "Port")
-        {
-            PortRole role = read_port_role(c);
-            if (role == PortRole.pv)
-            {
-                DevicePort spec;
-                spec.component = c;
-                spec.path = path.makeString(defaultAllocator());
-                spec.role = role;
-                spec.flow = read_flow_domain(c);
-                spec.circuit = read_port_circuit(owner, c, path);
-                spec.meter = c.get_first_component_by_template("EnergyMeter");
-                spec.phase = read_port_phase(c);
-                spec.capacity_amps = read_port_capacity(c);
-                spec.closed = read_port_closed(c);
-                if (spec.meter !is null)
-                    into ~= spec;
-            }
-        }
-        foreach (child; c.components[])
-        {
-            const(char)[] child_path = path.length ? tconcat(path, ".", child.id[]) : child.id[];
-            collect_device_production_ports(owner, child, child_path, into);
-        }
-    }
-
-    bool bus_has_real_class_terminal(Bus* b, PortRole role) pure
-    {
-        foreach (p; b.ports[])
-            if (p.role == role && !p.implicit && class_terminal(p))
-                return true;
-        return false;
-    }
-
-    bool production_contribution_exists(Appliance owner, const(char)[] port) pure
-    {
-        if (owner is null)
-            return false;
-        foreach (ref c; production_contributions[])
-            if (c.owner == owner.name[] && c.port == port)
-                return true;
-        return false;
-    }
-
-    const(char)[] primary_owner_circuit(Appliance owner) pure
-    {
-        foreach (p; ports[])
-        {
-            if (p.owner !is owner || p.bus is null)
-                continue;
-            if (p.role == PortRole.grid || p.role == PortRole.connection)
-                return p.bus.id[];
-        }
-        foreach (p; ports[])
-            if (p.owner is owner && p.bus !is null)
-                return p.bus.id[];
-        return null;
-    }
-
-    void add_production_member(Appliance owner, ref DevicePort spec)
-    {
-        const(char)[] group = production_group(spec.path[]);
-        ProductionContribution member;
-        member.owner = retain_production_string(owner.name[]);
-        member.group = retain_production_string(group);
-        member.port = retain_production_string(spec.path[]);
-        member.circuit = retain_production_string(spec.circuit);
-        member.kind = ProductionContributionKind.member;
-        member.component = spec.component;
-        member.meter = get_port_meter_data(spec.meter, spec.phase, spec.sign);
-        production_contributions ~= member;
     }
 
     void add_production_aggregate_once(Appliance owner, const(char)[] group)
@@ -1675,55 +1580,6 @@ private:
             return "pv";
         size_t dot = path.findLast('.');
         return dot < path.length ? path[0 .. dot] : path;
-    }
-
-    bool infer_link_endpoints()
-    {
-        bool changed;
-        foreach (link; links[])
-        {
-            if (!link.closed)
-                continue;
-            if (link.owner !is null && !is_passthrough(link.owner))
-                continue;
-            if (copy_inferred_meter_data(link.port_b, link.port_a))
-                changed = true;
-            if (copy_inferred_meter_data(link.port_a, link.port_b))
-                changed = true;
-        }
-        return changed;
-    }
-
-    // Only a two-port appliance conserves power across one unambiguous link.
-    // Dangling ports do not carry inferred flow yet, so they do not disqualify.
-    bool is_passthrough(Appliance a)
-    {
-        size_t n;
-        foreach (p; ports[])
-            if (p.owner is a && p.bus !is null)
-                ++n;
-        return n == 2;
-    }
-
-    bool copy_inferred_meter_data(Port* dst, Port* src)
-    {
-        if (dst is null || src is null)
-            return false;
-        if (dst.meter_data.has(MeterField.power) || !src.meter_data.has(MeterField.power))
-            return false;
-
-        dst.meter_data = src.meter_data;
-        apply_meter_sign(dst.meter_data, MeterSign.inverted);
-        mark_meter_data(dst.meter_data, Provenance.inferred_subtraction);
-        return true;
-    }
-
-    void mark_meter_data(ref MeterData data, Provenance provenance) pure
-    {
-        foreach (i; 0 .. num_fields)
-            foreach (phase; 0 .. 4)
-                if (data.provenance[i][phase] != Provenance.missing)
-                    data.provenance[i][phase] = provenance;
     }
 
     bool infer_single_dark_port(Bus* b)

--- a/src/apps/energy/topology.d
+++ b/src/apps/energy/topology.d
@@ -1384,13 +1384,14 @@ private:
 
     void infer_graph()
     {
-        // One assignment per pass lets a solved value reach the far side of
-        // its group before that neighborhood independently infers other ends.
+        // Infer only a single dark port, alternating with link mirroring.
         foreach (_; 0 .. bus_list.length + links.length + groups.length + 1)
         {
-            bool changed;
+            bool changed = infer_link_endpoints();
             foreach (b; bus_list[])
                 aggregate_bus(b);
+            // One assignment per pass lets its mirrored value reach the far bus
+            // before that bus independently infers the other end.
             foreach (b; bus_list[])
                 if (infer_single_dark_port(b))
                 {
@@ -1440,18 +1441,6 @@ private:
         dark.meter_data.reset_to_missing();
         dark.meter_data.write_value(MeterField.power, 0, -sum);
         dark.meter_data.mark(MeterField.power, 0, Provenance.inferred_subtraction);
-
-        // A closed contact is one electrical node, so voltage carries across;
-        // appliance ports may sit on different domains and never share it.
-        if (g.ports.length == 2 && g.kind != PortGroupKind.appliance)
-        {
-            Port* known = g.ports[0] is dark ? g.ports[1] : g.ports[0];
-            if (known.meter_data.has(MeterField.voltage))
-            {
-                dark.meter_data.voltage[0] = known.meter_data.voltage[0];
-                dark.meter_data.mark(MeterField.voltage, 0, Provenance.inferred_subtraction);
-            }
-        }
         return true;
     }
 
@@ -1580,6 +1569,55 @@ private:
             return "pv";
         size_t dot = path.findLast('.');
         return dot < path.length ? path[0 .. dot] : path;
+    }
+
+    bool infer_link_endpoints()
+    {
+        bool changed;
+        foreach (link; links[])
+        {
+            if (!link.closed)
+                continue;
+            if (link.owner !is null && !is_passthrough(link.owner))
+                continue;
+            if (copy_inferred_meter_data(link.port_b, link.port_a))
+                changed = true;
+            if (copy_inferred_meter_data(link.port_a, link.port_b))
+                changed = true;
+        }
+        return changed;
+    }
+
+    // Only a two-port appliance conserves power across one unambiguous link.
+    // Dangling ports do not carry inferred flow yet, so they do not disqualify.
+    bool is_passthrough(Appliance a)
+    {
+        size_t n;
+        foreach (p; ports[])
+            if (p.owner is a && p.bus !is null)
+                ++n;
+        return n == 2;
+    }
+
+    bool copy_inferred_meter_data(Port* dst, Port* src)
+    {
+        if (dst is null || src is null)
+            return false;
+        if (dst.meter_data.has(MeterField.power) || !src.meter_data.has(MeterField.power))
+            return false;
+
+        dst.meter_data = src.meter_data;
+        apply_meter_sign(dst.meter_data, MeterSign.inverted);
+        mark_meter_data(dst.meter_data, Provenance.inferred_subtraction);
+        return true;
+    }
+
+    void mark_meter_data(ref MeterData data, Provenance provenance) pure
+    {
+        foreach (i; 0 .. num_fields)
+            foreach (phase; 0 .. 4)
+                if (data.provenance[i][phase] != Provenance.missing)
+                    data.provenance[i][phase] = provenance;
     }
 
     bool infer_single_dark_port(Bus* b)

--- a/src/apps/energy/topology.d
+++ b/src/apps/energy/topology.d
@@ -499,7 +499,7 @@ private void collect_component(Bus* root, ref Array!(Bus*) into)
             if (!l.closed)
                 continue;
             Bus* other = l.a is b ? l.b : l.a;
-            if (into[].findFirst(other) < into.length)
+            if (other is null || into[].findFirst(other) < into.length)
                 continue;
             into ~= other;
             queue ~= other;
@@ -689,7 +689,7 @@ nothrow @nogc:
         l.capacity_amps = capacity_amps;
         l.closed = closed;
         a.links ~= l;
-        if (b !is a)
+        if (b !is null && b !is a)
             b.links ~= l;
         links ~= l;
         return l;
@@ -1087,13 +1087,14 @@ private:
         else
         {
             // A parent-only link dangles toward unenumerated attachments; its
-            // far endpoint is the boundary (the sink).
+            // far endpoint is the boundary (the sink). It is still a real link
+            // (capacity, contact state, meter), so it publishes like one.
             Bus* b = ensure_bus(left.length ? left : "unassigned");
             Port* pa = add_port(null, b, PortRole.connection, flow_for(link.kind), meter, link.meter_phase, link.meter_sign, "connection", link.name[]);
             PortRole dangling_role = link.role.length ? port_role_from_name(link.role) : PortRole.child;
             Port* pb = add_port(null, null, dangling_role, flow_for_role(dangling_role), null, 0, MeterSign.normal, "child", link.name[]);
-            PortGroup* g = add_group(link.name[], PortGroupKind.sink);
-            g.closed = link.closed;
+            Link* l = add_link(null, b, null, pa, pb, link.capacity.value, link.closed, link.name[], link.kind);
+            PortGroup* g = add_group(link.name[], PortGroupKind.sink, null, l);
             add_to_group(g, pa);
             add_to_group(g, pb);
         }


### PR DESCRIPTION
Every energy account becomes one reduction over **boundary edges** — the points where power crosses out of the modeled graph — classified by declared metadata, never by which way power happens to flow. This replaces five parallel account-specific discovery and sign schemes (class terminals, grid-inlet detection, link endpoint inference, inferred meter copying, unbound device productions), which were the root of the mixed-sign PV accounting bug that motivated the work.

**This PR also repairs master**: the current `conf/startup.conf` still speaks the removed `/apps/energy/circuit` language against code that registers `EnergyLink`, so master boots with no energy topology at all.

### The model

- A **port group** is an energy junction independent of any bus: an appliance's ports are joined by the equipment itself, with conservation `sum(port powers) = loss` (default 0) as the solving constraint.
- A **boundary** is the connected port of a one-port group, any dangling port, or a non-appliance port on the grid bus. Orientation is an accounting transform applied at the boundary; `Port.power` keeps the Bus→Port frame throughout.
- **Sinks** are just parent-only links: the dangling child port is the boundary, named by the link, absorbing a circuit's unenumerated load as a solved, classified flow instead of a rogue residual.
- Terminal links are first-class topology: a childless breaker keeps its capacity, contact state and utilisation in `topology.link.*` rather than vanishing.

### The published contract (schema v2)

`boundary.<name>.*` is the flat entity list the UX enumerates for every presentation view; `appliance.<name>.*` covers entities with no boundary; `topology.port.<id>.soc` carries the device's own gauge where a battery is behind the port. The triple-published mirrors (`topology.appliance.*`, `circuit.terminal.*`, `circuit.production.*`, the appliance index) are deleted — the element tree drops from ~10,000 to ~6,500 dump lines. Both schema versions bump to 2; the migration guide is the transition doc in #444.

### Review

Two independent review passes were applied:
- silent fallback to fabricated virtual ports when no port binding matches now warns; missing boundary flow publishes NaN rather than a fake zero; boundary key collisions between appliance and link names warn at bind.
- Open-contact appliance ports and zero-loss inference on dark conversion-appliance ports are **known deferrals**, documented in the survey (§3 contact-state seeding, §6 loss providers) — an open port is a known zero, which is exactly the deferred §3 design.

### Verification

- Tip builds; 114/114 unit tests from a provably fresh binary.
- Every commit builds independently (bisectable).
- Live against the reference site config: 22 links including 5 sinks, and the account identities hold exactly from an atomic snapshot: `generation = solar + battery + rogue` (2723.20 − 1916.73 + 2.19 = 808.66 vs 808.654), `load = generation + grid` (808.654 + 10.194 = 818.85 vs 818.847).
- Deployed on the reference Pi (supervisor slot 95, committed, zero failures); the frontend is actively migrating against this contract.

Known pre-existing issue this PR neither causes nor fixes: bus-level apparent/reactive/pf/frequency aggregation was dropped by the netlist rewrite already on master; those elements publish empty with `_source=missing`.