### PR TITLE
Unify series residency: buckets span RAM and disk

### DIFF
--- a/docs/SERIES_RESIDENCY.draft.md
+++ b/docs/SERIES_RESIDENCY.draft.md
@@ -1,0 +1,239 @@
+# Series residency: one block chain, three residencies
+
+Design spec drafted 2026-08-05. Not implemented. Supersedes the RAM/disk split described
+in [manager/record.d](../src/manager/record.d)'s header and the two-tier merge in `query_local`.
+
+The thesis: **RAM and disk are not two tiers of a series, they are two residencies of the same
+block.** Today they are separate structures with separate owners, separate readers, and
+separate history depth, and every consumer has to know which one it is talking to. Unifying
+them deletes the two-tier merge, makes cursors reach disk, ends the backfill truncation, and
+turns retention from "how much history exists" into "how much stays resident".
+
+## 1. Where we are
+
+Both tiers are already an ordered array of block descriptors:
+
+- **RAM**: `SeriesStore.buckets` is `Array!(Bucket*)`, ordered by `first_index`, binary-searched
+  by index or time.
+- **Disk**: ows is a doubly-linked chain *in the file*, but `SeriesContainer.open_()` walks it
+  once and builds `Array!BlockEntry`. The chain is a file-layout detail, not a data structure.
+
+The differences that matter are ownership and reach:
+
+| | RAM | Disk |
+|---|---|---|
+| Owner | `Element._history` | `RecordStream.container` (recorder-owned) |
+| Format | element-global, from the caller | per block, format runs with anchors |
+| Reachable from | `Cursor`, `read_records`, `index_for_time` | `query_local` only |
+| Eviction | destroys records, advances `first_index` | never pruned |
+
+`Element` holds no container reference, so everything reached through an Element API is
+RAM-only by construction. Only code holding a `RecordStream` can see disk.
+
+### Consequences we are living with
+
+- **`send_backfill` does not honour its range.** It takes `from_ms` but resolves it through
+  `index_for_time`, which clamps to `buckets[0].first_index`. A peer asking for 24h of a 1h-retained
+  element silently receives 1h, with no truncation marker on the wire. The forward edge is exact
+  (`track_live` records `record_count`, backfill runs to head, one synchronous burst, gap-free);
+  only the backward edge is undefined. This is documented as deliberate at
+  [sync/package.d:1668](../src/manager/sync/package.d#L1668) - deep recall was routed to
+  `history_req` "until cursor-paced draining lands".
+- **`history_req` is therefore load-bearing, not legacy.** It is the only path that reads disk.
+  It cannot be deleted before a tier-spanning reader exists.
+- **Format changes silently reinterpret retained history.** `Bucket` carries no `FormatId`;
+  `SeriesStore.read` takes it from the caller, which passes `element.format` - i.e. whatever it
+  is *now*. `writable_bucket` rolls on capacity, gap and tick overflow, never on format.
+  `SeriesEvent.format_change` is declared and never fired. Same stride gives wrong values; a
+  different stride misaligns reads and makes `drop_raw` free a wrong-sized allocation.
+  `set_format` was elided from the original design pass and never built. ows got this right
+  from day one (anchor blocks, `format_block`, per-block `load`); the RAM store never caught up.
+- **Deep reads block the main loop.** `container.load()` is a synchronous `read_at` per block.
+  A 24h window on a fast element is ~845 blocking SD reads inside a console command or a sync
+  request. The async machinery that once covered this belonged to the deleted db engine.
+- **No open-fd cap.** The db engine had an LRU (`max_open = 2048`); `SeriesContainer` opens its
+  file on first flush and holds it for the life of the stream. One permanently-open fd per
+  recorded element, uncapped.
+
+## 2. Target model
+
+`Bucket` becomes the single entry, with residency as a property rather than a location:
+
+| `raw` | `packed` | backing | meaning |
+|---|---|---|---|
+| set | null | - | open tail, or sealed and never packed |
+| set | set | - | packed, raw retained as a cache (a reader holds it, or budget allows) |
+| null | set | - | packed, resident |
+| null | null | file offset | flushed and evicted; recoverable |
+| null | null | none | gone (unrecorded element, or no container) |
+
+`reconstitute()` gains a disk arm beside its unpack arm. Everything downstream is untouched:
+same refcount, same `drop_raw` on the 0-edge, same sharing of one decoded image through the entry.
+
+### What this buys
+
+- **Cursors span tiers with no new API.** `SeriesStore.read()` already calls `reconstitute(b)`
+  when `!b.samples`. A cursor pulling 256 records touches one block, so reads are *naturally
+  paced* by consumption - this is the "cursor-paced draining" the sync comment defers to, and it
+  bounds per-tick work in a way `query_local`'s 845-block walk never did.
+- **`query_local`'s two-tier merge deletes entirely** - the container walk, the `ram_start`
+  splice, the ordering logic. It becomes "seek by time, read blocks".
+- **`send_backfill` stops lying** without being touched, because `index_for_time` and
+  `read_records` reach disk.
+- **Retention changes axis, correctly.** Evicting a flushed bucket drops its bytes and keeps its
+  descriptor; `first_index` does not advance. Retention becomes a memory budget, not a statement
+  about what history exists.
+
+## 3. Required changes
+
+1. **`Bucket` carries `FormatId`.** Stamped at creation from the element's current format.
+   `writable_bucket` adds a format-mismatch roll. `read`/`try_pack`/`reconstitute`/`drop_raw`/
+   `seal`/`free_bucket`/`tail_record`/`text_value` take the format from the bucket, not the caller.
+   `SeriesEvent.format_change` gets fired. **This is a live bug fix and stands on its own** - do it
+   first, independently of the rest.
+
+   This is also the field that makes the two descriptors converge: ows's `BlockEntry` already
+   carries its format (`BlockFormatHeader fmt`, resolved per entry at walk time), and `Bucket`
+   does not. With it, a bucket is fully self-describing - format, span, and one residency - which
+   is the precondition for interpreting a packed or disk-resident block without asking the element.
+
+2. **Raw becomes one `void[]` when sealed.** Today `raw` is three independent allocations
+   (`samples`, `offsets`, `heap`, each with its own capacity) *or* one combined allocation, with
+   `raw_combined` discriminating - two memory layouts for the same state. Split it by lifecycle
+   instead: an **open** bucket is a builder whose planes grow independently; a **sealed** bucket is
+   one immutable image in `[offsets | records | heap]` order. `raw_combined` then disappears,
+   because sealed implies combined, and `raw`/`packed` become symmetric `void[]` alternatives.
+   Three things fall out: `try_pack` loses its scratch copy (it currently memcpys three planes into
+   an image that `seal` could have left behind), `SeriesContainer.put` loses its marshalling
+   (the image order is already byte-identical to the ows payload, so a flush becomes a straight
+   write of `b.raw`), and the residency states end up on equal footing rather than one of them
+   needing a shape flag.
+
+3. **`Bucket` carries its file offset.** One `ulong file_offset` (0 = never flushed; 0 is the
+   `FileHeader` position and never a block start, which is the sentinel ows already uses for
+   `next`/`prev`/`format_block`). The read size is `packed_bytes`, which needs no new field:
+   `packed` and `file_offset` are two *locations of the same encoded image*, so the size describes
+   it in either place. Nothing else is needed - the chain links (`next`/`prev`) exist so the file
+   can be walked without an index, and the RAM array is that index; the format-anchor pointer is
+   resolved at open and collapses into the bucket's own `FormatId`. That leaves `Bucket` and
+   `BlockEntry` differing only by the file-walk artifacts RAM doesn't need.
+
+4. **Ownership inverts.** The store gains the backing handle; the recorder demotes from owner of
+   the file to the thing that drives flushing. A series becomes RAM-and-disk rather than RAM plus
+   a separate recorder-owned file.
+5. **Index continuity.** On open, `head` resumes from the container's `last_index + 1`. Today RAM
+   restarts at 0 while the file holds 0..N, which is harmless only because `query_local` seeks by
+   time. Under one sequence it is mandatory, and it makes the file's index space meaningful again.
+6. **Eviction distinguishes flushed from gone.** With a container, eviction drops bytes and keeps
+   the descriptor. Without one, it destroys as today.
+7. **Reconstituted blocks may predate a format change** - which is why (1) is a prerequisite, not a
+   consequence.
+
+### Restart is not a special case
+
+On open, walk the chain and build one `Bucket` per block in the fully-evicted state
+(`raw == packed == null`, `file_offset` set). Everything but the residency pointers comes from
+the headers: `first_index`/`count` from the index span, `first_tick`/`last_offset` from the tick
+span, `heap_used` from `heap_bytes`, `codec` and `packed_bytes` directly, offsets-plane presence
+from `flags.irregular`, and `FormatId` from the resolved anchor run. `capacity` is meaningless
+until something reconstitutes and fills in there. `head` resumes at the last block's
+`last_index + 1`.
+
+There is then no load path and no restart branch - a cursor opened at index 0 walks all of
+recorded history through the same `reconstitute` that serves a packed block.
+
+**`SeriesContainer.dir` deletes with it.** Headers are unpacked into buckets at open and the
+`Array!BlockEntry` never exists; the bucket array *is* the directory. `find_by_time` collapses
+into the store's existing one, and `load(i)` becomes a byte read at an offset. What remains of
+the container is the write side and nothing else: the `File`, the append position, the tail offset
+for patching `next`, and the current format-run anchor - and even the anchor is derivable from the
+previous bucket's format, so caching it is an optimisation rather than state. The container demotes
+from an indexed store to a block reader/writer over a file, and indexing lives in exactly one place.
+
+Note this does not change the descriptor *count*: today the container's directory already covers
+every block in the file while the RAM buckets cover only the retained window, and the two sets are
+disjoint. Unification spans both with one array of the same total size - neutral on memory, but see
+the limit below.
+
+### Known limit: the directory is O(blocks in file)
+
+This merges two directories into one rather than adding a third - ows already builds a
+`BlockEntry` (104 bytes) per block for the whole file at open, so the cost exists today. But it
+is not free, and it becomes the binding constraint as files age: a 1s element is ~337 blocks/day,
+so ~123k blocks and ~12MB of descriptors per element-year. Thousands of recorded elements on a Pi
+will not hold. Mitigations, when it bites: index every Nth block and chain-walk within a span, or
+write a footer index so open does not walk at all. Worth deciding before long-lived files exist
+rather than after.
+
+## 4. Retention: existence vs residency
+
+Today `SeriesStore`'s `min_records`/`max_records`/`min_age`/`max_age` conflate two questions,
+because with one copy of the data they were the same question. With a backing store they split:
+
+- **Existence (disk retention)**: how far back history goes. Currently unimplemented - ows files
+  grow forever.
+- **Residency (memory retention)**: how much is decoded in RAM. This is what the current fields
+  become.
+
+Buckets fall into three classes, and only the third is a cache:
+
+| class | evictable | why |
+|---|---|---|
+| open tail | never | appended to; `latest`/`tail_record` read from it |
+| sealed, unflushed | no - eviction *destroys* | the only copy; the recorder's pin holds it until flushed |
+| flushed (`file_offset != 0`) | yes, whenever `refs == 0` | recoverable with one read |
+
+So **retention policy only matters where there is no backing store.** For a recorded element,
+residency becomes a global budget rather than a per-element policy - which is the better model,
+since per-element record counts are a poor proxy for a shared resource. (`SeriesStore`'s
+`// TODO: byte budgets` says as much; note its `== records * stride` parenthetical went stale when
+the text heap landed - a byte budget must count heap bytes too.) For an unrecorded element the
+existing floors and ceilings still govern existence, unchanged.
+
+Pins keep their meaning but narrow to two jobs: protecting a raw-side borrow (memory safety) and
+holding unflushed data until the recorder consumes it (durability). They stop being a statement
+about how much history exists.
+
+**Disk retention needs a decision, not just an implementation.** The doubly-linked chain supports
+front-pruning - repoint the new head's `prev` and the `FileHeader`'s first-block offset - but that
+orphans space and needs a free-space story. File rotation by time span, deleting whole files, is
+the simpler answer and composes with the file-per-device direction. Recommend rotation, but it is
+a genuine fork.
+
+## 5. What falls out afterwards
+
+Sequenced, because order matters:
+
+1. Bucket-local format (above) - independent, do now.
+2. Unified residency + paced cursor reads.
+3. `send_backfill` serves deep recall through it, and reports its served range so truncation is
+   never silent.
+4. `history_req` and `encode_history` die. `Sample`, `QueryMode`, `SampleAggregator` and
+   `GraphIntervalSampler` **demote** rather than disappear - `/record/graph` renders to a fixed
+   terminal width and legitimately needs doubles and bucketing, so they become private types of
+   the console chart renderer instead of a query/protocol boundary.
+
+Note step 4 is client-visible: it needs a `docs/UX_TODO.md` entry and coordinated web/droid
+updates.
+
+## 6. Deliberately out of scope
+
+- **Decimation ladder.** Server-side reduction that reads a *coarse tier* rather than reducing
+  raw. Note what today's path does and does not do: `query_local` reads every raw record in the
+  window and *then* buckets, so it bounds the wire, never the read. It is a response cap, not
+  decimation, and it reserves nothing for the ladder.
+- **fd cap.** ~40 lines when wanted: `SeriesContainer.close_file()` dropping `_file` while keeping
+  `dir`/`_tail`/`_end`/`_fmt_anchor`, plus a cap and an intrusive LRU on the recorder, which
+  already owns every stream centrally. Held off because file-per-device would change the shape.
+- **File-per-device and multi-channel series.** Two separable wins that are easy to conflate.
+  File-per-device is a *container* concern (a series id in `BlockHeader`, per-series directories
+  within one chain) and buys fds only. Shared timestamp planes and cross-channel predictive coding
+  are a *series* concern, and the model already has the vocabulary for it - the value-shapes table's
+  "composite / multi-channel" row, one series with a compound record and columnar planes. The
+  distinction: genuinely simultaneous observation (one Modbus response, one CAN frame, one ADC
+  conversion) should be one multi-channel series, because the timestamp is shared for a physical
+  reason. Merely co-located elements may share a *file* but sharing a timestamp plane would be a
+  lie. Multi-channel is the bigger win but needs `Element` to become a `(series, channel)`
+  projection rather than the owner of `_history`.
+- **Element destruction.** Durable holders keep raw `Element*`; see the
+  [manager/element.d](../src/manager/element.d) header for the constraint.

--- a/docs/SOURCE_SURVEY.draft.md
+++ b/docs/SOURCE_SURVEY.draft.md
@@ -169,12 +169,12 @@ captured series to ~400.
 Delivery is already built: the sync/websocket protocol carries
 `history_req` / `history` frames (`inbound_history_req` in
 [../src/manager/sync/package.d](../src/manager/sync/package.d)), answered
-synchronously from RAM buckets plus the `.owsig` container. Console
+synchronously from RAM buckets plus the `.ows` container. Console
 `/record/query` and `/record/graph` serve from the same local path.
 
 Remaining:
 
-- **Container retention/rotation**: `.owsig` files grow without bound.
+- **Container retention/rotation**: `.ows` files grow without bound.
   Needs a size/age budget per series or per recorder. This is now the only
   thing between the current state and leaving recording on indefinitely.
 - **Class-specific retention**: the short class (budget, allocations) wants

--- a/docs/SYNC_PROTOCOL.draft.md
+++ b/docs/SYNC_PROTOCOL.draft.md
@@ -13,7 +13,7 @@ synchronously within the burst, which is gapless because nothing interleaves; cu
 when transports grow backpressure). The `detach_peer` defect below is fixed. Deviations and
 deferrals are recorded in the commit messages on the way past; the notable ones:
 
-- Formats failing `owsig.container_serialisable` (including text) are skipped from the model
+- Formats failing `ows.container_serialisable` (including text) are skipped from the model
   surface with a log, not answered with `err` -- per-node errors inside a glob burst were
   unresolved.
 - Constraint min/max/step do not ride the `type` format block yet; the element write path does
@@ -242,7 +242,7 @@ the format block; their source comment already declares the intent
 
 Formats with no wire representation (user types pending name binding, domain-clocked series
 pending clock anchors) are declined with `err {code:"unserialisable"}` -- shared verdict with
-[`owsig.container_serialisable()`](../src/manager/owsig.d#L50), not a second opinion.
+[`ows.container_serialisable()`](../src/manager/ows.d#L50), not a second opinion.
 
 ### 5. `add` -- `{h, path, class, ft|sig, access?, mode?, v?, t?}`
 

--- a/openwatt.vcxproj
+++ b/openwatt.vcxproj
@@ -135,7 +135,7 @@
     <DCompile Include="src\manager\features.d" />
     <DCompile Include="src\manager\id.d" />
     <DCompile Include="src\manager\log.d" />
-    <DCompile Include="src\manager\owsig.d" />
+    <DCompile Include="src\manager\ows.d" />
     <DCompile Include="src\manager\package.d" />
     <DCompile Include="src\manager\path.d" />
     <DCompile Include="src\manager\plugin.d" />

--- a/openwatt.vcxproj.filters
+++ b/openwatt.vcxproj.filters
@@ -396,7 +396,7 @@
     <DCompile Include="src\manager\series.d">
       <Filter>src\manager</Filter>
     </DCompile>
-    <DCompile Include="src\manager\owsig.d">
+    <DCompile Include="src\manager\ows.d">
       <Filter>src\manager</Filter>
     </DCompile>
     <DCompile Include="src\manager\package.d">

--- a/src/manager/element.d
+++ b/src/manager/element.d
@@ -178,16 +178,12 @@ nothrow @nogc:
     RecordBlock next(uint max_records)
     {
         SeriesStore* h = element._history;
-        ulong first = h.first_index;
-        ulong lost = 0;
-        if (position < first)
-        {
-            lost = first - position;
-            position = first;
-        }
         RecordBlock r = h.read(element.format, position, max_records, bit);
-        r.lost = lost;
-        position += r.count;
+        if (r.count)
+        {
+            r.lost = r.first_index - position;  // records evicted or destroyed below the block
+            position = r.first_index + r.count;
+        }
         if (h.pin_mask & (1 << bit))
             h.pin_position[bit] = position;
         return r;
@@ -476,7 +472,7 @@ public:
         if (!_history || !_history.buckets.length)
             return null;
         const(Bucket)* b = _history.buckets[$-1];
-        if (!b.count)
+        if (!b.count || !b.samples)
             return null;
         return cast(const(char)[])heap_view(b.heap, (cast(const(ushort)*)b.samples)[b.count - 1]);
     }
@@ -487,9 +483,10 @@ public:
         if (!_history || !_history.buckets.length)
             return null;
         const(Bucket)* b = _history.buckets[$-1];
-        if (!b.count)
+        if (!b.count || !b.samples)
             return null;
-        return (cast(const(ubyte)*)b.samples)[(b.count - 1) * data_format.stride .. b.count * data_format.stride];
+        ubyte stride = format_info(b.format).stride;
+        return (cast(const(ubyte)*)b.samples)[(b.count - 1) * stride .. b.count * stride];
     }
 
     void store_sample(T)(T v, SysTime t = getSysTime(), Subscriber who = null)
@@ -705,9 +702,9 @@ public:
             if (Bucket* rb = _history.cursor_ref[c.bit])
             {
                 _history.cursor_ref[c.bit] = null;
-                _history.release_ref(rb, format);
+                _history.release_ref(rb);
             }
-            _history.drop_loose_raws(format);
+            _history.drop_loose_raws();
             _history.cursor_mask &= ~cast(ushort)(1 << c.bit);
             _history.pin_mask &= ~cast(ushort)(1 << c.bit);
         }
@@ -728,7 +725,7 @@ public:
         if (_history)
         {
             foreach (b; _history.buckets)
-                free_bucket(b);
+                _history.free_bucket(b);
             destroy!false(*_history);
             free((cast(void*)_history)[0 .. SeriesStore.sizeof]);
             _history = null;
@@ -871,6 +868,7 @@ private:
                 h.buckets ~= b;
                 h.head = 1;
             }
+            b.format = format;
             b.heap_used = 0;
             uint entry = add_heap_entry(*b, v);
             (cast(ushort*)b.samples)[0] = cast(ushort)entry;
@@ -886,7 +884,8 @@ private:
         uint entry = uint.max;
         if (b)
         {
-            bool roll = b.count + 1 > b.capacity || follows_gap
+            bool format_changed = b.format != format;
+            bool roll = b.count + 1 > b.capacity || follows_gap || format_changed
                      || (b.count && tick - b.first_tick > uint.max);
             if (!roll)
             {
@@ -896,7 +895,9 @@ private:
             }
             if (roll)
             {
-                seal(b);
+                retire_tail(b);
+                if (format_changed)
+                    fire_format_change();
                 b = null;
                 entry = uint.max;
             }
@@ -1038,10 +1039,15 @@ private:
         // roll when the new block's offset from this bucket's base would exceed the uint offset field:
         // a slow stream spanning >~71 min at 1 MHz, or a base discontinuity that would underflow it
         bool overflow = b && b.offsets && b.count && max_tick - b.first_tick > uint.max;
-        if (!b || b.count + n > b.capacity || follows_gap || overflow)
+        bool format_changed = b && b.format != format;
+        if (!b || b.count + n > b.capacity || follows_gap || overflow || format_changed)
         {
             if (b)
-                seal(b);
+            {
+                retire_tail(b);
+                if (format_changed)
+                    fire_format_change();
+            }
             b = alloc_bucket(n > bucket_capacity ? n : bucket_capacity);
             b.first_index = _history.head;
             b.follows_gap = follows_gap;
@@ -1050,27 +1056,33 @@ private:
         return b;
     }
 
-    void seal(Bucket* b)
+    // roll the tail out of the write path: a non-empty tail seals, an empty one is recycled
+    // so sealed buckets always carry records
+    void retire_tail(Bucket* b)
     {
-        if (b.sealed)
-            return;
-        b.sealed = true;
-        if (b.count && b.count < b.capacity)
+        debug assert(_history.buckets.length && _history.buckets[$-1] is b);
+        if (b.count || b.sealed)
+            _history.seal(b);
+        else
         {
-            b.samples = realloc(b.samples[0 .. b.capacity * data_format.stride], b.count * data_format.stride).ptr;
-            if (b.offsets)
-                b.offsets = cast(uint*)realloc((cast(void*)b.offsets)[0 .. b.capacity * uint.sizeof], b.count * uint.sizeof).ptr;
-            b.capacity = b.count;
+            _history.free_bucket(b);
+            _history.buckets.popBack();
         }
-        if (b.heap && b.heap_used < b.heap_capacity)
-        {
-            b.heap = realloc(b.heap[0 .. b.heap_capacity], b.heap_used).ptr;
-            b.heap_capacity = b.heap_used;
-        }
-        // pack now if nothing borrows the raw side; otherwise the last release_ref packs
-        _history.try_pack(b, format);
     }
 
+    void fire_format_change()
+    {
+        SampleUpdate update;
+        update.element = &this;
+        update.event = SeriesEvent.format_change;
+        update.timestamp = _last_update;
+        submit(update, false);
+    }
+
+    // Retention splits by residency: a flushed bucket's eviction drops its bytes and keeps
+    // the descriptor (recoverable through the container), so the policy governs what stays
+    // decoded in RAM. Where there is no backing copy, eviction destroys, exactly as before;
+    // under a container, unflushed sealed buckets are held for the recorder.
     void evict_over_budget()
     {
         SeriesStore* h = _history;
@@ -1081,9 +1093,17 @@ private:
         ulong min_age_ticks = h.min_age ? to_ticks(h.min_age) : 0;
         ulong max_age_ticks = h.max_age ? to_ticks(h.max_age) : 0;
         ulong floor = h.pin_floor;
-        while (h.buckets.length > 1)
+        for (size_t i = 0; i + 1 < h.buckets.length; )
         {
-            Bucket* front = h.buckets[0];
+            Bucket* front = h.buckets[i];
+            bool flushed = front.file_offset != 0;
+            if (flushed && !front.resident)
+            {
+                ++i;
+                continue;
+            }
+            if (!front.sealed)
+                break;
             ulong newest = h.buckets[$-1].last_tick;
             bool forced = (h.max_records && h.head - front.first_index > h.max_records)
                        || (max_age_ticks && newest - front.last_tick > max_age_ticks);
@@ -1091,33 +1111,43 @@ private:
             {
                 if (!h.min_records && !h.min_age)
                     break;
-                if (front.first_index + front.count > floor)
+                if (!flushed && front.first_index + front.count > floor)
                     break;
                 if (h.min_records && h.head - front.first_index - front.count < h.min_records)
                     break;
                 if (min_age_ticks && newest - front.last_tick <= min_age_ticks)
                     break;
             }
-            free_bucket(front);
-            h.buckets.remove(0);
+            if (flushed)
+            {
+                if (front.refs)
+                {
+                    ++i;    // borrowed; the release drops it
+                    continue;
+                }
+                if (front.packed)
+                {
+                    free(front.packed[0 .. front.packed_bytes]);
+                    front.packed = null;
+                }
+                h.drop_raw(front);
+                ++i;
+            }
+            else if (h.container)
+                break;      // the only copy; the recorder flushes it shortly
+            else
+            {
+                h.free_bucket(front);
+                h.buckets.remove(i);
+            }
         }
-    }
-
-    void free_bucket(Bucket* b)
-    {
-        _history.drop_raw(b, data_format);
-        if (b.packed)
-            free(b.packed[0 .. b.packed_bytes]);
-        foreach (bit; 0 .. 16)
-            if (_history.cursor_ref[bit] is b)
-                _history.cursor_ref[bit] = null;    // lapped reader; its borrow dies with the bucket
-        free((cast(void*)b)[0 .. Bucket.sizeof]);
     }
 
     Bucket* alloc_bucket(uint capacity)
     {
         Bucket* b = cast(Bucket*)alloc(Bucket.sizeof).ptr;
         *b = Bucket.init;
+        b.format = format;
         b.capacity = capacity;
         b.samples = alloc(capacity * data_format.stride).ptr;
         if (!data_format.regular)
@@ -1679,7 +1709,7 @@ unittest
         Cursor zc = z.open_series_cursor(0);
         RecordBlock zb = zc.next(16);
         assert(zb.count == 2 && zb.get!double(0) == 1.0 && zb.time(1) == from_unix_time_ns(2_000));
-        assert(pb.samples !is null && pb.refs == 1 && pb.raw_combined);  // reconstituted, borrowed
+        assert(pb.samples !is null && pb.refs == 1);  // reconstituted, borrowed
         zb = zc.next(16);
         assert(zb.count == 1);
         assert(pb.samples is null && pb.refs == 0 && pb.packed !is null); // ref moved on, raw dropped

--- a/src/manager/ows.d
+++ b/src/manager/ows.d
@@ -4,21 +4,31 @@ module manager.ows;
 // header carries next/prev file offsets and its index/timestamp span; the first block of a
 // format run additionally carries a BlockFormatHeader (and, later, name-binding data for
 // enum/user/codec identity) behind it, and followers point at that anchor via format_block,
-// so a format change just starts a new run and stable runs skip the repeat noise. The
-// runtime keeps the headers as an in-memory directory with the format resolved per entry,
-// so time-seek is a binary search and recall is: load one block's payload, view it in place
-// as a RecordBlock (byte-identical to the RAM image).
+// so a format change just starts a new run and stable runs skip the repeat noise.
 //
-// Dynamic-record series (text) serialise as their RAM image: fixed-stride u16 offset records
-// plus a trailing byte heap. put() compacts the heap per block - only entries the block's
-// records reference ship, dedup'd by content, offsets rebased - since a cursor block may
-// cover a slice of a bucket whose heap holds more than it references.
+// The container is a block reader/writer over the file, nothing more: indexing lives in the
+// SeriesStore. open_() walks the chain once and adopts every block into the store as a
+// fully-evicted Bucket (headers only, no bytes), so a cursor opened at index 0 walks all of
+// recorded history through the same reconstitute() that serves a packed block. append()
+// writes one sealed bucket's encoded image as one block - the sealed raw image is
+// byte-identical to the ows payload, so a flush is a straight write.
 //
 // Not serialisable yet: user types and enum identity (need name binding), domain-clocked
 // series (need anchor blocks for the clock).
+//
+// TODO *** ADOPTION UNDER LIVE CURSORS IS UNRESOLVED ***
+// open_() rebases standing RAM buckets (and the store's pin positions) behind the adopted
+// history, but external Cursor structs hold their position by VALUE and cannot be reached,
+// so a cursor opened before the container attaches keeps a stale (pre-rebase) position: it
+// will re-read adopted history as if new, and a pinned sync cursor would re-ship it to the
+// peer. The window is the sub-second gap between element creation and the recorder's scan;
+// open_() logs a warning when it fires. Fix candidates: a store-held rebase epoch/offset the
+// cursor applies lazily, or cursors holding store-side positions only.
 
 import urt.array;
 import urt.file;
+import urt.log : writeWarning;
+import urt.mem.alloc;
 import urt.si.unit : ScaledUnit;
 
 import manager.series;
@@ -83,30 +93,21 @@ struct BlockFormatHeader
 }
 static assert(BlockFormatHeader.sizeof == 24);
 
-struct BlockEntry
-{
-nothrow @nogc:
-
-    ulong offset;
-    BlockHeader hdr;
-    BlockFormatHeader fmt;  // resolved for every entry; anchors own it, followers copy their run's
-
-    uint raw_bytes() const pure
-        => cast(uint)(((hdr.flags & BlockHeader.Flags.irregular) ? hdr.count * uint.sizeof : 0) + hdr.count * fmt.stride + hdr.heap_bytes);
-}
-
 struct SeriesContainer
 {
 nothrow @nogc:
 
-    Array!BlockEntry dir;
-
     bool is_open() const pure
         => _open;
 
-    bool open_(const(char)[] path)
+    // Open the file and adopt its history into the store: one fully-evicted Bucket per block,
+    // renumbered contiguously from zero (files written before index continuity may hold
+    // overlapping spans). Standing RAM buckets shift up behind the adopted history and head
+    // resumes after the last record, so the index space is one sequence across restarts.
+    bool open_(const(char)[] path, ref SeriesStore store)
     {
         assert(!_open);
+        assert(store.container is null, "store already has a backing container");
         if (urt.file.open(_file, path, FileOpenMode.ReadWrite) != Result.success)
             return false;
         _open = true;
@@ -124,6 +125,7 @@ nothrow @nogc:
                 return false;
             }
             _end = FileHeader.sizeof;
+            store.container = &this;
             return true;
         }
         if (fh.magic != "OWSG" || fh.version_ != 1)
@@ -132,44 +134,75 @@ nothrow @nogc:
             return false;
         }
 
-        // walk the chain to rebuild the directory, resolving each entry's format run
+        Array!(Bucket*) adopted;
         ulong offset = fh.header_bytes;
         _end = fh.header_bytes;
-        BlockFormatHeader run_fmt;
+        FormatId run_id = FormatId.invalid;
+        ulong next_index = 0;
         while (offset)
         {
-            BlockEntry e;
-            if (read_at(_file, (cast(void*)&e.hdr)[0 .. BlockHeader.sizeof], offset, bytes) != Result.success
-                || bytes < BlockHeader.sizeof)
+            BlockHeader hdr;
+            if (read_at(_file, (cast(void*)&hdr)[0 .. BlockHeader.sizeof], offset, bytes) != Result.success
+                || bytes < BlockHeader.sizeof || hdr.header_bytes < BlockHeader.sizeof)
                 break;
-            e.offset = offset;
-            if (e.hdr.format_block == 0)
+            if (hdr.format_block == 0)
             {
-                if (read_at(_file, (cast(void*)&run_fmt)[0 .. BlockFormatHeader.sizeof],
+                if (read_at(_file, (cast(void*)&_afmt)[0 .. BlockFormatHeader.sizeof],
                             offset + BlockHeader.sizeof, bytes) != Result.success
                     || bytes < BlockFormatHeader.sizeof)
                     break;
                 _fmt_anchor = offset;
-                _afmt = run_fmt;
+                run_id = register_block_format(_afmt);
             }
-            else if (e.hdr.format_block != _fmt_anchor)
+            else if (hdr.format_block != _fmt_anchor)
             {
-                // referenced run isn't the walking one (future compaction); resolve backwards
-                foreach_reverse (ref const BlockEntry p; dir[])
-                {
-                    if (p.offset == e.hdr.format_block)
-                    {
-                        run_fmt = p.fmt;
-                        break;
-                    }
-                }
+                // referenced run isn't the walking one (future compaction); resolve directly
+                if (read_at(_file, (cast(void*)&_afmt)[0 .. BlockFormatHeader.sizeof],
+                            hdr.format_block + BlockHeader.sizeof, bytes) != Result.success
+                    || bytes < BlockFormatHeader.sizeof)
+                    break;
+                _fmt_anchor = hdr.format_block;
+                run_id = register_block_format(_afmt);
             }
-            e.fmt = run_fmt;
-            dir ~= e;
+            if (hdr.count && run_id.valid)
+            {
+                Bucket* b = cast(Bucket*)alloc(Bucket.sizeof).ptr;
+                *b = Bucket.init;
+                b.format = run_id;
+                b.first_index = next_index;
+                b.count = hdr.count;
+                b.first_tick = hdr.first_tick;
+                b.last_offset = cast(uint)(hdr.last_tick - hdr.first_tick);
+                b.heap_used = hdr.heap_bytes;
+                b.codec = hdr.codec;
+                b.packed_bytes = hdr.payload_bytes;
+                b.pack_declined = hdr.codec == ows_codec_raw;
+                b.sealed = true;
+                b.follows_gap = (hdr.flags & BlockHeader.Flags.follows_gap) != 0;
+                b.file_offset = offset + hdr.header_bytes;
+                adopted ~= b;
+                next_index += hdr.count;
+            }
             _tail = offset;
-            _end = offset + e.hdr.header_bytes + e.hdr.payload_bytes;
-            offset = e.hdr.next;
+            _end = offset + hdr.header_bytes + hdr.payload_bytes;
+            offset = hdr.next;
         }
+
+        if (next_index)
+        {
+            if (store.cursor_mask)
+                writeWarning("series container attached under live cursors; their positions predate the rebase");
+            foreach (b; store.buckets[])
+                b.first_index += next_index;
+            foreach (bit; 0 .. 16)
+                if (store.pin_mask & (1 << bit))
+                    store.pin_position[bit] += next_index;
+            store.head += next_index;
+            foreach (b; store.buckets[])
+                adopted ~= b;
+            store.buckets = adopted.move;
+        }
+        store.container = &this;
         return true;
     }
 
@@ -181,56 +214,29 @@ nothrow @nogc:
         _tail = 0;
         _end = 0;
         _fmt_anchor = 0;
-        dir.clear();
     }
 
-    bool put(ref const RecordBlock blk)
+    // append one sealed bucket as one block; on success the bucket carries its file offset
+    // and its codec/packed_bytes describe the payload as written
+    bool append(Bucket* b)
     {
-        ref const DataFormat f = *blk.data_format;
-        debug assert(container_serialisable(f));
-        uint count = blk.count;
-        if (count == 0)
-            return true;
-        bool irregular = blk.ts !is null;
-        uint offs_bytes = irregular ? count * cast(uint)uint.sizeof : 0;
+        debug assert(b.sealed && b.count && !b.file_offset && b.resident);
+        const(DataFormat)* f = format_info(b.format);
+        debug assert(container_serialisable(*f));
 
-        uint heap_bytes = 0;
-        if (f.count == 0)
+        const(void)[] payload;
+        ubyte codec;
+        if (b.packed)
         {
-            // compact the heap: only referenced entries ship, dedup'd, offsets rebased
-            _rbuf.resize(count * ushort.sizeof);
-            _hbuf.clear();
-            ushort[] recs = cast(ushort[])_rbuf[];
-            foreach (i; 0 .. count)
-            {
-                const(void)[] v = blk.dynamic(i);
-                uint off = uint.max;
-                uint pos = 0;
-                while (pos < _hbuf.length)
-                {
-                    const(void)[] e = heap_view(_hbuf.ptr, pos);
-                    if (e == v)
-                    {
-                        off = pos;
-                        break;
-                    }
-                    pos += heap_entry_bytes(e.length);
-                }
-                if (off == uint.max)
-                {
-                    off = cast(uint)_hbuf.length;
-                    _hbuf.resize(off + heap_entry_bytes(v.length));
-                    ushort* p = cast(ushort*)(_hbuf.ptr + off);
-                    *p = cast(ushort)v.length;
-                    (cast(ubyte*)(p + 1))[0 .. v.length] = cast(const(ubyte)[])v[];
-                    if (v.length & 1)
-                        (cast(ubyte*)(p + 1))[v.length] = 0;
-                }
-                recs[i] = cast(ushort)off;
-            }
-            heap_bytes = cast(uint)_hbuf.length;
+            payload = b.packed[0 .. b.packed_bytes];
+            codec = b.codec;
         }
-        uint raw_bytes = offs_bytes + count * f.stride + heap_bytes;
+        else
+        {
+            void* base = b.offsets ? cast(void*)b.offsets : b.samples;
+            payload = base[0 .. b.image_bytes];
+            codec = ows_codec_raw;
+        }
 
         BlockFormatHeader bf;
         bf.rate = f.rate;
@@ -249,151 +255,79 @@ nothrow @nogc:
         h.header_bytes = cast(ushort)(BlockHeader.sizeof + (anchor ? BlockFormatHeader.sizeof : 0));
         h.format_block = anchor ? 0 : _fmt_anchor;
         h.prev = _tail;
-        h.first_index = blk.first_index;
-        h.last_index = blk.first_index + count - 1;
-        h.first_tick = blk.tick(0);
-        h.last_tick = blk.tick(count - 1);
-        h.payload_bytes = raw_bytes;
-        h.flags = irregular ? BlockHeader.Flags.irregular : 0;
-        h.codec = ows_codec_raw;
-        h.heap_bytes = heap_bytes;
+        h.first_index = b.first_index;
+        h.last_index = b.first_index + b.count - 1;
+        h.first_tick = b.first_tick;
+        h.last_tick = b.last_tick;
+        h.payload_bytes = cast(uint)payload.length;
+        h.flags = cast(ubyte)((f.regular ? 0 : BlockHeader.Flags.irregular)
+                            | (b.follows_gap ? BlockHeader.Flags.follows_gap : 0));
+        h.codec = codec;
+        h.heap_bytes = b.heap_used;
 
-        _wbuf.resize(h.header_bytes + raw_bytes);
-        ubyte[] raw = _wbuf[h.header_bytes .. $];
-        if (irregular)
-        {
-            // rebase the offsets plane so first_tick doubles as the block's time base
-            uint[] offs = cast(uint[])raw[0 .. offs_bytes];
-            uint base = blk.ts[0];
-            foreach (i; 0 .. count)
-                offs[i] = blk.ts[i] - base;
-        }
-        if (f.count == 0)
-        {
-            raw[offs_bytes .. offs_bytes + count * ushort.sizeof] = _rbuf[];
-            raw[offs_bytes + count * ushort.sizeof .. $] = _hbuf[];
-        }
-        else
-            raw[offs_bytes .. $] = cast(const(ubyte)[])blk.records();
-
-        foreach (i; 0 .. g_num_codecs)
-        {
-            if (!g_codecs[i].match || !g_codecs[i].match(f, blk))
-                continue;
-            _pbuf.resize(raw_bytes);
-            ptrdiff_t packed = g_codecs[i].pack(blk, raw, _pbuf[]);
-            if (packed > 0 && packed < raw_bytes)
-            {
-                h.codec = cast(ubyte)(first_registered_codec + i);
-                h.payload_bytes = cast(uint)packed;
-                _wbuf.resize(h.header_bytes + packed);
-                _wbuf[h.header_bytes .. $] = _pbuf[0 .. packed];
-            }
-            break;
-        }
-
-        *cast(BlockHeader*)_wbuf.ptr = h;
+        ubyte[BlockHeader.sizeof + BlockFormatHeader.sizeof] hbuf = void;
+        *cast(BlockHeader*)hbuf.ptr = h;
         if (anchor)
-            *cast(BlockFormatHeader*)(_wbuf.ptr + BlockHeader.sizeof) = bf;
+            *cast(BlockFormatHeader*)(hbuf.ptr + BlockHeader.sizeof) = bf;
 
         ulong offset = _end;
         size_t written;
-        if (write_at(_file, _wbuf[], offset, written) != Result.success || written < _wbuf.length)
+        if (write_at(_file, hbuf[0 .. h.header_bytes], offset, written) != Result.success
+            || written < h.header_bytes)
+            return false;
+        if (write_at(_file, payload, offset + h.header_bytes, written) != Result.success
+            || written < payload.length)
             return false;
         if (_tail)
             if (write_at(_file, (cast(const(void)*)&offset)[0 .. 8], _tail, written) != Result.success)
                 return false; // next-link patch failed; block stays unreferenced, its space reused on the next put
-        if (dir.length)
-            dir[$-1].hdr.next = offset;
-        dir ~= BlockEntry(offset, h, bf);
         _tail = offset;
-        _end = offset + _wbuf.length;
+        _end = offset + h.header_bytes + payload.length;
         if (anchor)
         {
             _fmt_anchor = offset;
             _afmt = bf;
         }
+
+        b.file_offset = offset + h.header_bytes;
+        if (!b.packed)
+        {
+            b.packed_bytes = cast(uint)payload.length;
+            b.codec = ows_codec_raw;
+            b.pack_declined = true; // the file is the canonical encoded copy; never re-pack
+        }
         return true;
     }
 
-    // load block i; the returned view and its format are valid until the next load
-    bool load(size_t i, out RecordBlock blk)
+    // fetch a flushed bucket's encoded image; dst is packed_bytes long
+    bool read_payload(ref const Bucket b, void[] dst)
     {
-        ref const BlockEntry e = dir[i];
-        uint raw_bytes = e.raw_bytes;
-        _buf.resize(raw_bytes);
-
-        _fmt = DataFormat(cast(ValueType)e.fmt.type, cast(SeriesKind)e.fmt.kind);
-        if (e.fmt.unit)
-        {
-            ScaledUnit u;
-            (cast(ubyte*)&u)[0 .. ScaledUnit.sizeof] = (cast(const(ubyte)*)&e.fmt.unit)[0 .. ScaledUnit.sizeof];
-            _fmt = DataFormat(cast(ValueType)e.fmt.type, cast(SeriesKind)e.fmt.kind, u);
-        }
-        _fmt.count = e.fmt.count;
-        _fmt.rate = e.fmt.rate;
-        bool irregular = (e.hdr.flags & BlockHeader.Flags.irregular) != 0;
-
+        debug assert(b.file_offset && dst.length == b.packed_bytes);
         size_t bytes;
-        if (e.hdr.codec == ows_codec_raw)
-        {
-            if (read_at(_file, _buf[], e.offset + e.hdr.header_bytes, bytes) != Result.success || bytes < raw_bytes)
-                return false;
-        }
-        else
-        {
-            if (e.hdr.codec < first_registered_codec || e.hdr.codec >= first_registered_codec + g_num_codecs)
-                return false; // unbound codec id (the name table lands with a real codec)
-            _pbuf.resize(e.hdr.payload_bytes);
-            if (read_at(_file, _pbuf[], e.offset + e.hdr.header_bytes, bytes) != Result.success
-                || bytes < e.hdr.payload_bytes)
-                return false;
-            if (!g_codecs[e.hdr.codec - first_registered_codec].unpack(_pbuf[], _fmt, e.hdr.count, irregular, e.hdr.heap_bytes, _buf[]))
-                return false;
-        }
-        uint offs_bytes = irregular ? e.hdr.count * cast(uint)uint.sizeof : 0;
-        blk.format = register_format(_fmt);
-        blk.count = e.hdr.count;
-        blk.first_index = e.hdr.first_index;
-        blk.t0 = e.hdr.first_tick;
-        blk.ts = irregular ? cast(const(uint)*)_buf.ptr : null;
-        blk.data = _buf.ptr + offs_bytes;
-        if (e.hdr.heap_bytes)
-        {
-            blk.heap = _buf.ptr + offs_bytes + e.hdr.count * e.fmt.stride;
-            blk.heap_bytes = e.hdr.heap_bytes;
-        }
-        return true;
-    }
-
-    // first block whose span ends at or after tick; dir.length when none
-    size_t find_by_time(ulong tick) const
-    {
-        size_t lo = 0, hi = dir.length;
-        while (lo < hi)
-        {
-            size_t mid = (lo + hi) / 2;
-            if (dir[mid].hdr.last_tick < tick)
-                lo = mid + 1;
-            else
-                hi = mid;
-        }
-        return lo;
+        return read_at(_file, dst, b.file_offset, bytes) == Result.success && bytes >= dst.length;
     }
 
 private:
     File _file;
-    Array!ubyte _buf;
-    Array!ubyte _wbuf;
-    Array!ubyte _pbuf;
-    Array!ubyte _rbuf;  // dynamic-record put: remapped record plane
-    Array!ubyte _hbuf;  // dynamic-record put: compacted heap
-    DataFormat _fmt;
     BlockFormatHeader _afmt;
     ulong _fmt_anchor;
     ulong _tail;
     ulong _end;
     bool _open;
+
+    static FormatId register_block_format(ref const BlockFormatHeader bf)
+    {
+        DataFormat f = DataFormat(cast(ValueType)bf.type, cast(SeriesKind)bf.kind);
+        if (bf.unit)
+        {
+            ScaledUnit u;
+            (cast(ubyte*)&u)[0 .. ScaledUnit.sizeof] = (cast(const(ubyte)*)&bf.unit)[0 .. ScaledUnit.sizeof];
+            f = DataFormat(cast(ValueType)bf.type, cast(SeriesKind)bf.kind, u);
+        }
+        f.count = bf.count;
+        f.rate = bf.rate;
+        return register_format(f);
+    }
 
     static bool same_format(ref const BlockFormatHeader a, ref const BlockFormatHeader b) pure
         => a.type == b.type && a.kind == b.kind && a.count == b.count
@@ -408,124 +342,151 @@ unittest
 
     static immutable DataFormat f64_held = DataFormat(ValueType.f64, SeriesKind.held);
 
-    Element e;
-    e.format = register_format(f64_held);
-    e.ensure_history();
-    foreach (i; 0 .. 4)
-    {
-        e.write_sample(i * 1.5, from_unix_time_ns((i + 1) * 1_000_000UL));
-        if (i == 1)
-            e.mark_gap(); // second block
-    }
-
     enum path = "ows_unittest.tmp";
     delete_file(path);
 
+    // first life: two sealed buckets flush as two blocks; eviction leaves headers-only
+    // descriptors that reconstitute straight from the file
     {
+        Element e;
+        e.format = register_format(f64_held);
+        SeriesStore* h = e.ensure_history();
         SeriesContainer c;
-        assert(c.open_(path));
-        Cursor cur = e.open_series_cursor(0);
-        while (cur.pending)
+        assert(c.open_(path, *h));
+        assert(h.container is &c);
+
+        foreach (i; 0 .. 4)
         {
-            RecordBlock blk = cur.next(256);
-            if (blk.count == 0)
-                break;
-            assert(c.put(blk));
+            e.write_sample(i * 1.5, from_unix_time_ns((i + 1) * 1_000_000UL));
+            if (i == 1)
+                e.mark_gap(); // second bucket
         }
-        e.close_series_cursor(cur);
-        assert(c.dir.length == 2);
-        c.close_();
-    }
+        assert(h.buckets.length == 2);
+        h.seal(h.buckets[$-1]);
+        foreach (b; h.buckets[])
+            assert(c.append(b));
+        assert(h.buckets[0].file_offset && h.buckets[1].file_offset);
 
-    // reopen: the chain rebuilds the directory; loaded blocks read back as in-memory views
-    {
-        SeriesContainer c;
-        assert(c.open_(path));
-        assert(c.dir.length == 2);
-        assert(c.dir[0].hdr.first_index == 0 && c.dir[1].hdr.last_index == 3);
-
-        // format run: the anchor carries the format header, followers point and stay slim
-        assert(c.dir[0].hdr.format_block == 0);
-        assert(c.dir[0].hdr.header_bytes == BlockHeader.sizeof + BlockFormatHeader.sizeof);
-        assert(c.dir[1].hdr.format_block == c.dir[0].offset);
-        assert(c.dir[1].hdr.header_bytes == BlockHeader.sizeof);
-        assert(c.dir[1].fmt.stride == 8); // follower resolved its run's format
-
-        RecordBlock blk;
-        assert(c.load(0, blk));
+        // evict both to disk; the descriptors stay and the read round-trips
+        foreach (b; h.buckets[])
+        {
+            h.drop_raw(b);
+            if (b.packed)
+            {
+                free(b.packed[0 .. b.packed_bytes]);
+                b.packed = null;
+            }
+        }
+        assert(!h.buckets[0].resident);
+        RecordBlock blk = e.read_records(0, 16);
         assert(blk.count == 2 && blk.get!double(0) == 0.0 && blk.get!double(1) == 1.5);
         assert(blk.time(1) == from_unix_time_ns(2_000_000));
-        assert(c.load(1, blk));
+
+        c.close_();
+        h.container = null;
+        e.teardown();
+    }
+
+    // second life: open adopts the chain as evicted buckets, head resumes, a cursor at 0
+    // walks all of recorded history, and new writes append to the same index space
+    {
+        Element e;
+        e.format = register_format(f64_held);
+        SeriesStore* h = e.ensure_history();
+        SeriesContainer c;
+        assert(c.open_(path, *h));
+        assert(h.buckets.length == 2 && h.head == 4);
+        assert(!h.buckets[0].resident && h.buckets[0].sealed);
+        assert(h.buckets[1].follows_gap);
+
+        e.write_sample(9.0, from_unix_time_ns(5_000_000));
+        assert(e.record_count == 5);
+        assert(h.buckets[$-1].first_index == 4);
+
+        Cursor cur = e.open_series_cursor(0);
+        RecordBlock blk = cur.next(256);
+        assert(blk.count == 2 && blk.get!double(0) == 0.0);
+        blk = cur.next(256);
         assert(blk.count == 2 && blk.get!double(1) == 4.5);
         assert(blk.box(1).asDouble == 4.5);
-
-        // time-seek through the in-memory directory
-        assert(c.find_by_time(2_500) == 1);  // 2.5ms in usec ticks
-
-        // append after reopen: prev/next links patch across sessions
-        e.write_sample(9.0, from_unix_time_ns(5_000_000));
-        Cursor cur = e.open_series_cursor(4);
-        RecordBlock nb = cur.next(256);
-        assert(nb.count == 1 && c.put(nb));
-        e.close_series_cursor(cur);
-        assert(c.dir.length == 3 && c.dir[2].hdr.prev == c.dir[1].offset);
-        assert(c.dir[2].hdr.format_block == c.dir[0].offset); // anchor survives reopen
-        c.close_();
-    }
-
-    {
-        SeriesContainer c;
-        assert(c.open_(path));
-        assert(c.dir.length == 3);
-        RecordBlock blk;
-        assert(c.load(2, blk));
+        blk = cur.next(256);
         assert(blk.count == 1 && blk.get!double(0) == 9.0);
+        assert(!cur.pending);
+        e.close_series_cursor(cur);
+        assert(!h.buckets[0].resident);   // the walk's borrows dropped on close
 
-        // a format change anchors a new run
-        DataFormat s32_fmt = DataFormat(ValueType.s32, SeriesKind.held);
-        int rv = 42;
-        uint[1] rts = 0;
-        RecordBlock rb;
-        rb.format = register_format(s32_fmt);
-        rb.count = 1;
-        rb.first_index = 5;
-        rb.t0 = 6_000_000 / 1000;
-        rb.ts = rts.ptr;
-        rb.data = &rv;
-        assert(c.put(rb));
-        assert(c.dir[3].hdr.format_block == 0);
-        assert(c.load(3, blk) && blk.get!int(0) == 42);
+        // flush the tail: append after reopen patches prev/next across sessions
+        h.seal(h.buckets[$-1]);
+        assert(c.append(h.buckets[$-1]));
+
         c.close_();
+        h.container = null;
+        e.teardown();
     }
 
-    // text: heap-plane round-trip, compacted and dedup'd per block
+    // third life: three blocks now; standing RAM history rebases behind the adopted file
+    {
+        Element e;
+        e.format = register_format(f64_held);
+        e.ensure_history();
+        e.write_sample(21.0, from_unix_time_ns(6_000_000));   // written before the recorder attaches
+        SeriesStore* h = e.ensure_history();
+        assert(h.head == 1);
+
+        SeriesContainer c;
+        assert(c.open_(path, *h));
+        assert(h.head == 6);
+        assert(h.buckets.length == 4 && h.buckets[$-1].first_index == 5);
+
+        Cursor cur = e.open_series_cursor(0);
+        double[6] expect = [0.0, 1.5, 3.0, 4.5, 9.0, 21.0];
+        size_t n;
+        for (;;)
+        {
+            RecordBlock blk = cur.next(256);
+            if (!blk.count)
+                break;
+            foreach (i; 0 .. blk.count)
+                assert(blk.get!double(i) == expect[n++]);
+        }
+        assert(n == 6);
+        e.close_series_cursor(cur);
+
+        c.close_();
+        h.container = null;
+        e.teardown();
+    }
+    delete_file(path);
+
+    // text: the heap plane rides the sealed image; round-trips through flush and adoption
     DataFormat text_fmt = DataFormat(ValueType.char_, SeriesKind.held);
     text_fmt.count = 0;
-    Element t;
-    t.format = register_format(text_fmt);
-    t.ensure_history();
-    t.write_sample("alpha", from_unix_time_ns(1_000_000));
-    t.write_sample("a somewhat longer beta value", from_unix_time_ns(2_000_000));
-    t.write_sample("alpha", from_unix_time_ns(3_000_000));
-
     enum tpath = "ows_text_unittest.tmp";
     delete_file(tpath);
     {
+        Element t;
+        t.format = register_format(text_fmt);
+        SeriesStore* h = t.ensure_history();
         SeriesContainer c;
-        assert(c.open_(tpath));
-        Cursor cur = t.open_series_cursor(0);
-        RecordBlock blk = cur.next(256);
-        assert(blk.count == 3 && c.put(blk));
-        t.close_series_cursor(cur);
-        assert(c.dir[0].hdr.heap_bytes == heap_entry_bytes(5) + heap_entry_bytes(28));
+        assert(c.open_(tpath, *h));
+        t.write_sample("alpha", from_unix_time_ns(1_000_000));
+        t.write_sample("a somewhat longer beta value", from_unix_time_ns(2_000_000));
+        t.write_sample("alpha", from_unix_time_ns(3_000_000));
+        h.seal(h.buckets[$-1]);
+        assert(c.append(h.buckets[0]));
+        assert(h.buckets[0].heap_used == heap_entry_bytes(5) + heap_entry_bytes(28));
         c.close_();
+        h.container = null;
+        t.teardown();
     }
     {
+        Element t;
+        t.format = register_format(text_fmt);
+        SeriesStore* h = t.ensure_history();
         SeriesContainer c;
-        assert(c.open_(tpath));
-        assert(c.dir.length == 1 && c.dir[0].fmt.stride == 2);
-        RecordBlock blk;
-        assert(c.load(0, blk));
+        assert(c.open_(tpath, *h));
+        assert(h.buckets.length == 1 && h.head == 3);
+        RecordBlock blk = t.read_records(0, 16);
         assert(blk.count == 3);
         assert(blk.text(0) == "alpha");
         assert(blk.box(1).asString == "a somewhat longer beta value");
@@ -533,16 +494,50 @@ unittest
         assert((cast(const(ushort)*)blk.data)[0] == (cast(const(ushort)*)blk.data)[2]);
         assert(blk.time(2) == from_unix_time_ns(3_000_000));
         c.close_();
+        h.container = null;
+        t.teardown();
     }
     delete_file(tpath);
-    t.teardown();
 
-    delete_file(path);
-    e.teardown();
+    // a format change starts a new run: the follower re-anchors and both read back typed
+    enum fpath = "ows_format_unittest.tmp";
+    delete_file(fpath);
+    {
+        Element e;
+        e.format = register_format(f64_held);
+        SeriesStore* h = e.ensure_history();
+        SeriesContainer c;
+        assert(c.open_(fpath, *h));
+        e.write_sample(1.0, from_unix_time_ns(1_000_000));
+        h.seal(h.buckets[$-1]);
+        assert(c.append(h.buckets[0]));
+
+        static immutable DataFormat s32_held = DataFormat(ValueType.s32, SeriesKind.held);
+        e.format = register_format(s32_held);
+        e.write_sample(42, from_unix_time_ns(2_000_000));   // format roll: new bucket, new run
+        assert(h.buckets.length == 2 && h.buckets[1].format == e.format);
+        h.seal(h.buckets[$-1]);
+        assert(c.append(h.buckets[1]));
+        c.close_();
+        h.container = null;
+        e.teardown();
+    }
+    {
+        Element e;
+        static immutable DataFormat s32_held = DataFormat(ValueType.s32, SeriesKind.held);
+        e.format = register_format(s32_held);
+        SeriesStore* h = e.ensure_history();
+        SeriesContainer c;
+        assert(c.open_(fpath, *h));
+        assert(h.buckets.length == 2);
+        assert(h.buckets[0].format != h.buckets[1].format);   // per-run formats survive
+        RecordBlock blk = e.read_records(0, 16);
+        assert(blk.count == 1 && blk.get!double(0) == 1.0);   // served in the OLD format
+        blk = e.read_records(1, 16);
+        assert(blk.count == 1 && blk.get!int(0) == 42);
+        c.close_();
+        h.container = null;
+        e.teardown();
+    }
+    delete_file(fpath);
 }
-
-
-private:
-
-__gshared SeriesCodec[8] g_codecs;
-__gshared ubyte g_num_codecs;

--- a/src/manager/ows.d
+++ b/src/manager/ows.d
@@ -1,6 +1,6 @@
-module manager.owsig;
+module manager.ows;
 
-// owsig v0: raw-image series container. The file is a doubly-linked block list: each block
+// ows v0: raw-image series container. The file is a doubly-linked block list: each block
 // header carries next/prev file offsets and its index/timestamp span; the first block of a
 // format run additionally carries a BlockFormatHeader (and, later, name-binding data for
 // enum/user/codec identity) behind it, and followers point at that anchor via format_block,
@@ -255,7 +255,7 @@ nothrow @nogc:
         h.last_tick = blk.tick(count - 1);
         h.payload_bytes = raw_bytes;
         h.flags = irregular ? BlockHeader.Flags.irregular : 0;
-        h.codec = owsig_codec_raw;
+        h.codec = ows_codec_raw;
         h.heap_bytes = heap_bytes;
 
         _wbuf.resize(h.header_bytes + raw_bytes);
@@ -335,7 +335,7 @@ nothrow @nogc:
         bool irregular = (e.hdr.flags & BlockHeader.Flags.irregular) != 0;
 
         size_t bytes;
-        if (e.hdr.codec == owsig_codec_raw)
+        if (e.hdr.codec == ows_codec_raw)
         {
             if (read_at(_file, _buf[], e.offset + e.hdr.header_bytes, bytes) != Result.success || bytes < raw_bytes)
                 return false;
@@ -418,7 +418,7 @@ unittest
             e.mark_gap(); // second block
     }
 
-    enum path = "owsig_unittest.tmp";
+    enum path = "ows_unittest.tmp";
     delete_file(path);
 
     {
@@ -508,7 +508,7 @@ unittest
     t.write_sample("a somewhat longer beta value", from_unix_time_ns(2_000_000));
     t.write_sample("alpha", from_unix_time_ns(3_000_000));
 
-    enum tpath = "owsig_text_unittest.tmp";
+    enum tpath = "ows_text_unittest.tmp";
     delete_file(tpath);
     {
         SeriesContainer c;

--- a/src/manager/record.d
+++ b/src/manager/record.d
@@ -2,7 +2,7 @@ module manager.record;
 
 // Element history recording. A Recorder walks the device tree and attaches a
 // RecordStream to every element whose data-model path matches its filter. The
-// Element's typed SeriesStore is the live source and an owsig container extends
+// Element's typed SeriesStore is the live source and an ows container extends
 // that history on disk.
 // Graph queries convert numeric records to doubles and normalise quantities to
 // base SI scale. The container itself retains the element's typed records.
@@ -27,7 +27,7 @@ import manager.console.graph;
 import manager.console.live_view;
 import manager.device;
 import manager.element;
-import manager.owsig;
+import manager.ows;
 import manager.plugin;
 
 nothrow @nogc:
@@ -74,7 +74,7 @@ nothrow @nogc:
             cursor = e.open_series_cursor(0, true);
         if (!cursor.pending)
             return;
-        if (!container.is_open && !container.open_(owner.make_filename(path[], ".owsig")[]))
+        if (!container.is_open && !container.open_(owner.make_filename(path[], ".ows")[]))
             return; // disk trouble; records stay pinned, retry next flush
 
         while (cursor.pending)
@@ -253,7 +253,7 @@ private:
 }
 
 
-// Serves whatever coverage exists: RAM buckets, extended backwards by the owsig
+// Serves whatever coverage exists: RAM buckets, extended backwards by the ows
 // container when they don't reach `from`. Partial coverage is answered as partial.
 void query_local(ref RecordStream rs, ulong from, ulong to, uint max_points, QueryMode mode, ref Array!Sample result)
 {
@@ -647,7 +647,7 @@ private:
         // the element self-captures; the first flush ships its standing history
     }
 
-    String make_filename(const(char)[] path, const(char)[] ext = ".owsig")
+    String make_filename(const(char)[] path, const(char)[] ext = ".ows")
     {
         MutableString!0 fn;
         fn.append(_dir[], '/');

--- a/src/manager/record.d
+++ b/src/manager/record.d
@@ -56,11 +56,15 @@ nothrow @nogc:
 
     Recorder owner;
     Element* element;       // TODO: key by EID when element destruction lands (see manager.element header)
-    Cursor cursor;          // typed-series intake: pinned, never lapped
     SeriesContainer container;
     String path;            // data-model path: "device.component.element"
+    size_t flush_pos;       // buckets below this are on disk
 
     this(this) @disable;
+
+    // the open tail seals once it ages past this, so slow series still reach disk in
+    // bounded time; fast series roll by capacity well before it
+    enum tail_flush_age = 5 * 60_000_000UL;  // usecs
 
     void flush()
     {
@@ -70,31 +74,52 @@ nothrow @nogc:
         if (!container_serialisable(*f))
             return; // stays in RAM; user/domain series wait on name binding and clock anchors
 
-        if (cursor.element is null)
-            cursor = e.open_series_cursor(0, true);
-        if (!cursor.pending)
-            return;
-        if (!container.is_open && !container.open_(owner.make_filename(path[], ".ows")[]))
-            return; // disk trouble; records stay pinned, retry next flush
-
-        while (cursor.pending)
+        SeriesStore* h = e.ensure_history();
+        if (!container.is_open)
         {
-            RecordBlock blk = cursor.next(256);
-            if (blk.count == 0)
-                break;
-            if (!container.put(blk))
-            {
-                cursor.seek(blk.first_index); // rewind just this block; earlier puts are on disk
-                break;
-            }
+            if (!container.open_(owner.make_filename(path[], ".ows")[], *h))
+                return; // disk trouble; sealed buckets stay resident, retry next flush
+            flush_pos = 0;  // adopted buckets carry their offsets; the loop walks past them
         }
+
+        ulong now = unixTimeNs(getSysTime()) / 1000;
+        while (flush_pos < h.buckets.length)
+        {
+            Bucket* b = h.buckets[flush_pos];
+            if (!b.sealed)
+            {
+                if (!b.count || now - b.first_tick < tail_flush_age)
+                    break;
+                h.seal(b);  // the element rolls a fresh bucket on its next write
+            }
+            if (b.count && !b.file_offset && !container.append(b))
+                break; // disk trouble; retry next flush
+            ++flush_pos;
+        }
+    }
+
+    // ship what is pending, then release the store's backing reference and close the file
+    void reset_container()
+    {
+        if (!container.is_open)
+            return;
+        flush();
+        if (element.has_history)
+            element.ensure_history().detach_container();
+        container.close_();
+        flush_pos = 0;
     }
 
     void close()
     {
-        if (cursor.element)
-            element.close_series_cursor(cursor);
-        container.close_();
+        if (container.is_open)
+        {
+            // seal the tail so its records reach disk with the container
+            SeriesStore* h = element.ensure_history();
+            if (h.buckets.length && !h.buckets[$-1].sealed && h.buckets[$-1].count)
+                h.seal(h.buckets[$-1]);
+        }
+        reset_container();
     }
 }
 
@@ -253,68 +278,40 @@ private:
 }
 
 
-// Serves whatever coverage exists: RAM buckets, extended backwards by the ows
-// container when they don't reach `from`. Partial coverage is answered as partial.
+// Serves whatever coverage exists. The series spans its full recorded history - buckets
+// evicted to disk reconstitute through the store - so the walk is one pass, cursor-paced.
+// Partial coverage is answered as partial.
 void query_local(ref RecordStream rs, ulong from, ulong to, uint max_points, QueryMode mode, ref Array!Sample result)
 {
     Element* e = rs.element;
     Array!Sample local;
     ulong idx = e.index_for_time(from_unix_time_ns(from));
-    for (; idx != ulong.max;)
+    if (idx != ulong.max)
     {
-        RecordBlock blk = e.read_records(idx, 256);
-        if (blk.count == 0)
-            break;
-        bool past = false;
-        foreach (i; 0 .. blk.count)
+        Cursor c = e.open_series_cursor(idx);
+        for (;;)
         {
-            ulong t = unixTimeNs(blk.time(i));
-            if (t > to)
-            {
-                past = true;
+            RecordBlock blk = c.next(256);
+            if (blk.count == 0)
                 break;
-            }
-            double v;
-            Variant val = blk.box(i);
-            if (sample_to_double(val, v))
-                local ~= Sample(t, v);
-        }
-        if (past)
-            break;
-        idx += blk.count;
-    }
-
-    if ((local.length == 0 || local[0].time > from) && rs.container.is_open && rs.container.dir.length)
-    {
-        // the container reaches further back than RAM retention
-        Array!Sample merged;
-        ulong ram_start = local.length ? local[0].time : ulong.max;
-        size_t bi = rs.container.find_by_time(from / 1000);
-        if (bi == rs.container.dir.length)
-            --bi;       // everything ends before `from`: the last block holds the seed
-        else if (bi)
-            --bi;       // step back one block for held state
-        outer: for (; bi < rs.container.dir.length; ++bi)
-        {
-            if (rs.container.dir[bi].hdr.first_tick * 1000 > to)
-                break;
-            RecordBlock blk;
-            if (!rs.container.load(bi, blk))
-                break;
+            bool past = false;
             foreach (i; 0 .. blk.count)
             {
                 ulong t = unixTimeNs(blk.time(i));
-                if (t >= ram_start || t > to)
-                    break outer;
+                if (t > to)
+                {
+                    past = true;
+                    break;
+                }
                 double v;
                 Variant val = blk.box(i);
                 if (sample_to_double(val, v))
-                    merged ~= Sample(t, v);
+                    local ~= Sample(t, v);
             }
+            if (past)
+                break;
         }
-        foreach (ref const Sample s; local[])
-            merged ~= s;
-        local = merged.move;
+        e.close_series_cursor(c);   // drops the raws the walk reconstituted
     }
     ulong bucket_width = max_points ? (to - from) / max_points + 1 : 0;
 
@@ -470,14 +467,14 @@ nothrow @nogc:
         _dir = value.makeString(g_app.allocator);
         mark_set!(typeof(this), "dir")();
 
-        // A restart would drop every cursor, and a cursor reopened at index 0
-        // re-ships the standing RAM history.
+        // No restart: each stream detaches its store from the old file and the next
+        // flush reopens (and re-adopts) under the new directory.
         if (running)
         {
             import urt.file : create_directory;
             create_directory(_dir[]);
             foreach (rs; _streams.values)
-                rs.container.close_();
+                rs.reset_container();
         }
     }
 
@@ -632,8 +629,7 @@ private:
 
     void release(RecordStream* rs)
     {
-        rs.flush(); // ship what is still pending before the container closes
-        rs.close();
+        rs.close(); // seals the tail and ships what is still pending
         defaultAllocator().freeT(rs);
     }
 

--- a/src/manager/series.d
+++ b/src/manager/series.d
@@ -1,7 +1,7 @@
 module manager.series;
 
 // The series contract: the typed record format shared by every host of observed data.
-// Element is the first host; the recorder's owsig containers and waveform/byte/packet taps
+// Element is the first host; the recorder's ows containers and waveform/byte/packet taps
 // host the same formats without becoming elements.
 // Event! payloads and device-function params/results will describe themselves with the
 // same DataFormat vocabulary, boxed through Variant only at the console/API edges.
@@ -446,13 +446,13 @@ nothrow @nogc:
 }
 
 // One codec vocabulary, three residencies: a packed image is the same bytes whether it lives
-// behind a RAM bucket, in an owsig block, or in flight. The raw image layout is
-// [offsets plane?][record plane][heap], identical to the owsig payload. Codecs register with
+// behind a RAM bucket, in an ows block, or in flight. The raw image layout is
+// [offsets plane?][record plane][heap], identical to the ows payload. Codecs register with
 // a selection predicate; the first match packs and RAW is the mandatory fallback (a codec
 // that doesn't beat raw is ignored). Ids 0/1 are reserved (raw, zlib); registered ids are
 // process-local: TODO bind them by NAME before any ships.
-enum ubyte owsig_codec_raw = 0;
-enum ubyte owsig_codec_zlib = 1;
+enum ubyte ows_codec_raw = 0;
+enum ubyte ows_codec_zlib = 1;
 enum ubyte first_registered_codec = 2;
 
 struct SeriesCodec

--- a/src/manager/series.d
+++ b/src/manager/series.d
@@ -32,6 +32,8 @@ import urt.traits : is_boolean, is_some_float, is_some_int, Unqual;
 import urt.typereg : find_type_details, TypeDetails;
 import urt.variant;
 
+import manager.ows : SeriesContainer;
+
 nothrow @nogc:
 
 
@@ -486,32 +488,47 @@ struct Bucket
 {
     ulong first_index;
     ulong first_tick;
+    ulong file_offset; // container file offset of the encoded image; 0 = never flushed
     uint last_offset;
     uint count;
-    uint capacity;
+    uint capacity;     // open builder only; == count once sealed
+    FormatId format = FormatId.invalid; // stamped at creation; a format change rolls the bucket
     bool follows_gap;  // <- we should steal a bit for this!
-    bool sealed;       // tail retired: shrunk to fit, immutable
+    bool sealed;       // tail retired: the raw side is one immutable image
+
+    // The residency entry: samples/offsets/heap are the raw side, packed the encoded side,
+    // file_offset the same encoded image on disk. An open bucket is a builder whose planes
+    // grow independently; a sealed bucket's raw side is one allocation in
+    // [offsets | records | heap] order, byte-identical to the ows payload. A sealed bucket
+    // packs on its last release; with another residency present the raw side is a cache,
+    // dropped at refs==0 and reconstituted on demand for late readers. A bucket with no
+    // resident bytes is recoverable through its file_offset.
     void* samples;
     uint* offsets;     // null when regular
     void* heap;        // dynamic-record series: 2-aligned len-prefixed values, dedup'd per bucket
     uint heap_used;
     uint heap_capacity;
-
-    // the two-pointer entry: samples/offsets/heap are the raw side, packed the encoded side.
-    // At least one is live. A sealed bucket packs on its last release; with packed present the
-    // raw side is a cache, dropped at refs==0 and reconstituted on demand for late readers.
     void* packed;
-    uint packed_bytes;
+    uint packed_bytes;  // size of the encoded image, in RAM and/or on disk
     ushort refs;        // readers borrowing the raw side; the open tail is implicitly protected
-    ubyte codec;
-    bool pack_declined; // codecs tried and beaten by raw; raw-only permanently, don't retry
-    bool raw_combined;  // reconstituted raw is one allocation spanning all planes; free once
+    ubyte codec;        // codec of the encoded image; ows_codec_raw = the raw image itself
+    bool pack_declined; // codecs tried and beaten by raw, or the file holds it raw; don't retry
 
 pure nothrow @nogc:
     ulong last_tick() const => first_tick + last_offset;
     SysTime first_time() const => from_unix_time_ns(first_tick * 1000);
     SysTime last_time() const => from_unix_time_ns(last_tick * 1000);
     SysTime get_time(size_t i) const => from_unix_time_ns((first_tick + (offsets ? offsets[i] : i)) * 1000);
+
+    bool resident() const => samples !is null || packed !is null;
+
+    // sealed raw image size; the offsets plane's presence follows the format, not the
+    // (possibly dropped) pointer
+    uint image_bytes() const
+    {
+        const(DataFormat)* f = format_info(format);
+        return (f.regular ? 0 : count * cast(uint)uint.sizeof) + count * f.stride + heap_used;
+    }
 }
 
 struct SeriesStore
@@ -523,6 +540,7 @@ nothrow @nogc:
     // FORCE eviction regardless of pins (stalled or undriven consumers get lapped and the
     // cursor reports records_lost); between floor and ceiling, consumption governs
     Array!(Bucket*) buckets;
+    SeriesContainer* container; // backing store; buckets evicted to disk reconstitute through it
     ulong head;
     ulong min_age;      // usecs (converted to domain ticks at evict time); 0 = none
     ulong max_age;      // usecs; 0 = no ceiling
@@ -581,20 +599,24 @@ nothrow @nogc:
     // cursor_bit tracks the reader's raw-side borrow: the cursor's ref moves to the bucket it
     // reads, so a view stays valid until the next read. Bit-less reads (queries) reconstitute
     // without a ref; their loose raws drop at the next cursor close (byte budgets own the rest).
+    // `format` only labels an empty result; a found bucket speaks for itself. When from_index
+    // falls in an evicted hole the read serves from the next surviving bucket and reports the
+    // skip through r.first_index.
     RecordBlock read(FormatId format, ulong from_index, uint max_records, ubyte cursor_bit = ubyte.max)
     {
         RecordBlock r;
         r.format = format;
-        const(DataFormat)* fmt = format_info(format);
         Bucket* b = find_by_index(from_index);
-        if (b && from_index < b.first_index)
-            b = null;
         if (cursor_bit != ubyte.max)
-            move_ref(cursor_bit, b, format);
+            move_ref(cursor_bit, b);
         if (!b)
             return r;
-        if (!b.samples && !reconstitute(b, format))
+        if (!b.samples && !reconstitute(b))
             return r;
+        if (from_index < b.first_index)
+            from_index = b.first_index;
+        const(DataFormat)* fmt = format_info(b.format);
+        r.format = b.format;
         uint offset = cast(uint)(from_index - b.first_index);
         uint n = b.count - offset;
         if (n > max_records)
@@ -609,7 +631,7 @@ nothrow @nogc:
         return r;
     }
 
-    void move_ref(ubyte bit, Bucket* b, FormatId format)
+    void move_ref(ubyte bit, Bucket* b)
     {
         Bucket* old = cursor_ref[bit];
         if (old is b)
@@ -618,61 +640,77 @@ nothrow @nogc:
         if (b)
             ++b.refs;
         if (old)
-            release_ref(old, format);
+            release_ref(old);
     }
 
-    void release_ref(Bucket* b, FormatId format)
+    void release_ref(Bucket* b)
     {
         debug assert(b.refs);
         if (--b.refs)
             return;
-        if (b.packed)
-            drop_raw(b, format_info(format));
+        if (b.packed || b.file_offset)
+            drop_raw(b);
         else
-            try_pack(b, format);
+            try_pack(b);
+    }
+
+    // retire the open tail: shrink the builder planes into one immutable image in
+    // [offsets | records | heap] order, byte-identical to the ows payload
+    void seal(Bucket* b)
+    {
+        if (b.sealed)
+            return;
+        debug assert(b.count, "empty buckets are recycled, not sealed");
+        const(DataFormat)* fmt = format_info(b.format);
+        uint offs_bytes = b.offsets ? b.count * cast(uint)uint.sizeof : 0;
+        uint rec_bytes = b.count * fmt.stride;
+        uint total = offs_bytes + rec_bytes + b.heap_used;
+        void[] img = alloc(total);
+        ubyte* p = cast(ubyte*)img.ptr;
+        p[0 .. offs_bytes] = (cast(const(ubyte)*)b.offsets)[0 .. offs_bytes];
+        p[offs_bytes .. offs_bytes + rec_bytes] = (cast(const(ubyte)*)b.samples)[0 .. rec_bytes];
+        p[offs_bytes + rec_bytes .. total] = (cast(const(ubyte)*)b.heap)[0 .. b.heap_used];
+        free(b.samples[0 .. b.capacity * fmt.stride]);
+        if (b.offsets)
+            free((cast(void*)b.offsets)[0 .. b.capacity * uint.sizeof]);
+        if (b.heap)
+            free(b.heap[0 .. b.heap_capacity]);
+        b.sealed = true;
+        b.offsets = offs_bytes ? cast(uint*)p : null;
+        b.samples = p + offs_bytes;
+        b.heap = b.heap_used ? p + offs_bytes + rec_bytes : null;
+        b.capacity = b.count;
+        b.heap_capacity = b.heap_used;
+        // pack now if nothing borrows the raw side; otherwise the last release_ref packs
+        try_pack(b);
     }
 
     // packing only reads the raw side, so it may run on any sealed bucket regardless of
     // readers (a disk writer can pack what the UX is still rendering); only DROPPING raw
-    // waits for the last borrow to release
-    void try_pack(Bucket* b, FormatId format)
+    // waits for the last borrow to release. A flushed bucket never re-packs: the file is
+    // the canonical encoded copy and codec/packed_bytes describe it.
+    void try_pack(Bucket* b)
     {
-        if (b.packed || b.pack_declined || !b.sealed || !b.count || !g_num_codecs)
+        if (b.packed || b.pack_declined || b.file_offset || !b.sealed || !b.count || !g_num_codecs)
             return;
-        const(DataFormat)* fmt = format_info(format);
-        uint offs_bytes = b.offsets ? b.count * cast(uint)uint.sizeof : 0;
-        uint rec_bytes = b.count * fmt.stride;
-        uint total = offs_bytes + rec_bytes + b.heap_used;
-
-        RecordBlock blk;
-        blk.format = format;
-        blk.count = b.count;
-        blk.first_index = b.first_index;
-        blk.t0 = b.first_tick;
-        blk.ts = b.offsets;
-        blk.data = b.samples;
-        blk.heap = b.heap;
-        blk.heap_bytes = b.heap_used;
+        const(DataFormat)* fmt = format_info(b.format);
+        RecordBlock blk = block_view(b);
+        void* base = b.offsets ? cast(void*)b.offsets : b.samples;
+        const(void)[] img = base[0 .. b.image_bytes];
 
         foreach (i; 0 .. g_num_codecs)
         {
             if (!g_codecs[i].match || !g_codecs[i].match(*fmt, blk))
                 continue;
-            void[] img = alloc(total);
-            ubyte* p = cast(ubyte*)img.ptr;
-            p[0 .. offs_bytes] = (cast(const(ubyte)*)b.offsets)[0 .. offs_bytes];
-            p[offs_bytes .. offs_bytes + rec_bytes] = (cast(const(ubyte)*)b.samples)[0 .. rec_bytes];
-            p[offs_bytes + rec_bytes .. total] = (cast(const(ubyte)*)b.heap)[0 .. b.heap_used];
-            void[] dst = alloc(total);
+            void[] dst = alloc(img.length);
             ptrdiff_t packed_size = g_codecs[i].pack(blk, img, dst);
-            free(img);
-            if (packed_size > 0 && packed_size < total)
+            if (packed_size > 0 && packed_size < img.length)
             {
                 b.packed = realloc(dst, packed_size).ptr;
                 b.packed_bytes = cast(uint)packed_size;
                 b.codec = cast(ubyte)(first_registered_codec + i);
                 if (!b.refs)
-                    drop_raw(b, fmt);
+                    drop_raw(b);
             }
             else
                 free(dst);
@@ -682,47 +720,71 @@ nothrow @nogc:
             b.pack_declined = true;
     }
 
-    // repopulate the raw side from packed: one combined allocation in the shared image layout,
-    // shared by every reader positioned in the bucket until the last ref drops it again
-    bool reconstitute(Bucket* b, FormatId format)
+    // repopulate the raw side from the packed image, or from the container for a bucket
+    // evicted to disk: one combined allocation in the shared image layout, shared by every
+    // reader positioned in the bucket until the last ref drops it again
+    bool reconstitute(Bucket* b)
     {
         if (b.samples)
             return true;
-        debug assert(b.packed, "bucket has neither raw nor packed side");
-        if (b.codec < first_registered_codec || b.codec >= first_registered_codec + g_num_codecs)
-            return false;
-        const(DataFormat)* fmt = format_info(format);
+        const(DataFormat)* fmt = format_info(b.format);
         bool irregular = !fmt.regular;
         uint offs_bytes = irregular ? b.count * cast(uint)uint.sizeof : 0;
         uint rec_bytes = b.count * fmt.stride;
         uint total = offs_bytes + rec_bytes + b.heap_used;
+
+        const(void)[] encoded = b.packed ? b.packed[0 .. b.packed_bytes] : null;
+        void[] fetched;
+        if (!encoded)
+        {
+            if (!b.file_offset || !container)
+                return false;
+            debug assert(b.packed_bytes, "flushed bucket lost its payload size");
+            fetched = alloc(b.packed_bytes);
+            if (!container.read_payload(*b, fetched))
+            {
+                free(fetched);
+                return false;
+            }
+            if (b.codec == ows_codec_raw)
+            {
+                debug assert(b.packed_bytes == total, "raw payload size disagrees with the headers");
+                mount_raw(b, fetched.ptr, offs_bytes, rec_bytes, irregular);
+                return true;
+            }
+            encoded = fetched;
+        }
+        if (b.codec < first_registered_codec || b.codec >= first_registered_codec + g_num_codecs)
+        {
+            if (fetched)
+                free(fetched);
+            return false;
+        }
         void[] img = alloc(total);
-        if (!g_codecs[b.codec - first_registered_codec].unpack(b.packed[0 .. b.packed_bytes], *fmt,
-                                                               b.count, irregular, b.heap_used, img))
+        bool ok = g_codecs[b.codec - first_registered_codec].unpack(encoded, *fmt, b.count,
+                                                                    irregular, b.heap_used, img);
+        if (fetched)
+            free(fetched);
+        if (!ok)
         {
             free(img);
             debug assert(false, "packed bucket failed to reconstitute");
             return false;
         }
-        b.offsets = irregular ? cast(uint*)img.ptr : null;
-        b.samples = img.ptr + offs_bytes;
-        b.heap = b.heap_used ? img.ptr + offs_bytes + rec_bytes : null;
-        b.capacity = b.count;
-        b.heap_capacity = b.heap_used;
-        b.raw_combined = true;
+        mount_raw(b, img.ptr, offs_bytes, rec_bytes, irregular);
         return true;
     }
 
-    // free the raw side; entered with packed present, or from bucket teardown
-    void drop_raw(Bucket* b, const(DataFormat)* fmt)
+    // free the raw side; entered with another residency present, or from bucket teardown
+    void drop_raw(Bucket* b)
     {
         if (!b.samples)
             return;
-        if (b.raw_combined)
+        const(DataFormat)* fmt = format_info(b.format);
+        if (b.sealed)
         {
             void* base = b.offsets ? cast(void*)b.offsets : b.samples;
-            uint offs_bytes = b.offsets ? b.count * cast(uint)uint.sizeof : 0;
-            free(base[0 .. offs_bytes + b.count * fmt.stride + b.heap_used]);
+            free(base[0 .. b.image_bytes]);
         }
         else
         {
@@ -735,17 +797,78 @@ nothrow @nogc:
         b.samples = null;
         b.offsets = null;
         b.heap = null;
+        b.capacity = 0;
         b.heap_capacity = 0;
-        b.raw_combined = false;
+    }
+
+    void free_bucket(Bucket* b)
+    {
+        drop_raw(b);
+        if (b.packed)
+        {
+            free(b.packed[0 .. b.packed_bytes]);
+            b.packed = null;
+        }
+        foreach (bit; 0 .. 16)
+            if (cursor_ref[bit] is b)
+                cursor_ref[bit] = null;    // lapped reader; its borrow dies with the bucket
+        free((cast(void*)b)[0 .. Bucket.sizeof]);
     }
 
     // sweep raws reconstituted by bit-less readers (queries); called from cursor close
-    void drop_loose_raws(FormatId format)
+    void drop_loose_raws()
     {
-        const(DataFormat)* fmt = format_info(format);
         foreach (b; buckets[])
-            if (b.packed && b.samples && !b.refs)
-                drop_raw(b, fmt);
+            if (b.sealed && b.samples && !b.refs && (b.packed || b.file_offset))
+                drop_raw(b);
+    }
+
+    // the backing store is going away: descriptors whose only residency was the file are
+    // unreachable and drop; survivors forget their file copy and stand alone again
+    void detach_container()
+    {
+        container = null;
+        for (size_t i = 0; i < buckets.length; )
+        {
+            Bucket* b = buckets[i];
+            if (!b.resident && b.file_offset)
+            {
+                free_bucket(b);
+                buckets.remove(i);
+                continue;
+            }
+            b.file_offset = 0;
+            if (!b.packed)
+            {
+                b.packed_bytes = 0;
+                b.codec = 0;
+            }
+            ++i;
+        }
+    }
+
+    RecordBlock block_view(Bucket* b)
+    {
+        RecordBlock blk;
+        blk.format = b.format;
+        blk.count = b.count;
+        blk.first_index = b.first_index;
+        blk.t0 = b.first_tick;
+        blk.ts = b.offsets;
+        blk.data = b.samples;
+        blk.heap = b.heap;
+        blk.heap_bytes = b.heap_used;
+        return blk;
+    }
+
+private:
+    void mount_raw(Bucket* b, void* base, uint offs_bytes, uint rec_bytes, bool irregular)
+    {
+        b.offsets = irregular ? cast(uint*)base : null;
+        b.samples = cast(ubyte*)base + offs_bytes;
+        b.heap = b.heap_used ? cast(ubyte*)base + offs_bytes + rec_bytes : null;
+        b.capacity = b.count;
+        b.heap_capacity = b.heap_used;
     }
 }
 

--- a/src/manager/sync/package.d
+++ b/src/manager/sync/package.d
@@ -1665,8 +1665,9 @@ nothrow @nogc:
     // Backfill behind the add: the add already carried the latest value, history streams
     // as val blocks after it so a UI paints instantly and fills the chart. Served
     // synchronously within the burst; nothing can interleave, so a live sub's feed takes
-    // over gap-free where the backfill ends. Serves the in-RAM retained series; deep
-    // (db-resident) recall stays on history_req until cursor-paced draining lands.
+    // over gap-free where the backfill ends. The series spans its full recorded history
+    // (disk-evicted buckets reconstitute through the store), so from_ms is honoured as
+    // far as history exists.
     void send_backfill(SyncPeer to, SyncEncoder enc, Element* e, ulong from_ms, ulong to_ms)
     {
         import urt.time : from_unix_time_ns;


### PR DESCRIPTION
Bucket carries its format and file offset; a sealed bucket is one raw image, byte-identical to the container payload. The container demotes to a block reader/writer: open adopts the file's blocks as evicted buckets and head resumes after them, so cursors and queries reach full recorded history and query_local's two-tier merge goes. Retention drops the bytes of flushed buckets and keeps their descriptors; the recorder flushes whole sealed buckets and seals tails older than 5 minutes. owsig renames to ows.

Design in docs/SERIES_RESIDENCY.draft.md.