### PR TITLE
ble: drive client lifecycle through the state machine

### DIFF
--- a/src/driver/baremetal/ble.d
+++ b/src/driver/baremetal/ble.d
@@ -741,8 +741,7 @@ private:
             {
                 // connect attempt failed
                 log.error("connection failed");
-                _queue.complete(cast(ubyte)_pending_connect_tag, MessageState.failed);
-                clear_pending_connect();
+                complete_pending_connect(MessageState.failed);
                 return;
             }
 
@@ -754,10 +753,7 @@ private:
 
                 // dropped while the GATT cache was still warming
                 if (_pending_connect_tag >= 0 && session.peer == _pending_connect_peer)
-                {
-                    _queue.complete(cast(ubyte)_pending_connect_tag, MessageState.failed);
-                    clear_pending_connect();
-                }
+                    complete_pending_connect(MessageState.failed);
 
                 // notify subscribers via disconnect frame
                 Packet p;
@@ -780,6 +776,13 @@ private:
         _pending_connect_peer = MACAddress.init;
     }
 
+    void complete_pending_connect(MessageState state)
+    {
+        ubyte tag = cast(ubyte)_pending_connect_tag;
+        clear_pending_connect();
+        _queue.complete(tag, state);
+    }
+
     void on_discover_complete(BLEConn conn, const(BLEGattChar)[] chars, BLEError error)
     {
         auto session = find_session_by_transport(conn.id);
@@ -792,10 +795,7 @@ private:
         {
             log.error("GATT discovery failed");
             if (pending)
-            {
-                _queue.complete(cast(ubyte)_pending_connect_tag, MessageState.failed);
-                clear_pending_connect();
-            }
+                complete_pending_connect(MessageState.failed);
             session.active = false;
             return;
         }
@@ -821,10 +821,7 @@ private:
         }
 
         if (pending)
-        {
-            _queue.complete(cast(ubyte)_pending_connect_tag, MessageState.complete);
-            clear_pending_connect();
-        }
+            complete_pending_connect(MessageState.complete);
     }
 
     void on_read_complete(BLEConn conn, ushort handle, const(ubyte)[] data, BLEError error)

--- a/src/manager/base.d
+++ b/src/manager/base.d
@@ -567,7 +567,7 @@ nothrow @nogc:
                 return "Destroyed";
             case State.init_failed:
             case State.failure:
-                return "Failed";
+                return _fail_reason ? _fail_reason : "Failed";
             case State.validate:
                 return "Invalid";
             case State.starting:
@@ -696,6 +696,9 @@ protected:
 
     State _state = State.validate;
 
+    // set before returning error from startup(); shown through backoff; must be immortal (string literal)
+    const(char)[] _fail_reason;
+
     final void set_state(State new_state)
     {
         assert(_state != State.destroyed, "Cannot change state of a destroyed object!");
@@ -741,6 +744,7 @@ protected:
 
             case State.starting:
                 _last_init_attempt = getTime();
+                _fail_reason = null;
                 goto do_update;
 
             case State.validate:

--- a/src/protocol/ble/client.d
+++ b/src/protocol/ble/client.d
@@ -178,6 +178,23 @@ nothrow @nogc:
         }
     }
 
+    override const(char)[] status_message() const
+    {
+        if (!_iface || !_iface.running)
+            return "Waiting for BLE interface";
+        if (_connect_handle >= 0)
+            return "Connecting to peer";
+
+        switch (_att_phase)
+        {
+            case ATTPhase.mtu:          return "Negotiating GATT MTU";
+            case ATTPhase.services:     return "Discovering GATT services";
+            case ATTPhase.chars:        return "Discovering GATT characteristics";
+            case ATTPhase.descriptors:  return "Discovering GATT descriptors";
+            default:                    return super.status_message();
+        }
+    }
+
 protected:
 
     override bool validate() const
@@ -193,10 +210,37 @@ protected:
             _iface.subscribe(&iface_state_change);
             _subscribed = true;
         }
+        if (_connect_result >= MessageState.complete)
+        {
+            MessageState r = _connect_result;
+            _connect_result = MessageState.queued;
+            _connect_handle = -1;
+            if (r != MessageState.complete)
+            {
+                log.error("connection to ", _peer, " failed");
+                _fail_reason = "Could not connect to peer";
+                return CompletionStatus.error;
+            }
+            _connected = true;
+            log.info("connected to ", _peer);
+            att_start(_iface.mtu);
+        }
+
+        if (_att_phase == ATTPhase.failed)
+        {
+            _fail_reason = "GATT exchange failed";
+            return CompletionStatus.error;
+        }
         if (_connect_handle >= 0)
             return CompletionStatus.continue_;
         if (_connected)
-            return CompletionStatus.complete;
+        {
+            // discovery is part of bring-up; a failed GATT exchange must back off
+            if (_att_phase == ATTPhase.ready)
+                return CompletionStatus.complete;
+            att_update(getTime());
+            return CompletionStatus.continue_;
+        }
 
         // send connect_ind to the interface
         Packet p;
@@ -211,6 +255,7 @@ protected:
         if (_connect_handle < 0)
         {
             log.error("failed to submit connect request");
+            _fail_reason = "Could not submit connect request";
             return CompletionStatus.error;
         }
 
@@ -226,6 +271,7 @@ protected:
             _iface.abort(_connect_handle);
             _connect_handle = -1;
         }
+        _connect_result = MessageState.queued; // after the abort; its completion records a result
 
         if (_connected)
         {
@@ -251,6 +297,9 @@ protected:
 
     override void update()
     {
+        // retry immediately; a persistent fault fails the next startup and backs off there
+        if (_att_phase == ATTPhase.failed)
+            return restart();
         att_update(getTime());
     }
 
@@ -280,6 +329,7 @@ private:
     MACAddress _peer;
     MACAddress _local_mac;
     int _connect_handle = -1;
+    MessageState _connect_result;   // queued = no result yet
     bool _subscribed;
     bool _connected;
     Array!NotifyHandler _notify_handlers;
@@ -296,24 +346,13 @@ private:
         return _local_mac;
     }
 
+    // may fire inline from forward() or inside the driver's completion sweep; just
+    // record the result, startup() consumes it
     void on_connect_complete(int handle, MessageState state)
     {
-        if (state < MessageState.complete)
+        if (state < MessageState.complete || handle < 0)
             return;
-
-        _connect_handle = -1;
-
-        if (state == MessageState.complete)
-        {
-            _connected = true;
-            log.info("connected to ", _peer);
-            att_start(_iface.mtu);
-        }
-        else
-        {
-            log.error("connection to ", _peer, " failed");
-            restart();
-        }
+        _connect_result = state;
     }
 
     void log_read_response(const(ubyte)[] value, ATTError error)
@@ -522,7 +561,7 @@ private:
         _user_ops.clear();
 
         log.error("ATT failure on connection to ", _peer);
-        restart();
+        // callers are receive handlers; the state machine reacts to ATTPhase.failed
     }
 
     const(GattChar)* find_char_by_handle(ushort value_handle) const


### PR DESCRIPTION
Driver completion callbacks ran inline, mutating client state and calling restart() from inside the interface completion path. Connect results are now recorded and consumed by startup(), and GATT discovery joins bring-up, so a peer that cannot connect or complete the GATT exchange fails from startup() and takes the normal backoff path. Runtime ATT failure restarts and retries immediately; if the fault persists it fails during the next startup.

Startup failure reasons are held on BaseObject, shown through the backoff interval, and cleared on the next attempt. Status messages explain what a latent client is waiting on. Bumps urt for the windows BLE driver fixes this depends on (open-watt/urt#196 -- merge that first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)