### PR TITLE
protobuf: support optional fields and large tags

### DIFF
--- a/src/tools/protobuf/package.d
+++ b/src/tools/protobuf/package.d
@@ -40,18 +40,53 @@ struct FieldInfo
     ushort ty;
 }
 
+enum uint max_field_id = 536_870_911;
+
+struct ProtoOptional(T)
+{
+    bool present;
+    T value;
+
+    ref T ensure() return
+    {
+        present = true;
+        return value;
+    }
+
+    static if (!is(T == struct))
+    {
+        void set(T value)
+        {
+            present = true;
+            this.value = value;
+        }
+    }
+
+    void clear()
+    {
+        present = false;
+        value = T.init;
+    }
+}
 
 size_t buffer_len(T)(ref const T msg) pure nothrow @nogc
 {
-    static assert(is(typeof(T.syntax)) && is(typeof(T.id)), "T must be a protobuf message struct");
+    static assert(is(typeof(T.syntax)), "T must be a protobuf message struct");
     enum pack = T.syntax == 3;
 
     size_t len = 0;
     static foreach (i; 0 .. msg.tupleof.length)
     {{
         enum info = __traits(getAttributes, msg.tupleof[i])[0];
-        // TODO: there are options to pack or not pack per item... (i think?)
-        len += 1 + encode_len!(pack, info.wire)(msg.tupleof[i]);
+        alias Field = typeof(msg.tupleof[i]);
+        enum tag = (ulong(info.id) << 3) | (info.wire & 7);
+        static if (is(Field == ProtoOptional!U, U))
+        {
+            if (msg.tupleof[i].present)
+                len += varint_len(tag) + encode_len!(pack, info.wire)(msg.tupleof[i].value);
+        }
+        else
+            len += varint_len(tag) + encode_len!(pack, info.wire)(msg.tupleof[i]);
     }}
     return len;
 }
@@ -66,8 +101,20 @@ size_t proto_serialise(T)(ubyte[] buffer, ref const T msg) pure nothrow @nogc
     {{
         enum info = __traits(getAttributes, msg.tupleof[i])[0];
         ulong tag = (ulong(info.id) << 3) | (info.wire & 7);
-        offset += put_varint(buffer[offset .. $], tag);
-        offset += buffer[offset .. $].encode_value!(pack, info.wire)(msg.tupleof[i]);
+        alias Field = typeof(msg.tupleof[i]);
+        static if (is(Field == ProtoOptional!U, U))
+        {
+            if (msg.tupleof[i].present)
+            {
+                offset += put_varint(buffer[offset .. $], tag);
+                offset += buffer[offset .. $].encode_value!(pack, info.wire)(msg.tupleof[i].value);
+            }
+        }
+        else
+        {
+            offset += put_varint(buffer[offset .. $], tag);
+            offset += buffer[offset .. $].encode_value!(pack, info.wire)(msg.tupleof[i]);
+        }
     }}
     return offset;
 }
@@ -82,7 +129,10 @@ ptrdiff_t proto_deserialise(T)(const(ubyte)[] buffer, out T msg) nothrow @nogc
     {
         ulong tag;
         offset += buffer[offset..$].get_varint(tag);
-        member: switch (cast(uint)(tag >> 3))
+        ulong field_id = tag >> 3;
+        if (field_id == 0 || field_id > max_field_id)
+            return -1;
+        member: switch (cast(uint)field_id)
         {
             static foreach (i; 0 .. msg.tupleof.length)
             {{
@@ -90,14 +140,20 @@ ptrdiff_t proto_deserialise(T)(const(ubyte)[] buffer, out T msg) nothrow @nogc
                 case info.id:
                     if ((info.wire & 7) != (tag & 7))
                         goto default; // wire type mismatch, skip this field
-                    ptrdiff_t taken = decode_value!(pack, info.wire)(buffer[offset..$], msg.tupleof[i]);
+                    alias Field = typeof(msg.tupleof[i]);
+                    static if (is(Field == ProtoOptional!U, U))
+                    {
+                        msg.tupleof[i].present = true;
+                        ptrdiff_t taken = decode_value!(pack, info.wire)(buffer[offset..$], msg.tupleof[i].value);
+                    }
+                    else
+                        ptrdiff_t taken = decode_value!(pack, info.wire)(buffer[offset..$], msg.tupleof[i]);
                     if (taken < 0)
-                        return -1; // error
+                        return -1;
                     offset += taken;
                     break member;
             }}
             default:
-                // unknown field in the bitstream, skip it...
                 switch (tag & 7)
                 {
                     case WireType.varint:
@@ -114,7 +170,7 @@ ptrdiff_t proto_deserialise(T)(const(ubyte)[] buffer, out T msg) nothrow @nogc
                         offset += 4;
                         break;
                     default:
-                        return -1; // error: unknown wire type
+                        return -1;
                 }
                 break;
         }
@@ -176,7 +232,7 @@ size_t encode_len(bool pack, ubyte ty, T)(auto ref const T value) pure nothrow @
             static if (ty == WireType.zigzag)
                 return varint_len((value << 1) ^ (value >> 63));
             else static if (ty == WireType.fixed64)
-                return 4;
+                return 8;
             else
                 return varint_len(value);
         }
@@ -343,7 +399,10 @@ ptrdiff_t decode_value(bool pack, ubyte ty, T)(const(ubyte)[] buffer, ref T valu
     }
 
     static if (is(T == Array!ubyte))
-        value.extend(len)[] = block[];
+    {
+        value.clear();
+        value.extend(block.length)[] = block[];
+    }
     else static if (is(T == Array!U, U))
     {
         static if (pack)
@@ -378,7 +437,7 @@ ptrdiff_t decode_value(bool pack, ubyte ty, T)(const(ubyte)[] buffer, ref T valu
         {
             static if (ty == WireType.zigzag)
                 value = cast(T)(long(val >> 1) ^ -long(val & 1));
-            else static if (ty == WireType.fixed64)
+            else
                 value = cast(T)cast(long)val;
         }
         else
@@ -438,4 +497,167 @@ size_t get_varint(const(ubyte)[] buffer, out ulong i) pure nothrow @nogc
             return offset;
         shift += 7;
     }
+}
+
+version (unittest)
+{
+    private struct LargeTagMessage
+    {
+        enum syntax = 3;
+        @FieldInfo(16, WireType.varint, 0) uint value;
+    }
+
+    private struct MaxTagMessage
+    {
+        enum syntax = 3;
+        @FieldInfo(max_field_id, WireType.varint, 0) uint value;
+    }
+
+    private struct OptionalIntMessage
+    {
+        enum syntax = 3;
+        @FieldInfo(2, WireType.varint, 0) ProtoOptional!int value;
+    }
+
+    private struct OptionalBytesMessage
+    {
+        enum syntax = 3;
+        @FieldInfo(3, WireType.length_delimited, 0) ProtoOptional!(Array!ubyte) value;
+    }
+
+    private struct NestedMessage
+    {
+        enum syntax = 3;
+        this(this) @disable;
+        @FieldInfo(1, WireType.varint, 0) uint value;
+    }
+
+    private struct OptionalMessage
+    {
+        enum syntax = 3;
+        @FieldInfo(4, WireType.length_delimited, 0) ProtoOptional!NestedMessage value;
+    }
+
+    private struct BytesMessage
+    {
+        enum syntax = 3;
+        @FieldInfo(1, WireType.length_delimited, 0) Array!ubyte value;
+    }
+
+    private struct Int64Message
+    {
+        enum syntax = 3;
+        @FieldInfo(1, WireType.varint, 0) long value;
+    }
+
+    private struct SFixed64Message
+    {
+        enum syntax = 3;
+        @FieldInfo(1, WireType.fixed64, 0) long value;
+    }
+}
+
+unittest
+{
+    LargeTagMessage large_tag;
+    large_tag.value = 150;
+    ubyte[4] large_tag_wire;
+    assert(buffer_len(large_tag) == large_tag_wire.length);
+    assert(proto_serialise(large_tag_wire[], large_tag) == large_tag_wire.length);
+    ubyte[4] expected_large_tag_wire = [0x80, 0x01, 0x96, 0x01];
+    assert(large_tag_wire == expected_large_tag_wire);
+
+    MaxTagMessage max_tag;
+    max_tag.value = 1;
+    ubyte[6] max_tag_wire;
+    assert(buffer_len(max_tag) == max_tag_wire.length);
+    assert(proto_serialise(max_tag_wire[], max_tag) == max_tag_wire.length);
+    ubyte[6] expected_max_tag_wire = [0xF8, 0xFF, 0xFF, 0xFF, 0x0F, 0x01];
+    assert(max_tag_wire == expected_max_tag_wire);
+
+    ubyte[2] zero_tag_wire = [0x00, 0x01];
+    LargeTagMessage invalid_tag;
+    assert(proto_deserialise(zero_tag_wire[], invalid_tag) == -1);
+    ubyte[6] oversized_tag_wire = [0x80, 0x80, 0x80, 0x80, 0x10, 0x01];
+    assert(proto_deserialise(oversized_tag_wire[], invalid_tag) == -1);
+
+    OptionalIntMessage optional;
+    ubyte[2] optional_wire;
+    assert(buffer_len(optional) == 0);
+    assert(proto_serialise(optional_wire[], optional) == 0);
+    optional.value.set(0);
+    assert(buffer_len(optional) == optional_wire.length);
+    assert(proto_serialise(optional_wire[], optional) == optional_wire.length);
+    ubyte[2] expected_optional_wire = [0x10, 0x00];
+    assert(optional_wire == expected_optional_wire);
+
+    OptionalIntMessage decoded_optional;
+    assert(proto_deserialise(optional_wire[], decoded_optional) == optional_wire.length);
+    assert(decoded_optional.value.present);
+    assert(decoded_optional.value.value == 0);
+    decoded_optional.value.clear();
+    assert(!decoded_optional.value.present);
+    assert(decoded_optional.value.value == 0);
+
+    OptionalBytesMessage optional_bytes;
+    ubyte[2] optional_bytes_value = [0xAA, 0xBB];
+    optional_bytes.value.ensure().extend(2)[] = optional_bytes_value[];
+    ubyte[4] optional_bytes_wire;
+    assert(buffer_len(optional_bytes) == optional_bytes_wire.length);
+    assert(proto_serialise(optional_bytes_wire[], optional_bytes) == optional_bytes_wire.length);
+    ubyte[4] expected_optional_bytes_wire = [0x1A, 0x02, 0xAA, 0xBB];
+    assert(optional_bytes_wire == expected_optional_bytes_wire);
+    OptionalBytesMessage decoded_optional_bytes;
+    assert(proto_deserialise(optional_bytes_wire[], decoded_optional_bytes) == optional_bytes_wire.length);
+    assert(decoded_optional_bytes.value.present);
+    assert(decoded_optional_bytes.value.value[] == optional_bytes_value[]);
+
+    OptionalMessage optional_message;
+    optional_message.value.ensure().value = 7;
+    ubyte[4] optional_message_wire;
+    assert(buffer_len(optional_message) == optional_message_wire.length);
+    assert(proto_serialise(optional_message_wire[], optional_message) == optional_message_wire.length);
+    ubyte[4] expected_optional_message_wire = [0x22, 0x02, 0x08, 0x07];
+    assert(optional_message_wire == expected_optional_message_wire);
+    OptionalMessage decoded_optional_message;
+    assert(proto_deserialise(optional_message_wire[], decoded_optional_message) == optional_message_wire.length);
+    assert(decoded_optional_message.value.present);
+    assert(decoded_optional_message.value.value.value == 7);
+    decoded_optional_message.value.clear();
+    assert(!decoded_optional_message.value.present);
+    assert(decoded_optional_message.value.value.value == 0);
+
+    ubyte[8] bytes_wire = [0x0A, 0x03, 0x01, 0x02, 0x03, 0x0A, 0x01, 0x09];
+    BytesMessage decoded_bytes;
+    assert(proto_deserialise(bytes_wire[], decoded_bytes) == bytes_wire.length);
+    ubyte[1] expected_bytes = [0x09];
+    assert(decoded_bytes.value[] == expected_bytes[]);
+
+    Int64Message int64_message;
+    int64_message.value = -2;
+    ubyte[11] int64_wire;
+    assert(buffer_len(int64_message) == int64_wire.length);
+    assert(proto_serialise(int64_wire[], int64_message) == int64_wire.length);
+    ubyte[11] expected_int64_wire = [
+        0x08, 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0x01
+    ];
+    assert(int64_wire == expected_int64_wire);
+    Int64Message decoded_int64;
+    assert(proto_deserialise(int64_wire[], decoded_int64) == int64_wire.length);
+    assert(decoded_int64.value == -2);
+
+    SFixed64Message sfixed64_message;
+    sfixed64_message.value = -2;
+    ubyte[9] sfixed64_wire;
+    assert(buffer_len(sfixed64_message) == sfixed64_wire.length);
+    assert(proto_serialise(sfixed64_wire[], sfixed64_message) == sfixed64_wire.length);
+    ubyte[9] expected_sfixed64_wire = [
+        0x09, 0xFE, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF
+    ];
+    assert(sfixed64_wire == expected_sfixed64_wire);
+    SFixed64Message decoded_sfixed64;
+    assert(proto_deserialise(sfixed64_wire[], decoded_sfixed64) == sfixed64_wire.length);
+    assert(decoded_sfixed64.value == -2);
 }

--- a/src/tools/protobuf/parse.d
+++ b/src/tools/protobuf/parse.d
@@ -5,10 +5,7 @@ import urt.array;
 import urt.string;
 import urt.conv;
 
-
-// this is all designed to run as CTFE
-// we should confirm there are no relics from this code in any output binary...
-
+// This parser is designed to run as CTFE.
 
 alias ImportHandler = string delegate(string filename);
 
@@ -69,7 +66,7 @@ struct ProtoField
     bool repeated;
     bool optional;
     ubyte reserved;
-    ubyte id;
+    uint id;
     ubyte wire_type;
     ushort logical_type;
 }
@@ -104,9 +101,6 @@ ProtoSpec load_proto(const(char)[] path, const(char)[] filename) nothrow
     assert(file, "Failed to load proto file: " ~ path ~ filename);
     scope(exit) { defaultAllocator.free(file); }
     return parse_proto(cast(string)file, null);
-//    return (cast(string)file, (string import_file) {
-//        return cast(string)load_file(path ~ import_file, defaultAllocator);
-//    });
 }
 
 ProtoSpec parse_proto(string data, ImportHandler import_handler) nothrow
@@ -115,13 +109,8 @@ ProtoSpec parse_proto(string data, ImportHandler import_handler) nothrow
     try
         parse(proto, data, import_handler);
     catch (Exception e)
-    {
-        // parse error!
-        // TODO: complain
         assert(false, "Failed to parse proto: " ~ e.msg);
-    }
 
-    // now in a second pass, we'll hook up the type names
     foreach (ref msg; proto.messages)
     {
     outer: foreach (ref f; msg.fields)
@@ -142,7 +131,7 @@ ProtoSpec parse_proto(string data, ImportHandler import_handler) nothrow
             if (e.name == f.type)
             {
                 f.wire_type = WireType.varint;
-                f.logical_type = LogicalType.enum_;// | (i << 4);
+                f.logical_type = LogicalType.enum_;
                 continue outer;
             }
         }
@@ -258,8 +247,9 @@ ProtoMessage parse_message(ref string data)
     data.expect('{');
     while (!data.check('}'))
     {
-        try r.opts ~= data.parse_option(true);
-        catch (WrongItem e)
+        if (data.starts_with_keyword("option", true))
+            r.opts ~= data.parse_option(true);
+        else
             r.fields ~= data.parse_field();
     }
     return r;
@@ -307,7 +297,7 @@ ProtoOption parse_option(ref string data, bool statement)
     if (statement)
     {
         data.seek_next_token();
-        if (!data.startsWith("option"))
+        if (!data.starts_with_keyword("option", true))
             throw new WrongItem("Expected 'option'");
         data = data[6..$];
     }
@@ -355,7 +345,10 @@ ProtoField parse_field(ref string data)
         r.type = data.take_identifier();
         r.name = data.take_identifier();
         data.expect('=');
-        r.id = cast(ubyte)data.take_int();
+        long id = data.take_int();
+        if (!valid_field_id(id))
+            throw new Exception("Invalid field number");
+        r.id = cast(uint)id;
         if (data.check('['))
         {
             bool first = true;
@@ -373,6 +366,9 @@ ProtoField parse_field(ref string data)
     return r;
 }
 
+private bool valid_field_id(long id) pure nothrow @nogc
+    => id >= 1 && id <= max_field_id && (id < 19_000 || id > 19_999);
+
 ProtoValue parse_value(ref string data)
 {
     data.seek_next_token();
@@ -380,7 +376,6 @@ ProtoValue parse_value(ref string data)
         throw new Exception("Unexpected end of input");
     if (data[0] == '+' || data[0] == '-' || data[0].is_numeric)
     {
-        // number
         size_t i = 0;
         if (data[0] == '+' || data[0] == '-')
             ++i;
@@ -443,6 +438,17 @@ void seek_next_token(ref string data)
         else
             break;
     }
+}
+
+private bool starts_with_keyword(string data, string keyword, bool allow_parenthesis = false)
+{
+    data.seek_next_token();
+    if (!data.startsWith(keyword))
+        return false;
+    if (data.length == keyword.length)
+        return true;
+    char next = data[keyword.length];
+    return next.is_whitespace || (allow_parenthesis && next == '(');
 }
 
 void expect_whitespace(ref string data)
@@ -532,9 +538,6 @@ string take_identifier(ref string data)
     }
     return data.takeFront(i);
 }
-
-
-// synthesise D enums and structs...
 
 string generate_enum(ref const ProtoEnum e)
 {
@@ -654,12 +657,43 @@ enum string[] type_names = [
 string make_type_for(ref const ProtoField field)
 {
     ubyte logical_type = field.logical_type & 0xF;
+    string type_name;
     if (logical_type == LogicalType.enum_)
-        return field.type;
+        type_name = field.type;
     else if (logical_type == LogicalType.message)
-        return field.type;
-    string type_name = type_names[logical_type];
-    if (field.repeated)
-        return logical_type == LogicalType.bytes ? "Array!(Array!ubyte)" : "Array!" ~ type_name;
+        type_name = field.type;
+    else
+    {
+        type_name = type_names[logical_type];
+        if (field.repeated)
+            type_name = logical_type == LogicalType.bytes ? "Array!(Array!ubyte)" : "Array!" ~ type_name;
+    }
+    if (field.optional)
+        type_name = "ProtoOptional!(" ~ type_name ~ ")";
     return type_name;
+}
+
+version (unittest)
+{
+    static assert("option (id) = 1;".starts_with_keyword("option", true));
+    static assert(!"optional int64 count = 16;".starts_with_keyword("option", true));
+
+    static assert(() {
+        string data = "optional int64 count = 16;";
+        ProtoField field = data.parse_field();
+        field.logical_type = LogicalType.int64;
+        return field.optional
+            && field.id == 16
+            && field.make_type_for() == "ProtoOptional!(long)";
+    }());
+
+    static assert(!valid_field_id(0));
+    static assert(!valid_field_id(-1));
+    static assert(!valid_field_id(19_000));
+    static assert(!valid_field_id(19_999));
+    static assert(!valid_field_id(536_870_912));
+    static assert(valid_field_id(1));
+    static assert(valid_field_id(18_999));
+    static assert(valid_field_id(20_000));
+    static assert(valid_field_id(536_870_911));
 }


### PR DESCRIPTION
Generate presence-tracking wrappers for explicit optional fields and encode field keys at their actual varint length. Validate schema and wire field numbers across the full protobuf range.

Add exact-wire coverage for optional scalars, bytes and messages, large tags, and the repaired bytes, int64 and sfixed64 codec paths.