### PR TITLE
docs: boundary model spec, survey, and UX transition guide

### DIFF
--- a/docs/ENERGY.draft.md
+++ b/docs/ENERGY.draft.md
@@ -1,0 +1,245 @@
+# Energy Management
+
+OpenWatt's energy manager models your site as a graph of circuits, links, and appliances — matching how it's actually wired, because how it's wired determines what's physically possible and what's economically optimal.
+
+Most energy management systems model a flat list of devices with a single global power limit. That works until your site has structure — sub-panels, narrow links between buildings, separate inverters serving different areas, DC buses behind hybrid inverters. A 32A EVSE behind a 20A link to an outbuilding can only draw from the grid what the link allows, even if the main panel has 40A of headroom. But it can charge at full rate when the local battery and solar can supply the difference. A flat model can't express this. The circuit graph can.
+
+The energy manager does three things:
+
+- **Accounting** — reconcile every meter on the site into per-island solar/battery/grid/load figures, with unexplained power surfaced rather than smeared
+- **Protection** — never trip a breaker: every commanded watt is clamped against measured headroom along its physical route
+- **Optimisation** — service declared intent (policies) from the cheapest source: surplus solar first, battery second, grid only when a policy's tier permits it
+
+All three emerge from the same topology awareness. Knowing where the constraints are is the same as knowing where the opportunities are.
+
+## The Circuit Graph
+
+A **circuit** is an electrical space where things connect: a breaker's downstream wiring, a sub-panel, the DC bus inside a battery system. Circuits are not declared — they exist by being named. Referencing `house.gpo` from a link or an appliance port binding brings it into existence.
+
+**Links** are the installed infrastructure connecting circuits: breakers, inline meters, contactors, transfer legs. They carry the current limits and (optionally) the meters:
+
+```
+/apps/energy/link add name=main kind=breaker parent=grid child=main meter=se_meter.meter capacity=63A meter-phase=1
+/apps/energy/link add name=house kind=breaker parent=sub_main child=house meter=vue2.mains_a capacity=50A
+/apps/energy/link add name=house_gpo kind=breaker parent=house.backup child=house.gpo meter=vue2.circuit_7 capacity=20A
+/apps/energy/link add name=cabin kind=breaker parent=sub_main child=cabin meter=cabin_solar.inverter.export_meter meter-sign=inverted capacity=20A
+/apps/energy/link add name=house_gpo_outlets parent=house.gpo
+```
+
+Link properties:
+
+| Property | Meaning |
+|----------|---------|
+| `parent`, `child` | The circuits this link connects, in feed direction. A link with only `parent` set dangles toward unenumerated equipment and becomes a diffuse-load sink (see Metering and Accounting). A link with only `circuit` set is a point connection, not a bridge. |
+| `kind` | `breaker`, `meter`, etc. Inferred when omitted: `capacity` implies breaker, `meter` implies meter. |
+| `capacity` | Current limit as an ampere quantity (`capacity=20A`; a bare number reads as amps). This is what protection enforces. |
+| `meter`, `meter-phase`, `meter-sign` | Dot-path to any EnergyMeter component, which phase to read, and polarity correction. |
+| `closed` | Whether the link conducts (contactors, transfer switches). |
+| `role` | Declares what lives on the child circuit when it isn't otherwise modelled: `role=pv` on a breaker feeding microinverters books its backfeed as solar. See Metering and Accounting. |
+
+The meter can come from any protocol — a Modbus meter, an inverter's built-in CT, CT clamps on an ESPHome device, a Zigbee plug. The energy manager consumes Component trees and doesn't care who populated them.
+
+The grid is the implicit root circuit named `grid`. Everything reachable from it forms the on-grid island; disconnected groups (an unplugged car, an off-grid shed) form their own islands and are accounted independently.
+
+## Appliances
+
+Appliances are the things that consume, produce, or store energy. An appliance is a flat, named entity; its electrical shape comes from its device profile's **Port** components, and each port is bound to a circuit with a `<port>=<circuit>` property:
+
+```
+/apps/energy/appliance add name=goodwe grid=house backup=house.backup_feed battery=dc_bus device=goodwe_ems
+/apps/energy/appliance add name=house_battery connection=dc_bus device=house_bms
+/apps/energy/appliance add name=cabin_solar grid=cabin backup=cabin.backup_feed battery=cabin.dc solar.mppt1=cabin.pv1 solar.mppt2=cabin.pv2 device=cabin_solar
+/apps/energy/appliance add name=shed_evse grid=shed device=shed_twc
+/apps/energy/appliance add name=house_ac connection=house meter=vue2.circuit_4 kind=hvac
+/apps/energy/appliance add name=cabin_hot_water connection=cabin.laundry kind=water-heater
+```
+
+The goodwe line reads: this inverter's grid port is on the `house` circuit, its backup output feeds `house.backup_feed`, and its battery port faces the `dc_bus` circuit. The BMS is a separate appliance on that same `dc_bus` — that co-location is what lets the system reconcile the inverter's view against the battery's own.
+
+Appliance properties:
+
+| Property | Meaning |
+|----------|---------|
+| `<port>=<circuit>` | Bind a device Port (by path, e.g. `solar.mppt1`) to a circuit. Ports not bound explicitly may name their circuit in the device profile. |
+| `device` | Dot-path to the protocol device (or sub-component) carrying the appliance's data and control surface. |
+| `kind` | Appliance class: `inverter`, `battery`, `evse`, `car`, `hvac`, `water-heater`, `pv`, ... Normally inferred from `device.info.type`; set explicitly for anchors without devices. |
+| `meter` | Explicit consumption meter when it isn't on the device itself. |
+| `meter-sign` | Polarity correction for the meter. |
+| `state` | Explicit state component (SOC, temperature) when state lives on a different device than control — e.g. a car's BLE provides SOC while the wall connector provides the control. |
+| `vin` | Vehicle identity; see Cars. |
+| `capacity` | Usable battery kWh; fallback for SOC/energy estimation when the device can't report it. |
+| `root` | Marks this appliance as an explicit source root for otherwise-unrooted islands (generators, off-grid inverters). |
+
+Appliances with no device and no meter are valid: they are intent anchors. `cabin_hot_water` above has no control surface yet, but policies can already target it; `/apps/energy/why` reports "no control" until hardware arrives.
+
+### Cars
+
+Cars are appliances that move. A car with a `vin` attaches to a circuit named by its VIN. An EVSE that can identify the plugged-in car (e.g. Tesla Wall Connector) reports the same VIN as its `car` port's circuit — so the pairing is an ordinary circuit join, and it reshapes automatically on plug/unplug:
+
+```
+/apps/energy/appliance add name=evie kind=car vin=LRW3F7EKXMC392131
+/apps/energy/appliance add name=zephyr kind=car vin=5YJ3F7EC8LF488644
+/apps/energy/appliance add name=mg_zs kind=car connection=mg_zs    # EVSE can't read this VIN; bound manually
+```
+
+Policies target the car, not the charger. When the car is plugged in, the allocator drives it through the paired EVSE's control surface (`via` in the `/why` output). Unplugged cars report "not connected" — status, not error.
+
+## Metering and Accounting
+
+Power enters and leaves the modeled graph at **boundary edges**, and accounting happens exactly there. A port is a boundary when the equipment behind it is not modeled:
+
+- the single port of a one-port appliance (the dishwasher itself isn't modeled, its connection is);
+- a dangling port with no circuit (a hybrid inverter's MPPT input, the far end of a parent-only link);
+- a handover on the `grid` circuit, which stands for the unmodeled utility.
+
+Every other port is **interior**. Interior meters never source an account — they are constraints: they anchor inference, cross-check redundant observations, and expose wiring, polarity, and calibration errors. Modelling more equipment moves the boundary outward and automatically demotes the meters it passes to verification duty; a meter always means "the flow at this exact point" and is never re-described by configuration elsewhere.
+
+Classification is metadata, not sign. A boundary's account — solar, battery, grid, load — comes from its declared role or its owner's kind, never from which way power happens to flow at the moment. An untagged generator books as unclassified generation instead of disappearing.
+
+An inverter is the instructive case: it looks like an appliance, but electrically it's a coupling between circuits — a lossy transformer with a port on each bus. Its battery port reading is the *net* DC bus flow. If the DC bus holds only a battery, that net equals the battery; but put a DC-coupled charge controller on the same bus and the inverter can no longer see the panels' generation or the battery's true charge rate — only their sum. Modelling the DC bus as a circuit with its occupants as appliances recovers what the inverter cannot report — and the inverter's own battery-port meter stays useful as the cross-check on the new equipment's story.
+
+### Diffuse-load sinks
+
+Circuits with sockets carry loads nobody will ever enumerate. Declare that with a parent-only link — its dangling end is a boundary that absorbs the circuit's unexplained flow as a named account:
+
+```
+/apps/energy/link add name=house_gpo_outlets parent=house.gpo
+```
+
+The link's name is the account: `house_gpo_outlets` reports the plug loads on that circuit, per circuit, instead of leaving them pooled in island-wide rogue load. When another declared port on the same circuit is also unmetered, the two are indistinguishable and the solver defers rather than guessing a split. A sink absorbs meter error along with plug loads, so declare them only where sockets really exist and keep fully-enumerated circuits sink-free for full fault sensitivity.
+
+### Implicit terminals
+
+Declaring a port's role (`battery`, `pv`) states what lives on the circuit it faces. When nothing of that class is actually modelled there, the topology synthesizes an **implicit terminal** in its place and infers its flow from the circuit balance. The bank behind a bare hybrid inverter becomes an accountable battery without any extra configuration; when you later add the real BMS device, it displaces the implicit terminal automatically, and any leftover residual (DC cabling loss, meter disagreement) shows up honestly as rogue load on that circuit.
+
+The same declaration works on ordinary breakers. Microinverters plugged in behind a GPO circuit are invisible equipment backfeeding a boundary meter — declare the circuit's link with `role=pv` and the net backfeed books as solar:
+
+```
+/apps/energy/link add name=patio_gpo parent=house child=house.patio role=pv capacity=20A
+```
+
+Without the declaration, backfeed on a circuit is left as **rogue generation**: real, but unattributed.
+
+### Reconciliation and health
+
+Each circuit's balance is the signed sum of its port meters. The residual — what the meters can't explain — is classified per circuit:
+
+- **Unaccounted load** (the common case): unmetered GPO loads, cabling loss between bracketing meters. Normal life, reported, not alarming — and claimable per circuit by a sink.
+- **Unaccounted source**: power appearing from nowhere. Genuinely suspicious — flagged as an anomaly unless a declared role explains it.
+- Where a circuit has exactly one dark (unmetered) port that could physically carry the residual, inference assigns it — so one missing meter doesn't blind a circuit.
+- Groups conserve: a multi-port appliance's port flows sum to its conversion loss, a closed breaker's two ports mirror. A group with exactly one unknown port is solved from its siblings — this is what carries a circuit residual out through a sink's dangling end, and what closes a hybrid inverter's last port. Fully-measured appliances publish their self-consumption; fully-measured breakers flag disagreement beyond meter noise as a mismatch.
+
+Coverage per circuit is published as `measured` (balanced), `bounded` (dark terminals with a power bound), `rogue-value` (unexplained residual), or `unknown`.
+
+### Accounts
+
+Each island's accounts are projections of one reduction over its solved boundary edges — every boundary contributes exactly once, to the account its classification picks, oriented by its shape:
+
+- **SOLAR** — net flow of solar-classified boundaries (daily energy reconciled per source: an aggregate meter is authoritative over per-string/per-panel members)
+- **BATTERY** — net flow of battery-classified boundaries (positive = discharging)
+- **GRID** — net flow of the grid handover boundaries (positive = importing)
+- **ROGUE GENERATION / ROGUE LOAD** — unclassified boundary flows plus unattributed circuit residuals, summed island-wide
+- **GENERATION** — net on-site supply: solar + battery (signed) + rogue generation. Grid is not included; it has its own account. The identity `LOAD = GENERATION + GRID` holds exactly, and `GENERATION - BATTERY` is pure production (solar + rogue).
+- **LOAD** — `GENERATION + GRID`, clamped at zero
+
+Battery and solar terminals are DC-side meters, so inverter conversion losses land in LOAD — in both directions. Charging books the AC drawn at full value while only the smaller DC-side charge power is subtracted; discharging books the DC supply while the AC side delivers less. LOAD is therefore "household consumption plus conversion overhead": it will read slightly above the sum of your AC circuit meters, with the difference being real energy your energy system consumed. Conversion loss is just another rogue load.
+
+Daily energy tallies (`today.charge`, `today.import`, ...) accumulate from the source meters' energy counters since local midnight.
+
+## Policies: Declaring Intent
+
+Policies are layered intent that the allocator services every tick. Each policy names a target appliance, a tier, and a goal:
+
+```
+/apps/energy/policy
+add name=evie_reserve    target=evie   tier=floor         goal="soc(20)"
+add name=evie_ready      target=evie   tier=important     goal="soc(40)" deadline=11:00 shape=window
+add name=evie_topup      target=evie   tier=opportunistic goal="soc(90)"
+add name=cabin_ev_surplus target=cabin_evse tier=opportunistic goal="soc(100)"
+```
+
+**Tiers**, highest priority first:
+
+| Tier | Contract |
+|------|----------|
+| `floor` | Must always hold. Infinite priority; may buy from the grid. |
+| `essential` | Must reach the goal by its deadline. High priority, decays toward urgent as slack runs out. |
+| `important` | Try to reach the goal. Yields to floor/essential; solar and battery only — no grid buy. |
+| `opportunistic` | Consume surplus only; gated on battery/solar pressure. |
+
+**Goals**: `on`, `off`, `soc(N)`, `temp(N)`, `duty(...)`, or an expression. `deadline=HH:MM` feeds the slack boost on essential/important tiers. `shape=window` marks charge-window intent (parsed and published; ranking integration pending).
+
+A target usually carries several policies at different tiers — read each block top-to-bottom as intent: "never below 20%, be at 40% by 11am, fill to 90% on surplus."
+
+Autonomous equipment needs no policy: a hybrid inverter that manages its own battery reserve (PowerControl kind `autonomous`) takes no setpoint. Policies drive *commandable* controls.
+
+## Planning and Allocation
+
+Each tick, per island:
+
+1. **Budget** — the planner totals battery energy available/reserved, forecast supply and demand, and per-tier demand (`islands.<id>.budget.*`).
+2. **Ranking** — each policy gets a marginal value from its tier, goal distance, and deadline slack.
+3. **Allocation** — in rank order, each policy's command is routed to a control surface (the target's own, or its paired EVSE's) and clamped against the physical route.
+4. **Actuation** — accepted commands are written through the protocol layer; the reason for every decision is published (`allocation.<policy>.reason`).
+
+**Control paths** make protection structural: for every controllable appliance the graph computes the route from its connection back toward the grid or a source root, and the minimum spare capacity along that route (`headroom`). A command can never exceed the headroom of its narrowest link, minus capacity already committed to higher-ranked policies in the same tick. Boolean loads with a known nameplate are refused when switching on would exceed the route's headroom.
+
+This is also where topology becomes opportunity: an EVSE behind a 20A inter-building link can still charge hard when the local inverter and battery supply the difference — the path headroom constrains *grid-side* draw, and local sources sit downstream of the constraint.
+
+## Inspection
+
+Everything the energy manager believes and decides is published as elements on the synthetic `energy` device (see [ENERGY_ELEMENT_DATA_SPEC.md](ENERGY_ELEMENT_DATA_SPEC.md) — the contract the web frontend renders from). The console offers projections of the same state:
+
+| Command | Shows |
+|---------|-------|
+| `/apps/energy/live` | Live island accounts: solar, battery, grid, rogue, generation, load. |
+| `/apps/energy/topology [-w]` | The raw graph: buses, links, ports, coverage, residuals. |
+| `/apps/energy/circuit [-w]` | The reconciled circuit view (kernel projection). |
+| `/apps/energy/control print` | Every discovered control surface: kind, direction, unit, range, setpoint, nameplate. |
+| `/apps/energy/why` | Per-policy decisions: goal, satisfaction, marginal value, and the reason for the current command. |
+
+`why` is the first stop when the system does something surprising: every policy row states what it wanted, what it was allowed, and why.
+
+## How It Fits Together
+
+The energy manager sits at the top of the OpenWatt stack. It reads from the device model and writes control commands back through the protocol layer:
+
+```
+Energy Manager
+  reads from: Device -> Component -> Element (Port, EnergyMeter, Battery, PowerControl, ...)
+  writes to:  control setpoints on the same tree
+    |
+Protocol Layer
+  translates element writes into protocol operations
+  (Modbus write register, MQTT publish, TWC current command, BLE, ...)
+```
+
+This separation is what makes it protocol-agnostic:
+
+- Adding a new meter or inverter requires a device profile — the energy manager doesn't change
+- Any mix of protocols can feed a single site's energy management
+- The energy manager can be tested without hardware — mock the Elements
+
+By the time the energy app runs, protocol devices already exist with their Component trees populated:
+
+```
+# GoodWe hybrid inverter via proprietary protocol
+/protocol/goodwe/aa55/add name=cabin_solar remote=192.168.3.5 profile=gwxx48es
+/binding/goodwe/add name=cabin_solar device=cabin_solar client=cabin_solar profile=gwxx48es
+
+# Tesla Wall Connector via TWC protocol
+/interface/tesla-twc add name=shed_twc stream=shed
+/binding/tesla/twc/add name=shed_twc device=shed_twc slave_id=0x6820
+
+# ESPHome energy monitor (CT clamps)
+/protocol/esphome/client add name=vue2 remote=192.168.3.20
+/binding/esphome add name=vue2 device=vue2 client=vue2 profile=emporia
+```
+
+## Further Reading
+
+- [Element Data Spec](ENERGY_ELEMENT_DATA_SPEC.md) — The published element contract (frontend renders from this)
+- [Overview](OVERVIEW.md) — How the OpenWatt layers fit together
+- [Device Profiles](PROFILE_FILE_FORMAT.md) — Writing profiles for new meters and inverters
+- [Component Templates](COMPONENT_TEMPLATES.md) — Standard templates (EnergyMeter, Battery, Port, PowerControl, ...)
+- [CLI Reference](CLI.md) — Console command syntax

--- a/docs/ENERGY_UX_TRANSITION.md
+++ b/docs/ENERGY_UX_TRANSITION.md
@@ -1,0 +1,238 @@
+# Energy element contract: boundary-model transition
+
+Audience: the web frontend / UX team. The energy app's accounting was rebuilt
+around boundary edges (branch `ow/source-survey`). Most of the element
+contract is unchanged; this document lists exactly what moved, what it now
+means, and what is coming next so views can be planned rather than patched.
+
+## 1. The model shift in one paragraph
+
+Accounting now happens only at **boundary edges**: the points where power
+crosses out of the modeled graph (a one-port appliance's connection, a
+dangling port such as an inverter's MPPT input, the grid handover). Every
+boundary contributes to exactly one account, classified by metadata (declared
+role or equipment kind), never by which way power happens to flow. Interior
+meters no longer source accounts; they verify. Consequence for UX: numbers
+are attributable to a specific named edge, and "unexplained" power is an
+explicit, shrinking category rather than a smear.
+
+## 2. Semantic changes to existing elements
+
+### 2.1 `islands.<id>.account.rogue.*` composition changed
+
+- Previously: unattributed circuit residuals only.
+- Now: residuals PLUS measured-but-unclassified boundary flows. Equipment
+  with no role/kind tag used to vanish from accounts entirely; it now lands
+  here. Expect rogue generation to be nonzero on sites with untagged
+  generators.
+- Declaring a diffuse-load sink on a circuit (a parent-only link) REMOVES
+  that circuit's plug-load residual from rogue: it becomes a solved,
+  load-classified boundary. Total load is unchanged; rogue shrinks. The
+  per-sink figure is its `boundary.<link_name>.*` entry (section 4).
+- Copy suggestion: this account increasingly means "unclassified", not
+  "suspicious"; consider renaming in the UI when section 4 lands.
+
+### 2.2 `account.solar.power` and nighttime standby
+
+Solar is the net flow of solar-classified boundaries. A hybrid inverter's
+MPPT boundary reads ~0 at night (panels draw nothing); its standby power
+arrives through the interior grid port and lands in the appliance's
+self-consumption (the sum of all its port powers, published with the
+group-loss view). Only a one-port solar appliance (a net-metered
+microinverter drawing standby through its only connection) can take the
+solar account slightly negative at night; show it and tooltip it as standby
+draw rather than clamping.
+
+### 2.3 `account.battery.today.charge` / `.discharge` both accumulate
+
+The old implicit-terminal path misattributed one direction on some
+configurations. Both counters now accrue correctly from the battery
+boundary's meters. Dashboards comparing across the upgrade will see a step
+change; this is a correction, not noise.
+
+### 2.4 Grid daily counters
+
+Same elements (`account.grid.today.import/export`), now sourced from the
+grid handover boundary's meters instead of a special-cased root-bus scan.
+Values are identical on conventional configurations.
+
+## 3. Shape and type changes
+
+- **`circuit.schema_version` and `topology.schema_version` are now 2.**
+  Version 1 is the pre-boundary contract; a consumer built against v1
+  should treat v2 as this document. Gate on the version rather than
+  probing for the removed namespaces.
+
+- **New ports appear** in `topology.port.*`:
+  dangling ports (retained MPPT/battery inputs) and sink endpoints
+  (`<link>.connection`, `<link>.child`). They publish `bus=""` and may have
+  `owner=""`. Tolerate the empty strings; do not render dangling ports as
+  wiring errors -- they are boundary edges, arguably the most interesting
+  ports on the site.
+- **Ports with a battery behind them publish `soc`**:
+  `topology.port.<id>.soc` is the device's own gauge at that port (an
+  inverter's battery port, a BMS connection). The field exists only where
+  the device reports one; the reconciled multi-view value remains on the
+  battery boundary entry. Render appliance-card bands from the port value,
+  site-level battery state from the boundary.
+- **Appliance cards are built from ports**: select `topology.port.*` where
+  `owner` equals the appliance name -- one band per port, labeled by
+  `port`/`port_role`, full meter block plus `soc` where present. The old
+  `topology.appliance.*` mirror is gone; `topology.link.*` entries with
+  `kind=appliance` are the appliance's internal legs, not circuit edges --
+  do not draw them as breakers.
+- **Float capacities**: `topology.link.<id>.capacity` and
+  `control_path.<name>.limiting_capacity_amps` changed int ->
+  float (fractional amps are legal; config accepts `capacity=20A`).
+- **Production contributions**: `circuit` may be empty for dangling members;
+  member power is now always generation-positive (no frame mixing).
+
+## 4. The enumeration surface (available now) and what follows
+
+**Published now** -- the supported entity list for all presentation views:
+
+- `boundary.<name>.*`: one entry per accountable edge, keyed by its declared
+  name (`house_gpo_outlets`, `dishwasher`, `main`, `cabin_solar.solar.mppt1`).
+  Fields: `kind` (solar/generator/battery/grid/load/unclassified), `owner`,
+  `origin` (appliance/switchgear/handover/sink -- what declared it), `port`
+  (the exact topology port id, i.e. the pin in the site graph this boundary
+  hangs from), `circuit`, `island`, `power_in`/`power_out` (watts into/out
+  of the site), `provenance` (measured / inferred-* / missing),
+  `energy_in`/`energy_out`
+  (corrected counters where a meter backs the boundary). Filter by kind to
+  build every list: appliances (load with owner), per-circuit general load
+  (sinks), generation, batteries, grid. Sum any subset for aggregates; the
+  island accounts are the same reduction.
+
+  A boundary carries accounting semantics ONLY; physical data (capacity,
+  contact state, meters) lives on the topology entity its `port` points at.
+  The earlier `edge_kind`/`capacity`/`closed` duplication on switchgear
+  boundaries is REMOVED: parent-only links (sinks, terminal breakers) now
+  publish as first-class `topology.link.<id>.*` entries -- endpoints
+  (`child` is empty for a dangling end), kind, capacity, closed, live
+  current/utilisation, loss/mismatch -- so the network graph is
+  topology-first and boundaries are lightweight references onto it.
+- `appliance.<name>.*`: `kind`, `circuit`, `boundary` (key into the list
+  above, empty when none), `connected` -- covers presentation entities that
+  have no boundary (intent anchors, unplugged cars). Multi-port appliances
+  also publish `loss_power`: live self-consumption / conversion loss (the sum
+  of all port powers when every port is solved; empty otherwise).
+- `topology.link.<id>.loss_power` / `.mismatch`: for breakers and sinks the
+  same port sum is a cross-check, and `mismatch=true` means the two sides
+  disagree beyond meter noise (max of 50 W and 2 percent of flow) -- a
+  wiring/calibration alarm worth a distinct visual treatment.
+
+### Labeling: mapping boundary keys to user-facing names
+
+The boundary key is the configuration name of the thing that declared it,
+so it is already human-chosen; the association strategy for display labels:
+
+1. **`owner` non-empty**: the boundary belongs to that appliance. Label it
+   with your appliance display name; `appliance.<owner>.boundary` gives the
+   reverse mapping. When one appliance has several boundaries the key is
+   `<owner>.<port path>` (`cabin_solar.solar.mppt1`); the path suffix is the
+   sub-label ("MPPT 1").
+2. **`origin=sink`**: a declared diffuse-load catchall. Label from the
+   circuit: "General load on <circuit>" / "Outlets"; the key itself
+   (`house_gpo_outlets`) is the installer's own chosen name and works as a
+   default.
+3. **`kind=grid`**: the utility connection; label "Grid".
+4. **`origin=handover`, `owner` empty**: role-declared unmodeled equipment
+   (an implicit stand-in). Label from kind + circuit: "Solar on <circuit>",
+   "Battery on <circuit>". These disappear automatically when the real
+   equipment is modeled, replaced by an owned boundary.
+
+`origin` publishes the declaring group's kind:
+appliance / switchgear / transfer / handover / sink.
+
+### Site header stats
+
+The top-level dashboard figures, all per island (the on-grid island is the
+one whose `mode` is `on_grid`):
+
+| Stat | Source |
+|------|--------|
+| Local/grid mix | `account.local_fraction`: fraction of consumption served locally (1 while exporting; battery discharge counts as local regardless of what charged it) |
+| Overall production | `account.generation.power - account.battery.power` (pure production: solar + generators + unclassified generation, battery movement excluded) |
+| Overall consumption | `account.load.total.power`; today's energy is the counter identity `grid.today.import + solar.today.energy + battery.today.discharge - grid.today.export - battery.today.charge` |
+| Battery | `account.battery.power` (positive = discharging), `today.charge`/`today.discharge`, `budget.battery_available/battery_capacity/reserve_kwh`, SOC on battery-kind boundary entries |
+| Export meter | the boundary entry with `kind=grid` (`power_in` = importing, `power_out` = exporting, `energy_in`/`energy_out` = the meter's corrected counters, `provenance` = meter health) |
+| Ruleset "why" | `allocation.<policy>.*` (command, reason) alongside `policy.*` definitions; render adjacent to the export meter since grid exchange is where their effect lands |
+
+### Flow coloring
+
+`circuit.bus.<id>.local_fraction` is the per-node green/red ratio (1 = all
+local energy, 0 = all grid). Buses mix perfectly, so every flow leaving a
+bus carries that bus's ratio; the edge painting rule is: color each flow
+line with the local_fraction of the bus the flow is drawn from this sample
+(the edge's flow sign says which side that is). No per-edge blend is
+published because it is exactly this derivation.
+
+**Coming next** (paths tentative until `ENERGY_ELEMENT_DATA_SPEC.md` is
+updated):
+- **Fault and outage reports**: three severities that want distinct visual
+  treatment: (1) a normally-measured boundary currently running on inference
+  (meter offline; accounting continues -- info, not alarm); (2) several dark
+  boundaries confounded (category detail lost, net still accounted, culprit
+  list provided); (3) residual on a fully-measured circuit (genuine
+  meter/wiring fault).
+
+## 5. Deprecations: do not build against these
+
+Arbitrated for removal or replacement; migrate off them (or never adopt):
+
+| Namespace | Fate | Replacement |
+|-----------|------|-------------|
+| `topology.appliance.*` | delete (triple-published meter mirror) | identity: `appliance.*` / `boundary.*`; meters: `topology.port.*` |
+| `topology.appliance_index.*` | delete | `appliance.*` |
+| `circuit.terminal.*` | demote (per-port mix is derivable: port draw x bus ratio) | bus ratio at `circuit.bus.*`; `soc` moves to battery-kind boundary entries |
+| `circuit.branch.*` / `topology.link.*` | merge into ONE edge namespace: endpoints, closed, capacity, live current/power, utilisation | final name announced in the element spec |
+| `circuit.production.*`, `circuit.production_contribution.*` | retire | solar boundary entries, which will gain an aggregate-vs-member `mismatch` flag |
+
+`soc` is available on battery-kind boundary entries (`boundary.<name>.soc`,
+the reconciled store value); read it there, not from `circuit.terminal`.
+
+**Graphing is available now.** The presentation set records to disk (island
+accounts including the today counters, every `boundary.*` power/energy/soc,
+appliance loss), and the sync websocket already answers history requests:
+send a `history_req` frame with `path` (the full element path, e.g.
+`energy.islands.grid.account.grid.power`), `from`/`to` in epoch
+milliseconds, and `max_points` (default 500, hard cap 2000); you get back a
+`history` frame with `samples` as `[time_ms, value]` pairs. An unrecorded
+path answers with an error frame, which is the signal that the element is
+live-only by design -- ask for it to be added to the recorder rather than
+polling it into your own store.
+
+Recording is opt-in per element class, so what you can graph is exactly the
+supported presentation surface. Debug trees (`circuit.bus.*`,
+`topology.port.*`) are deliberately not recorded.
+
+## 6. Unchanged guarantees
+
+- All `islands.<id>.account.*` element paths and units.
+- The identities, which hold exactly and are assertable client-side:
+  `generation = solar + battery + rogue.generation` (plus generator kinds),
+  `load = generation + grid` clamped at zero.
+- Coverage vocabulary (`measured` / `bounded` / `rogue-value` / `unknown`).
+- Production/production-contribution element shapes.
+- Daily counters bank across meter resets as before. Note: energy counters
+  do not bridge meter outages -- live power rides through by inference, but
+  daily totals stall while a meter is silent and catch up when it returns.
+
+## 7. Frontend migration checklist
+
+1. Accept `bus=""` / `owner=""` on ports; group dangling ports as
+   "boundaries" rather than under a circuit.
+2. Parse capacities as floats.
+3. Expect solar ~0 at night on this site; small negative solar only
+   appears for one-port solar appliances (standby draw), tooltip it.
+4. Expect rogue to differ from the previous build (larger where untagged
+   equipment exists, smaller where sinks are declared).
+5. Treat battery daily-counter steps at upgrade time as a correction.
+6. Build entity lists and site header stats from `boundary.*` /
+   `appliance.*` / `islands.<id>.account.*` only; treat section 5's
+   namespaces as already gone.
+7. Adopt `appliance.<name>.loss_power` and `topology.link.<id>.mismatch`
+   (available now), and build charts against the sync `history_req` frame
+   (section 5); reserve UI space for the three-severity fault reporting
+   (section 4).

--- a/docs/SOURCE_SURVEY.draft.md
+++ b/docs/SOURCE_SURVEY.draft.md
@@ -47,6 +47,13 @@ a multi-unknown residual per port.
 
 ## 3. Contact-state zero seeding
 
+Review sharpened the scope: appliance ports carry contact state too
+(read_port_closed), but ports_connected treats appliances as unconditional
+junctions and group inference ignores per-port state, so an open contactor
+would still exchange inferred energy. An open port is a known zero, not an
+unknown; seed it as such here. Latent today: nothing in-tree publishes
+closed=false on an appliance port.
+
 Open switchgear should seed explicit zero through-flow on its ports instead
 of leaving them dark. Deferred because it changes bus coverage classification
 (dark/bounded becomes measured), which is account-visible; land it together
@@ -101,6 +108,11 @@ Also publish per-group loss/self-consumption (`PortGroup.loss_power`,
 each sample; only the publishers are missing.
 
 ## 6. Link loss providers
+
+Until a provider supplies loss, single-unknown group inference manufactures
+a zero-loss value for conversion appliances; the error is bounded by device
+loss and the value is marked inferred, but accounts built on it inherit the
+approximation.
 
 Every link/switchgear constraint already carries a loss term, default zero.
 Providers may later supply it, keyed by declared link identity so learned

--- a/docs/SOURCE_SURVEY.draft.md
+++ b/docs/SOURCE_SURVEY.draft.md
@@ -1,0 +1,264 @@
+# Boundary survey: remaining work
+
+Status: the boundary-edge accounting model is IMPLEMENTED (branch
+`ow/source-survey`, commits b31f317..a4aef43). The model itself is documented
+in [ENERGY.draft.md](ENERGY.draft.md): boundary edges as the single accounting
+authority, port groups with conservation constraints, geometry-declared sinks,
+closed-world circuits, one account reduction with metadata classification.
+
+This document now tracks only the deferred follow-ups, roughly in the order
+they are worth doing.
+
+## 1. Provenance representation upgrade
+
+The solver carries the flat provenance enum. The upgrade is a richer tag per
+solved value, combined through a single funnel so the representation is a
+value-type swap rather than a solver restructure:
+
+- **Requirement**: a value inferred from another inferred point stays
+  distinguishable from a direct measurement, and a later measured
+  contradiction becomes a reconciliation mismatch instead of silently
+  replacing history.
+- **Recommended form**: a dependency set of seed meters (small fixed bitset),
+  so mismatch and outage reports can name the meters a value stands on, and
+  outage-bridged values are distinguishable from never-metered ones.
+- The written precedence rule (measured outranks inferred; boundary-most
+  authoritative among equals; disagreement beyond the noise floor keeps the
+  winner and reports a mismatch; never silently average) holds regardless of
+  representation.
+
+## 2. Fault and underdetermined reporting
+
+The solver should report, per connected constraint component, its closure
+residual and the identities of its still-free variables. Severity falls out:
+
+1. Normally-measured boundary degraded to inferred: accounting continues;
+   alert on the provenance transition or the device's own offline state.
+2. Multiple dark boundaries in one component: category detail lost, net flow
+   still accounted, culprits named ("solar and battery on dc bus
+   unmeasurable; combined net flow X W").
+3. Residual on a fully-determined circuit: fault (meter error, wiring or sign
+   mismatch, undeclared equipment).
+4. Sink absorption: expected diffuse flow, a normal account.
+
+Today residuals still publish through the per-bus rogue/coverage fields; the
+component-level report with named free variables is not built. Never allocate
+a multi-unknown residual per port.
+
+## 3. Contact-state zero seeding
+
+Open switchgear should seed explicit zero through-flow on its ports instead
+of leaving them dark. Deferred because it changes bus coverage classification
+(dark/bounded becomes measured), which is account-visible; land it together
+with a review of the coverage semantics.
+
+## 4. Attribution seeding from boundaries (SHIPPED)
+
+`attribution.seed_source_mix` now consumes the solved boundary flows: a
+grid-kind in-flow seeds grid supply, every other in-flow seeds local
+(diffuse/unclassified supply is local by nature; battery discharge is local
+regardless of what charged it), and residuals never seed (error is not
+energy). The load-shortfall heuristic survives only as a fallback for a grid
+bus no grid boundary reported on. The network-flow projection downstream of
+the seeds is unchanged.
+
+## 5. Boundary publishing is the UX enumeration surface (SHIPPED, complete)
+
+Implemented: `boundary.<name>.*` (kind, owner, origin, port, circuit, island,
+directional power, provenance, counters, soc on batteries, mismatch on owned
+solar) and `appliance.<name>.*`; the demotions in section 9 are executed.
+Per-group loss is published too: `appliance.<name>.loss_power`
+(self-consumption/conversion loss for multi-port appliances) and
+`topology.link.<id>.loss_power`/`.mismatch` (two-sides-disagree alarm on
+switchgear and sinks). Nothing remains from this section. Original intent
+follows.
+
+Publish the boundary list as a flat, stable, enumerable namespace; it IS the
+user-facing entity list, and the UX must not have to walk the topology debug
+trees to build one. Per boundary, keyed by a stable name (owner appliance
+name, or the link name for sinks/handovers):
+
+- `kind` (solar/generator/battery/grid/load/unclassified), `owner`, `island`,
+  `circuit`;
+- live directional power (into/out of the site) and provenance
+  (measured/inferred);
+- corrected energy-counter values where a meter backs the boundary.
+
+UX filters this one list for every presentation view: kind load with an
+owner = appliances; kind load from a sink = per-circuit general load; solar
+and generator = generation sources; battery; grid. Aggregation at any level
+(island, kind, owner) is summation over the same list, guaranteed consistent
+with the island accounts because both are reductions of the same flows.
+
+Alongside it, a small appliance index for presentation entities that have no
+boundary yet (intent anchors, unplugged cars): name, kind, connected
+boundary reference when present, control availability. This replaces
+`topology.appliance_index` as the supported surface; the `topology.*` and
+`circuit.*` trees then demote to debug per section 9.
+
+Also publish per-group loss/self-consumption (`PortGroup.loss_power`,
+`mismatch`) for device-loss and wiring-alarm views. All values are computed
+each sample; only the publishers are missing.
+
+## 6. Link loss providers
+
+Every link/switchgear constraint already carries a loss term, default zero.
+Providers may later supply it, keyed by declared link identity so learned
+state survives topology rebuilds:
+
+- configured bound (watts or percent) or configured resistance;
+- a learned fit: with meters at both ends, `deltaV * I` is a well-conditioned
+  loss estimator (far better than subtracting two large powers), the fitted
+  slope is the run's resistance, the intercept self-calibrates the voltmeter
+  pair, and drift in fitted R is a corroding-joint diagnostic.
+
+Correct the propagated value by the loss estimate; provenance marks values
+standing on a learned parameter.
+
+## 7. Transfer switches
+
+`PortGroupKind.transfer` exists and asserts TODO. Needs a declaration surface
+(two input ports, one output, A/B/off position from contact feedback or a
+live element), connectivity per position, and the §acceptance transfer tests.
+Do not infer position from instantaneous power.
+
+## 8. Smaller items
+
+- **Flow-domain bound tightening**: on underdetermined components, use
+  supply/consume-only domains to publish directional bounds (never a per-port
+  allocation).
+- **Diffuse daily energy**: sinks have no counters; integrating inferred
+  power would fabricate energy data, so it stays out unless demanded, and
+  then explicitly marked as derived.
+- **Per-meter noise floors**: a single constant floor (50 W / 2 percent of
+  flow scale) suffices; refine per meter accuracy class later.
+- **Production layer: RESOLVED, retained internally.** Its element surface
+  and topology-survey role are deleted; what remains is the documented
+  aggregate-vs-member reconciliation policy itself, feeding solar daily
+  counters (a meterless inferred pv boundary is counted by its interior
+  mppt meters, aggregate authoritative) and the boundary mismatch flag.
+  Rewriting that boundary-side would relocate the same policy without
+  deleting coverage; not worth it.
+- **Energy counters do not bridge outages** (documented behavior): power
+  rides through by inference; daily counters stall and self-heal when the
+  meter returns, and energy transferred while a meter was both silent and
+  reset is lost to the daily account.
+
+## 9. History recording and element-footprint audit
+
+Status: recording is enabled and CURATED. Recording is opt-in by
+construction: a `Recorder` with no `filter=` records nothing, and each
+conf recorder names the class it captures. The filter is a comma list of
+path patterns where a leading `!` excludes, so the device archive is
+`filter="*,!energy.*,!config.*"` (raw data-source samples) and the runtime
+state classes are named explicitly. The reference site went from ~2090
+captured series to ~400.
+
+Delivery is already built: the sync/websocket protocol carries
+`history_req` / `history` frames (`inbound_history_req` in
+[../src/manager/sync/package.d](../src/manager/sync/package.d)), answered
+synchronously from RAM buckets plus the `.owsig` container. Console
+`/record/query` and `/record/graph` serve from the same local path.
+
+Remaining:
+
+- **Container retention/rotation**: `.owsig` files grow without bound.
+  Needs a size/age budget per series or per recorder. This is now the only
+  thing between the current state and leaving recording on indefinitely.
+- **Class-specific retention**: the short class (budget, allocations) wants
+  days, not months; today every recorder retains alike, so the classes are
+  separated by recorder but not yet by policy.
+
+The retention classes as arbitrated:
+
+- **Long history (UX graphing)**: island `account.*` powers and today
+  counters (grid import/export, per-battery charge/discharge, per-source
+  solar, rogue), the per-boundary flow views, battery SOC.
+- **Short history (local reasoning)**: planner budget, allocation decisions,
+  coverage/mismatch flags; enough to answer "what just happened", days not
+  months.
+- **No history, audit before demoting**: parts of the wide `topology.*` and
+  `circuit.*` trees are transient reasoning state wearing element costumes,
+  but the UX renders the site graph in meaningful detail, so demotion is an
+  itemised decision with the frontend, not a sweep. Elements exist for what
+  a user edits, a 3rd party samples, or the UX presents; whatever fails all
+  three moves to D structs and console views, which is also the same fix as
+  the first-publish element storm below.
+
+  Arbitrated so far:
+
+  - `circuit.bus.*` KEEP: the flow-coloring data (local_fraction is the
+    per-node green/red ratio). The mix treatment is defined by the seeding
+    rules in section 4 (unclassified/diffuse is local; fault residuals are
+    excluded).
+  - `circuit.terminal.*` DEMOTE: a bus is one electrical node, so
+    everything drawn from it shares the bus's mix; per-port local/grid is
+    derivable (port draw times bus ratio) and need not be published. Move
+    battery `soc` onto battery-kind boundary entries first (from the store
+    reconciliation, which already merges multi-view SOC; one bar per
+    battery, on the boundary marker, not per observing terminal).
+  - `circuit.branch.*` and `topology.link.*` MERGE into one edge namespace:
+    endpoints, closed, capacity, live current/power, utilisation (the UX
+    renders CB load-vs-capacity meters). No per-edge blend: a bus mixes
+    perfectly, so the blend on an edge is exactly the source-side bus's
+    local_fraction, fully determined by the edge's flow sign plus data
+    already published; the painting rule is documented for the frontend
+    instead of duplicated as elements. Retire the other tree.
+  - `circuit.production.*` RETIRE after the boundary entries gain an
+    aggregate-vs-member `mismatch` flag; `production_contribution.<index>`
+    (unstable array-position keys) demotes to the console circuit table.
+  - `topology.appliance.*` DELETE (triple-published meter mirror; identity
+    superseded by `appliance.*`/`boundary.*`); `topology.port.*` keeps the
+    surviving meter mirror, slimmed. `topology.appliance_index` deletes
+    after UX migrates.
+
+Related: the daily counters in accounts.d are hand-rolled reset-banking
+around live meter totals; once recording lands they become
+`value_at(source, midnight)` queries against the store (existing
+TODO(0.6, db.Stream)). Unmetered categories (rogue, sink diffuse) have no
+counter to record; daily energy for them requires the explicit
+integrate-with-derived-provenance decision (section 8).
+
+## 10. Performance work
+
+The first energy update after boot logged 233ms, which is far beyond what
+this graph size justifies. Profile before optimizing; the existing
+`log_slow_phase` / `log_slow_topology_publish` subdivisions (layout,
+cache_bind, values) localize it. Known suspects and strategies, roughly in
+expected-payoff order:
+
+- **Element-creation storm on first publish**: hundreds of
+  `find_or_create_element` calls, each tconcat-ing a full dot path and
+  walking the component tree with a linear child search per level, each
+  `set_element` allocating a fresh String, each creation fanning out
+  notifications to sync/ws/api subscribers. Strategies: per-component child
+  index, a bulk-bind mode that suppresses per-element notification until the
+  batch completes, reuse of the path buffer, set-if-changed for strings.
+- **Boot rebuild storm**: every link/appliance startup requests a topology
+  rebuild and every shape element change marks dirty; early boot can rebuild
+  the graph (and re-bind publishers) many times in consecutive frames.
+  Debounce rebuilds until configuration settles.
+- **Per-sample allocation churn**: `rebuild_productions` runs every sample
+  and `retain_production_string` heap-copies owner/group/port/circuit for
+  every contribution each time; battery-store contribution collection is
+  similar. Retain strings per topology rebuild, not per sample. The island
+  members string in the account publisher also rebuilds per sample.
+- **String identity -> IDs**: name comparisons should be interned indices or
+  pointers, not string scans. Sites: the `buses` map keyed by string,
+  production owner/group/circuit compares, `circuit_in_island` for
+  production contributions, `attribution.terminal_index` (linear over
+  ports), `is_first_owner_port` (O(ports^2) in the publisher). Island
+  membership for boundary accounts already compares `Bus*` directly; extend
+  the same treatment outward.
+- **Solver rescan**: the fixed point deliberately solves one unknown per
+  pass and rescans all buses and groups each pass, O(unknowns x graph).
+  Fine at current scale; the work-queue formulation (seed, solve, enqueue
+  adjacent constraints) removes the quadratic if large sites appear.
+
+## Out of scope (unchanged)
+
+- A general nonlinear power-flow solver.
+- Fabricating per-port values when several unknowns leave the system
+  underdetermined.
+- Replacing battery store identity/SOC reconciliation.
+- Replacing `DailySnapshot` with database-backed historical queries.


### PR DESCRIPTION
Companion to #443 — merge together.

Three documents:

- **SOURCE_SURVEY.draft.md** — the boundary-edge accounting model specification and the remaining-work log: provenance representation, fault reporting, contact-state seeding (sharpened by review: appliance ports carry contact state too, and an open port is a known zero), link loss providers (until one supplies loss, single-unknown inference manufactures a zero-loss value — bounded error, marked inferred), transfer switches, history retention, and the performance log.
- **ENERGY.draft.md** — the energy design doc rewritten around the implemented boundary model: metering and accounting at boundary edges, diffuse-load sinks, group conservation, accounts as projections.
- **ENERGY_UX_TRANSITION.md** — the frontend migration guide: what moved and what it means, the enumeration surface and labeling strategy, site header stats, the flow-colouring rule, the topology-first network-graph split, schema v2 gating, deprecations, and the migration checklist.
