### PR TITLE
Binary sync channel

### DIFF
--- a/docs/SYNC_TRANSPORTS.draft.md
+++ b/docs/SYNC_TRANSPORTS.draft.md
@@ -1,0 +1,272 @@
+# Sync Transports
+
+Status: design. Companion to [SYNC_PROTOCOL.draft.md](SYNC_PROTOCOL.draft.md), which defines the
+verb set and the foreign/sibling transport classes. This document covers the layer below: the
+physical links the binary sync channel rides, what each link must provide, and the adapter
+designs. The binary encoder ([binary_encoder.d](../src/manager/sync/binary_encoder.d)) is built;
+this is the plan for putting it on wires.
+
+**Where the substrate stands** (2026-08-10, after the ether/endpoint work landed):
+[`/interface/udp`](../src/router/iface/udp.d) exists and is better than what this document
+originally planned -- it is a router-layer interface (so ip-less tiers get it), does unicast and
+multi-drop, carries per-frame peer addresses in a `UDPFrame` header, and reaches ether peers
+(`[mac]:port`) with no IP configured. [`InterfaceCaps`](../src/router/iface/package.d#L59) now
+expresses `reliable` and `ordered` as advertised link properties, which is exactly contract
+items 2-3 below, in code. A unicast remote now genuinely filters rx to its peer on every
+platform, so "connected" means the same thing everywhere.
+
+**What blocks sync-over-UDP** is that the interface dispatches `UDPFrame` while `SyncPeer`
+subscribes `PacketFilter(PacketType.raw)`, so a peer on a UDP transport transmits and receives
+nothing. The peer is what changes -- see *Framing* below.
+
+## The link contract
+
+`SyncPeer.transport` is any `BaseInterface` delivering `RawFrame` packets. The encoder calls
+`transmit_frame` and never sees the link. What the sync channel requires of a link adapter:
+
+1. **Frame delimiting.** One protocol frame per packet. Datagram links get this free; byte
+   streams need framing.
+2. **Integrity.** Corrupt frames are dropped at the link, never delivered. CRC everywhere except
+   memory-coherent links.
+3. **Ordered delivery for the control plane.** The protocol assumes type-before-cite,
+   add_name-before-bind, add-before-val. Any reliability scheme must preserve per-peer order for
+   control verbs.
+
+4. **Best-effort is acceptable for the data plane.** `val`/`val_block`, `log`, `time_push` are
+   latest-value or cursor-recoverable. Lost vals self-heal: latest-value elements on the next
+   update, point series by backfill from the series cursor (residency-unified series reach full
+   history, so recovery is always possible). Retransmitting stale telemetry is worse than
+   re-reading it.
+5. **MTU.** Advertised via `hello.max_frame`, already negotiated. The encoder must learn to cap
+   `val_block` chunking to the peer's max_frame (currently fixed 256-record blocks); oversized
+   control frames (bind with many props) are a real hazard on small-MTU links. TODO on the
+   encoder side.
+6. **Channels (where shared).** Links carrying more than sync (console, OTA, log tap as separate
+   streams) need a mux id. Datagram links can instead use distinct ports; point streams use CPC
+   endpoints; RS485 uses an envelope channel byte.
+
+Items 2-3 are advertised by the link as `InterfaceCaps.reliable` / `.ordered`, so a peer can read
+its transport's caps and decide whether it must supply the missing guarantee itself (shmem and CPC
+advertise both; UDP advertises neither). That check is the natural home for the control-plane
+reliability layer below -- it arms only where the link doesn't already promise it.
+
+**Backpressure contract (cross-cutting fix, phase 1b):** `transmit_frame < 0` currently drops
+event-driven control frames with no retry, on every transport. The contract should become
+"accepted = enqueued": link adapters own a bounded queue (`PriorityPacketQueue` fits), and
+control verbs are only droppable when the peer is genuinely dead (queue overflow after patience,
+peer offline). Data-plane frames stay droppable (DEI=1); control frames ride PCP >= ca with
+DEI=0. Until this lands, reliable links mask the problem and lossy links occasionally lose a
+`state` or `result` frame.
+
+## Configuration language
+
+The most important design surface. The links differ in role shape -- symmetric peers (UDP),
+client/server (WS, TCP), master/slave (RS485), fixed pairing (shmem) -- but the user should
+only ever describe the **channel**; the sync module chooses and owns the transport adapter
+stack above it. Nobody hand-wires stream -> framing interface -> peer.
+
+**Principle: name the channel, get the stack.** Datagram links are already interface-shaped
+(one datagram, one frame), so their interface IS the channel object and carries the endpoint
+config directly -- no stream underneath. Byte streams are the ones needing an adapter stack.
+`SyncPeer` accepts, in increasing sugar:
+
+- `transport=<iface>` -- a raw-frame interface: `UDPInterface`, a WebSocket, later a
+  `CPCEndpoint` or the RS485/shmem adapters. How ws-server wires accepted sockets today.
+- `stream=<stream>` (future, lands with CPC) -- for byte streams only (serial, RS232 bridge,
+  TCP): the peer materialises the CPC stack above the stream and owns it (dynamic object,
+  destroyed with the peer). Mutually exclusive with `transport`, later set wins.
+- `remote=<uri>` (future) -- creates the channel object too. URI scheme selects everything:
+  `udp://host:port`, `ws://host/path`, `serial:///dev/ttyUSB0?baud=115200`,
+  `rs485://bus1/12`, `shm://ring0`. Mirrors WebSocket's `remote=` and the automation
+  `on=` URI convention.
+
+**Outbound/symmetric** links are two commands today, one with `remote=`:
+
+```
+/interface/udp add name=sync1 local-port=7000 remote-host=192.168.0.8 remote-port=7000
+/sync/peer add name=pi transport=sync1 encoder=binary
+```
+
+**Inbound/server** roles are listeners that spawn dynamic peers on accept, one collection per
+scheme, precedent set by `/sync/ws-server`: a future `/sync/udp-server` (accept datagrams from
+unknown sources, spawn a peer per source), `/sync/serial-server` (CPC secondary answering a
+primary). Spawned peers are `dynamic`, named after the listener, destroyed when the transport
+dies.
+
+**Master/slave (RS485)** maps onto the same two shapes: the master configures one peer per
+slave (`remote=rs485://bus1/12` -- bus interface plus slave address; the bus's single
+scheduler owns arbitration), the slave side is a listener (`/sync/rs485-server bus=...`
+responding when polled). **Shmem** is a fixed pairing: `remote=shm://ring0` on both cores.
+
+The encoder choice stays orthogonal (`encoder=json|binary`) but transports may default it:
+shmem and RS485 default binary; ws stays json for browsers.
+
+## Transport matrix
+
+| link | framing | integrity | reliability | mux | class |
+|---|---|---|---|---|---|
+| UDP unicast | datagram | UDP checksum | control: seq/ack layer; data: best-effort + cursor recovery | ports | foreign |
+| UDP multicast | datagram | UDP checksum | none on group; gap-detect + unicast backfill | ports | foreign, one-way |
+| shmem ring (BL808 M0/D0) | length prefix | memory | inherent; backpressure = ring full | channel byte | sibling |
+| UART / RS232 / SPI point link | CPC | CPC CRC | CPC retransmit | CPC endpoints | foreign |
+| I2C point link | (deferred) | - | - | - | needs data-ready GPIO or polling; prefer SPI/UART |
+| RS485 multi-drop | Modbus RTU envelope | CRC16 | poll/response retransmit | envelope channel byte | foreign |
+
+## UDP (phase 1)
+
+### UDPInterface -- built upstream
+
+[`router/iface/udp.d`](../src/router/iface/udp.d) landed independently and covers this: an
+event-driven endpoint (`udp_open`, reactor-delivered receive, no polling), one datagram per
+packet, `local-port=` + `remote=<addr:port>` configured on the interface itself, unicast
+(connected, rx filtered to the peer) or multi-drop (unconnected, per-frame peer addressing).
+IP fragmentation covers frames past link MTU -- fine on a wired LAN, degrades on lossy paths;
+max_frame chunking is the proper fix.
+
+### Framing: sync consumes UDPFrame -- SETTLED
+
+The interface delivers `UDPFrame` on rx (peer address per frame) while `SyncPeer` subscribes
+`PacketFilter(PacketType.raw)`, so sync over UDP transmits and never receives. The tempting fix
+was to make connected mode deliver `RawFrame` and present a drop-in raw pipe. **Rejected.**
+A packet type that changes with a mode forces every multi-mode consumer to branch on it, and it
+can never serve multicast, where a group has many senders and the per-frame source is the only
+way to tell publishers apart.
+
+`UDPFrame` stays, and the sync peer learns to read it. The decisive argument is that the paths
+diverge anyway: UDP is neither ordered nor reliable while ASH, CPC and shmem are both, so a UDP
+peer needs the control-plane reliability layer that the others must not pay for. Once the code
+path is separate on those grounds, the delivery struct differing costs nothing.
+`InterfaceCaps.reliable`/`.ordered` is the switch: the peer reads its transport's caps and arms
+the layer only where the link doesn't already promise the guarantee.
+
+The peer therefore subscribes by transport capability rather than assuming `raw`, which is also
+what lets one peer sit on a multi-drop segment later without another framing change.
+
+```
+/interface/udp add name=sync1 local-port=7000 remote-host=192.168.0.8 remote-port=7000
+/sync/peer add name=pi transport=sync1 encoder=binary
+```
+
+Multi-drop sync (several peers on one socket) still wants the peer-sub-interface shape from
+udp.d's TODO: sub-interfaces bound to a multi-drop trunk, each presenting one peer, spawned on
+first datagram from an unknown source. That is precisely the `/sync/udp-server` listener
+described above, so the two land together -- and with `UDPFrame` throughout, that work no longer
+has to re-open framing.
+
+### Reliability split (phase 2)
+
+Not one scheme, two planes:
+
+- **Control plane** (registry, bind/create/destroy, set/reset, cmd/result, sub, type/add,
+  model_set, res/err): small, rare, must arrive in order. A thin reliable layer per peer:
+  frame seq (varint), piggybacked cumulative ack, retransmit on timeout, small window (4-8).
+  Sits between the encoder and the interface, or as a framing wrapper the peer applies --
+  placement decided when built; it must not leak into encoders.
+- **Data plane** (val/val_block, log, time_push): best-effort, no retransmit. Loss recovery is
+  the protocol's own machinery: latest-value overwrites, and point-series gaps detected by the
+  receiver trigger a `sub {from}` backfill.
+
+Classification is by verb, known at encode time; a flag on `transmit_frame` (or PCP/DEI on the
+packet: control = ca/DEI=0, data = be/DEI=1) carries it to the link.
+
+### Multicast (phase 5)
+
+For one-publisher many-subscriber val feeds. Structural change: multicast needs a
+**publisher-owned handle and ft namespace** -- receivers adopt only, nobody allocates handles
+back, because only the publisher transmits on the group. This is a third session shape next to
+foreign and sibling: foreign-one-way.
+
+- Join: newcomer unicasts `hello` + `sub`; publisher unicasts current `type`/`add` schema and a
+  snapshot, then the receiver follows the group feed. A per-publisher datagram seq marks the
+  switchover point, gap-free against the snapshot cursor.
+- Loss: receivers detect gaps by datagram seq; recover by unicast `sub {from}` backfill. Never
+  per-receiver acks on the group (ack implosion).
+- Scope: publisher-enabled optimization, per group. Wired ethernet with IGMP snooping is the
+  win case. WiFi multicast (base-rate, no retries, DTIM buffering) usually loses to two or
+  three unicasts -- do not default it on.
+
+## Shared memory: BL808 M0/D0 (phase 3)
+
+Two SPSC rings, one per direction, length-prefixed frames. No CRC, no retransmit. This is the
+**sibling** class from SYNC_PROTOCOL: same-build cores, shared id/format tables, introduction
+and interning degenerate to identity. Notes:
+
+- Cache coherence: D0 is cached; rings live in an uncached window or get explicit maintenance.
+  Same class of lesson as the WRAM/PSRAM wifi work.
+- Backpressure: ring-full must surface as "queue and wait", not frame loss -- which is exactly
+  the transmit-is-enqueue contract above. Size rings so control bursts (startup registry fan-out)
+  fit.
+- M0 is `FEATURES=switch HEADLESS=1`: validate what actually syncs (interface state, counters,
+  console, logs) before sizing anything.
+
+## CPC over byte streams: UART, RS232, SPI (phase 4)
+
+Point-to-point board links (C6<->P4 and kin) are **not** assumed accurate: UART overruns are
+routine, SPI slaves desync and have no flow control, I2C acks bytes but not payloads. CPC
+(in tree, [protocol/cpc/](../src/protocol/cpc/)) already provides exactly the needed layer over
+UART and SPI-with-handshake-GPIO: HDLC-ish framing, CRC, retransmit, and multiplexed endpoints
+(sync on one endpoint, console/OTA on others). The adapter is: sync peer's transport = a
+`CPCEndpoint`. CPC's primary/secondary asymmetry is a config choice on a point link.
+
+I2C is deferred: the slave cannot initiate, so it needs a data-ready GPIO or master polling
+underneath CPC. Between our own boards, prefer SPI or UART.
+
+## RS485 multi-drop (phase 4, design settled here)
+
+Requirements: multiple OW sync nodes on one bus, coexisting with non-OW Modbus devices, master
+arbitrated.
+
+**Envelope: real Modbus RTU frames.** Not "looks like" -- actually valid:
+`[addr][fc=OW_SYNC][chan][seq|flags][sync frames...][crc16]`, with `fc` from the user-defined
+function code space (0x41-0x48 / 0x64-0x6E). Coexistence is then by construction, not
+probability: non-OW slaves ignore by address, bus analyzers see legal Modbus, and arbitration is
+Modbus discipline -- only the addressed node transmits, inside a bounded response window.
+
+**Token = poll.** The master's token grant is a request frame to one slave; the slave's transmit
+opportunity is its response window. Response carries queued sync frames plus a "more pending"
+flag; the master re-polls while more is set. Reliability falls out of the request/response
+shape: master times out and re-polls with the same seq; slave answers a repeated seq from its
+last-response cache. No free-running timers on the bus.
+
+**Mux without CPC.** One channel byte + one seq/flags byte in the envelope. Literal CPC is
+wrong here: its retransmit timers assume it owns a duplex link; polled half-duplex fights it.
+
+**One bus, one scheduler.** The sync adapter must live under the same scheduler as the Modbus
+master on that port -- sync grants interleave with ordinary Modbus polls through the existing
+priority queue. Two independent owners of one RS485 port cannot coexist. This slots into the
+Modbus L2/L3 trajectory (interfaces as switch ports).
+
+**Per-slave baud.** Electrically feasible (switch while idle between frames), but wrong-baud
+frames degrade the coexistence guarantee from "provably ignored" to "almost certainly ignored"
+(byte soup with a 1/65536 CRC accident), and silence timing shifts with baud. Design: baud is
+per-slave addressing metadata from day one; implementation deferred until a real fixed-baud
+legacy device forces it; default is a uniform bus.
+
+## Build order
+
+0. ~~UDPInterface~~ -- done upstream ([router/iface/udp.d](../src/router/iface/udp.d)).
+1. **Sync reads UDPFrame** (next): the peer subscribes by transport capability instead of
+   assuming raw. Unblocks node-to-node binary sync end to end, and is the first real two-node
+   validation of the encoder.
+2. **Backpressure contract**: transmit-is-enqueue, PCP/DEI classification of control vs data.
+   Reads `InterfaceCaps` to know what the link already promises.
+3. **Shmem ring** (with the BL808 work): sibling class, binary encoder's original target.
+4. **CPC endpoint transport** + **RS485 envelope**: RS485 benefits from the mux/seq conventions
+   the others settle.
+5. **UDP reliability layer** (control-plane seq/ack), **peer sub-interfaces** /
+   `/sync/udp-server`, then **multicast**.
+
+Order of 2 vs 5a is flexible: the UDP control-plane layer may *be* the backpressure contract's
+first implementation.
+
+## Open questions
+
+- Where the UDP reliable layer lives: inside UDPInterface (link property `reliable=yes`), a
+  wrapper interface, or peer-level. Leaning link-level wrapper so the peer stays
+  transport-blind.
+- `max_frame`-driven chunking in the encoders: needed before small-MTU links (CPC payload,
+  RS485 response windows) carry model bursts.
+- RS485 slave-to-slave traffic: hub through the master (star, matches current sync topology) or
+  scheduled slave-to-slave windows? Star first.
+- Multicast group addressing: per-publisher group derived from node id vs configured. Configured
+  first, derivation later.

--- a/openwatt.vcxproj
+++ b/openwatt.vcxproj
@@ -147,6 +147,7 @@
     <DCompile Include="src\manager\signal.d" />
     <DCompile Include="src\manager\sample\spec.d" />
     <DCompile Include="src\manager\sync\encoder.d" />
+    <DCompile Include="src\manager\sync\binary_encoder.d" />
     <DCompile Include="src\manager\sync\json_encoder.d" />
     <DCompile Include="src\manager\sync\package.d" />
     <DCompile Include="src\manager\sync\peer.d" />

--- a/openwatt.vcxproj.filters
+++ b/openwatt.vcxproj.filters
@@ -426,6 +426,9 @@
     <DCompile Include="src\manager\sync\encoder.d">
       <Filter>src\manager\sync</Filter>
     </DCompile>
+    <DCompile Include="src\manager\sync\binary_encoder.d">
+      <Filter>src\manager\sync</Filter>
+    </DCompile>
     <DCompile Include="src\manager\sync\json_encoder.d">
       <Filter>src\manager\sync</Filter>
     </DCompile>

--- a/src/manager/sync/binary_encoder.d
+++ b/src/manager/sync/binary_encoder.d
@@ -1,0 +1,1305 @@
+module manager.sync.binary_encoder;
+
+// BinaryEncoder - packed binary framing for node-to-node sync over byte
+// transports (serial, UDP, shmem rings). Same verb surface and dispatch
+// contract as JsonEncoder; a frame is [verb u8][fields], integers travel as
+// LEB128 varints (zigzag where signed), strings are length-prefixed, and
+// values use a small tagged Variant codec. Types the codec doesn't model
+// natively (quantities, enums, user types) travel as their string form -
+// the same fidelity the JSON channel has, and property setters parse them.
+
+import urt.array;
+import urt.log;
+import urt.mem.allocator;
+import urt.meta.enuminfo : VoidEnumInfo;
+import urt.string;
+import urt.variant;
+
+import manager.base;
+import manager.collection;
+import manager.element : Element;
+import manager.record : Sample;
+import manager.series : Constraint, DataFormat, RecordBlock, Scalar, SeriesKind, ValueType;
+import manager.sync;
+import manager.sync.encoder;
+import manager.sync.peer;
+
+
+nothrow @nogc:
+
+
+__gshared BinaryEncoder g_binary_encoder;
+
+
+// JSON overloads several verbs by field-shape (set/model_set, sub/model_sub,
+// type format/enum); the binary channel gives each shape its own verb byte.
+enum Verb : ubyte
+{
+    add_name,
+    bind,
+    unbind,
+    create,
+    destroy,
+    state,
+    set,
+    reset,
+    cmd,
+    result,
+    error,
+    sub,
+    unsub,
+    enum_req,
+    enum_,
+    history_req,
+    history,
+    log_sub,
+    log,
+    time_req,
+    time_resp,
+    time_push,
+    hello,
+    model_sub,
+    model_unsub,
+    type_format,
+    type_enum,
+    add,
+    val,
+    model_set,
+    res,
+    err,
+}
+
+
+final class BinaryEncoder : SyncEncoder
+{
+nothrow @nogc:
+
+    SyncModule sync;
+
+    this(SyncModule sync)
+    {
+        this.sync = sync;
+    }
+
+    // Outbound: registry
+
+    override void encode_add_name(SyncPeer peer, BaseObject obj)
+    {
+        begin_frame(Verb.add_name);
+        _buf.put_varint(peer.introduce(obj));
+        _buf.put_str(obj.name[]);
+        _buf.put_str(obj.type[]);
+        send_frame(peer);
+    }
+
+    // Outbound: mirror lifecycle
+
+    override void encode_bind(SyncPeer peer, BaseObject obj, uint seq)
+    {
+        SyncHandle h = peer.handle_of(obj);
+        debug assert(h != SyncPeer.invalid_handle, "bind without prior add_name");
+        begin_frame(Verb.bind);
+        _buf.put_varint(h);
+        _buf.put_str(obj.type[]);
+        _buf.put_varint(seq);
+
+        // props as (name, value) pairs, empty-name terminated; all SET props
+        // including read-only ones - proxies can't recompute derived state
+        auto props = obj.properties();
+        ulong set_bits = obj.props_set;
+        foreach (i, p; props)
+        {
+            if (!(set_bits & (ulong(1) << i)) || !p.get || p.name[] == "type")
+                continue;
+            _buf.put_str(p.name[]);
+            Variant v = p.get(obj);
+            _buf.put_variant(v);
+        }
+        _buf.put_str(null);
+        send_frame(peer);
+    }
+
+    override void encode_unbind(SyncPeer peer, CID target, uint seq)
+    {
+        begin_frame(Verb.unbind);
+        _buf.put_varint(peer.handle_of(target));
+        _buf.put_varint(seq);
+        send_frame(peer);
+    }
+
+    override void encode_create(SyncPeer peer, const(char)[] type, NamedArgument[] props, uint seq)
+    {
+        begin_frame(Verb.create);
+        _buf.put_varint(seq);
+        _buf.put_str(type);
+        foreach (ref arg; props)
+        {
+            _buf.put_str(arg.name[]);
+            _buf.put_variant(arg.value);
+        }
+        _buf.put_str(null);
+        send_frame(peer);
+    }
+
+    override void encode_destroy(SyncPeer peer, CID target, uint seq)
+    {
+        begin_frame(Verb.destroy);
+        _buf.put_varint(peer.handle_of(target));
+        _buf.put_varint(seq);
+        send_frame(peer);
+    }
+
+    // Outbound: state + property
+
+    override void encode_state(SyncPeer peer, CID target, StateSignal sig)
+    {
+        begin_frame(Verb.state);
+        _buf.put_varint(peer.handle_of(target));
+        _buf ~= cast(ubyte)sig;
+        send_frame(peer);
+    }
+
+    override void encode_set(SyncPeer peer, BaseObject obj, size_t prop_index, uint seq)
+    {
+        auto props = obj.properties();
+        if (prop_index >= props.length)
+            return;
+        auto p = props[prop_index];
+        if (!p.get)
+            return;
+
+        begin_frame(Verb.set);
+        _buf.put_varint(peer.handle_of(obj));
+        _buf.put_str(p.name[]);
+        Variant v = p.get(obj);
+        _buf.put_variant(v);
+        _buf.put_varint(seq);
+        send_frame(peer);
+    }
+
+    override void encode_set(SyncPeer peer, CID target, const(char)[] prop_name, ref const Variant value, uint seq)
+    {
+        begin_frame(Verb.set);
+        _buf.put_varint(peer.handle_of(target));
+        _buf.put_str(prop_name);
+        _buf.put_variant(value);
+        _buf.put_varint(seq);
+        send_frame(peer);
+    }
+
+    override void encode_reset(SyncPeer peer, CID target, const(char)[] prop_name, uint seq)
+    {
+        begin_frame(Verb.reset);
+        _buf.put_varint(peer.handle_of(target));
+        _buf.put_str(prop_name);
+        _buf.put_varint(seq);
+        send_frame(peer);
+    }
+
+    // Outbound: commands, errors, enums, subscriptions
+
+    override void encode_cmd(SyncPeer peer, uint seq, const(char)[] text)
+    {
+        begin_frame(Verb.cmd);
+        _buf.put_varint(seq);
+        _buf.put_str(text);
+        send_frame(peer);
+    }
+
+    override void encode_result(SyncPeer peer, uint seq, ref const Variant value, const(char)[] out_text)
+    {
+        begin_frame(Verb.result);
+        _buf.put_varint(seq);
+        _buf.put_variant(value);
+        _buf.put_str(out_text);
+        send_frame(peer);
+    }
+
+    override void encode_error(SyncPeer peer, uint seq, const(char)[] text)
+    {
+        begin_frame(Verb.error);
+        _buf.put_varint(seq);
+        _buf.put_str(text);
+        send_frame(peer);
+    }
+
+    override void encode_sub(SyncPeer peer, const(char)[] pattern)
+    {
+        begin_frame(Verb.sub);
+        _buf.put_str(pattern);
+        send_frame(peer);
+    }
+
+    override void encode_unsub(SyncPeer peer, const(char)[] pattern)
+    {
+        begin_frame(Verb.unsub);
+        _buf.put_str(pattern);
+        send_frame(peer);
+    }
+
+    override void encode_enum_req(SyncPeer peer, const(char)[] type_name, uint seq)
+    {
+        begin_frame(Verb.enum_req);
+        _buf.put_str(type_name);
+        _buf.put_varint(seq);
+        send_frame(peer);
+    }
+
+    override void encode_enum(SyncPeer peer, const(char)[] type_name, ref const Variant members, uint seq)
+    {
+        begin_frame(Verb.enum_);
+        _buf.put_str(type_name);
+        _buf.put_varint(seq);
+        _buf.put_variant(members);
+        send_frame(peer);
+    }
+
+    override void encode_history_req(SyncPeer peer, const(char)[] path, ulong from_ms, ulong to_ms, uint max_points, uint seq)
+    {
+        begin_frame(Verb.history_req);
+        _buf.put_str(path);
+        _buf.put_varint(from_ms);
+        _buf.put_varint(to_ms);
+        _buf.put_varint(max_points);
+        _buf.put_varint(seq);
+        send_frame(peer);
+    }
+
+    override void encode_history(SyncPeer peer, uint seq, const(char)[] path, const(Sample)[] samples)
+    {
+        begin_frame(Verb.history);
+        _buf.put_varint(seq);
+        _buf.put_str(path);
+        _buf.put_varint(samples.length);
+        foreach (ref s; samples)
+        {
+            _buf.put_varint(s.time / 1_000_000);
+            _buf.put_f64(s.value);
+        }
+        send_frame(peer);
+    }
+
+    // Outbound: log streaming
+
+    override void encode_log_sub(SyncPeer peer, Severity max_severity, bool off, const(char)[] tag)
+    {
+        begin_frame(Verb.log_sub);
+        _buf ~= off ? ubyte(0xFF) : cast(ubyte)max_severity;
+        _buf.put_str(tag);
+        send_frame(peer);
+    }
+
+    override bool encode_log(SyncPeer peer, const(char)[] line)
+    {
+        begin_frame(Verb.log);
+        _buf.put_str(line);
+        send_frame(peer);
+        return !_last_drop;
+    }
+
+    // Outbound: time sync
+
+    override void encode_time_req(SyncPeer peer, uint seq)
+    {
+        begin_frame(Verb.time_req);
+        _buf.put_varint(seq);
+        send_frame(peer);
+    }
+
+    override void encode_time_resp(SyncPeer peer, uint seq, ulong recv_ns, ulong xmit_ns, uint ver)
+    {
+        begin_frame(Verb.time_resp);
+        _buf.put_varint(seq);
+        _buf.put_varint(recv_ns);
+        _buf.put_varint(xmit_ns);
+        _buf.put_varint(ver);
+        send_frame(peer);
+    }
+
+    override void encode_time_push(SyncPeer peer, uint ver, long delta_ns)
+    {
+        begin_frame(Verb.time_push);
+        _buf.put_varint(ver);
+        _buf.put_zigzag(delta_ns);
+        send_frame(peer);
+    }
+
+    // Outbound: model plane
+
+    override void encode_hello(SyncPeer peer)
+    {
+        import manager.system : hostname;
+
+        begin_frame(Verb.hello);
+        _buf.put_varint(model_protocol_version);
+        _buf.put_str(hostname[]);
+        _buf ~= local_sync_caps;
+        _buf.put_varint(max_frame_size);
+        send_frame(peer);
+    }
+
+    override void encode_model_sub(SyncPeer peer, uint seq, const(char[])[] patterns, bool once)
+    {
+        begin_frame(Verb.model_sub);
+        _buf.put_varint(seq);
+        _buf ~= ubyte(once);
+        _buf.put_varint(0);   // from_ms
+        _buf.put_varint(0);   // to_ms
+        _buf.put_varint(patterns.length);
+        foreach (p; patterns)
+            _buf.put_str(p);
+        send_frame(peer);
+    }
+
+    override void encode_type_format(SyncPeer peer, uint ft, ref const DataFormat fmt)
+    {
+        import urt.mem.temp : tconcat;
+        import manager.sample : enum_info_name;
+
+        begin_frame(Verb.type_format);
+        _buf.put_varint(ft);
+        _buf.put_str(value_type_name(fmt.type));
+        _buf.put_str(enum_key_name!SeriesKind(fmt.kind));
+        _buf ~= fmt.count;
+        _buf.put_varint(fmt.rate);
+        _buf.put_str(fmt.desc == DataFormat.Desc.quantity ? tconcat(fmt.unit) : null);
+        _buf.put_str(fmt.desc == DataFormat.Desc.enum_ ? enum_info_name(fmt.enum_info) : null);
+
+        Variant min, max, step;
+        if (fmt.constraint && fmt.is_scalar)
+        {
+            ref const Constraint c = *fmt.constraint;
+            if (c.has & Constraint.Has.min)
+                min = scalar_variant(c.min, fmt.type);
+            if (c.has & Constraint.Has.max)
+                max = scalar_variant(c.max, fmt.type);
+            if (c.has & Constraint.Has.step)
+                step = scalar_variant(c.step, fmt.type);
+        }
+        _buf.put_variant(min);
+        _buf.put_variant(max);
+        _buf.put_variant(step);
+        send_frame(peer);
+    }
+
+    override void encode_type_enum(SyncPeer peer, const(char)[] name, const(VoidEnumInfo)* info)
+    {
+        begin_frame(Verb.type_enum);
+        _buf.put_str(name);
+        _buf.put_varint(info.count);
+        foreach (i; 0 .. info.count)
+        {
+            const(char)[] key = info.key_by_decl_index(i);
+            _buf.put_str(key);
+            _buf.put_zigzag(info.value_for(key).asLong);
+        }
+        send_frame(peer);
+    }
+
+    override void encode_add(SyncPeer peer, SyncHandle h, const(char)[] path, const(char)[] node_class, uint ft, Element* e)
+    {
+        import urt.time : unix_time_ns;
+        import manager.element : Access, SamplingMode;
+
+        begin_frame(Verb.add);
+        _buf.put_varint(h);
+        _buf.put_str(path);
+        _buf.put_str(node_class);
+        _buf ~= ubyte(e !is null);
+        if (e)
+        {
+            _buf.put_varint(ft);
+            _buf.put_str(e.access != Access.read ? enum_key_name!Access(e.access) : null);
+            _buf.put_str(e.sampling_mode != SamplingMode.manual ? enum_key_name!SamplingMode(e.sampling_mode) : null);
+
+            Variant v;
+            ulong t_ms = 0;
+            if (e.data_format.kind != SeriesKind.point)
+            {
+                // events retain no value; occurrences replay via backfill
+                v = e.value;
+                if (!v.isNull)
+                    t_ms = unix_time_ns(e.last_update) / 1_000_000;
+            }
+            _buf.put_variant(v);
+            _buf.put_varint(t_ms);
+        }
+        send_frame(peer);
+    }
+
+    override void encode_val(SyncPeer peer, SyncHandle h, Element* e)
+    {
+        import urt.time : unix_time_ns;
+
+        begin_frame(Verb.val);
+        _buf.put_varint(h);
+        _buf.put_varint(0);   // lost
+        _buf.put_varint(1);
+        _buf.put_varint(unix_time_ns(e.last_update) / 1_000_000);
+        Variant v = e.value;
+        _buf.put_variant(v);
+        send_frame(peer);
+    }
+
+    override void encode_val_block(SyncPeer peer, SyncHandle h, ref const RecordBlock blk)
+    {
+        import urt.time : unix_time_ns;
+
+        begin_frame(Verb.val);
+        _buf.put_varint(h);
+        _buf.put_varint(blk.lost);
+        _buf.put_varint(blk.count);
+        foreach (i; 0 .. blk.count)
+        {
+            _buf.put_varint(unix_time_ns(blk.time(i)) / 1_000_000);
+            Variant v = blk.box(i);
+            _buf.put_variant(v);
+        }
+        send_frame(peer);
+    }
+
+    override void encode_res(SyncPeer peer, uint seq)
+    {
+        begin_frame(Verb.res);
+        _buf.put_varint(seq);
+        Variant none;
+        _buf.put_variant(none);
+        send_frame(peer);
+    }
+
+    override void encode_res(SyncPeer peer, uint seq, ref const Variant value)
+    {
+        begin_frame(Verb.res);
+        _buf.put_varint(seq);
+        _buf.put_variant(value);
+        send_frame(peer);
+    }
+
+    override void encode_err(SyncPeer peer, uint seq, const(char)[] code, const(char)[] text)
+    {
+        begin_frame(Verb.err);
+        _buf.put_varint(seq);
+        _buf.put_str(code);
+        _buf.put_str(text);
+        send_frame(peer);
+    }
+
+    // Inbound
+
+    override void decode_and_dispatch(SyncPeer peer, const(ubyte)[] frame)
+    {
+        if (frame.length == 0)
+            return;
+        if (frame[0] > Verb.max)
+        {
+            log.warning("sync/bin: unknown verb ", frame[0]);
+            return;
+        }
+        Verb verb = cast(Verb)frame[0];
+        Reader r = Reader(frame[1 .. $]);
+
+        final switch (verb)
+        {
+            case Verb.add_name:
+            {
+                SyncHandle h = r.varint();
+                const(char)[] name = r.str();
+                const(char)[] type = r.str();
+                if (r.fail)
+                    break;
+                sync.inbound_add_name(peer, h, name, type);
+                break;
+            }
+
+            case Verb.bind:
+            {
+                CID target = peer.cid_of(r.varint());
+                const(char)[] type = r.str();
+                uint seq = cast(uint)r.varint();
+                if (r.fail)
+                    break;
+                sync.inbound_bind(peer, target, type, seq);
+                for (;;)
+                {
+                    const(char)[] prop = r.str();
+                    if (r.fail || prop.length == 0)
+                        break;
+                    Variant v = r.variant();
+                    if (r.fail)
+                        break;
+                    sync.inbound_set(peer, target, prop, v, 0);
+                }
+                break;
+            }
+
+            case Verb.unbind:
+            {
+                CID target = peer.cid_of(r.varint());
+                uint seq = cast(uint)r.varint();
+                if (!r.fail)
+                    sync.inbound_unbind(peer, target, seq);
+                break;
+            }
+
+            case Verb.create:
+            {
+                uint seq = cast(uint)r.varint();
+                const(char)[] type = r.str();
+                Array!NamedArgument props;
+                for (;;)
+                {
+                    const(char)[] prop = r.str();
+                    if (r.fail || prop.length == 0)
+                        break;
+                    Variant v = r.variant();
+                    if (r.fail)
+                        break;
+                    props ~= NamedArgument(prop, v.move);
+                }
+                if (!r.fail)
+                    sync.inbound_create(peer, type, props[], seq);
+                break;
+            }
+
+            case Verb.destroy:
+            {
+                CID target = peer.cid_of(r.varint());
+                uint seq = cast(uint)r.varint();
+                if (!r.fail)
+                    sync.inbound_destroy(peer, target, seq);
+                break;
+            }
+
+            case Verb.state:
+            {
+                CID target = peer.cid_of(r.varint());
+                ubyte sig = r.u8();
+                if (r.fail)
+                    break;
+                if (sig > StateSignal.offline)
+                {
+                    log.warning("sync/bin: bad state signal ", sig);
+                    break;
+                }
+                sync.inbound_state(peer, target, cast(StateSignal)sig);
+                break;
+            }
+
+            case Verb.set:
+            {
+                CID target = peer.cid_of(r.varint());
+                const(char)[] prop = r.str();
+                Variant v = r.variant();
+                uint seq = cast(uint)r.varint();
+                if (!r.fail)
+                    sync.inbound_set(peer, target, prop, v, seq);
+                break;
+            }
+
+            case Verb.reset:
+            {
+                CID target = peer.cid_of(r.varint());
+                const(char)[] prop = r.str();
+                uint seq = cast(uint)r.varint();
+                if (!r.fail)
+                    sync.inbound_reset(peer, target, prop, seq);
+                break;
+            }
+
+            case Verb.cmd:
+            {
+                uint seq = cast(uint)r.varint();
+                const(char)[] text = r.str();
+                if (!r.fail)
+                    sync.inbound_cmd(peer, seq, text);
+                break;
+            }
+
+            case Verb.result:
+            {
+                uint seq = cast(uint)r.varint();
+                Variant v = r.variant();
+                const(char)[] text = r.str();
+                if (!r.fail)
+                    sync.inbound_result(peer, seq, v, text);
+                break;
+            }
+
+            case Verb.error:
+            {
+                uint seq = cast(uint)r.varint();
+                const(char)[] text = r.str();
+                if (!r.fail)
+                    sync.inbound_error(peer, seq, text);
+                break;
+            }
+
+            case Verb.sub:
+            {
+                const(char)[] pattern = r.str();
+                if (!r.fail)
+                    sync.inbound_sub(peer, pattern.makeString(defaultAllocator));
+                break;
+            }
+
+            case Verb.unsub:
+            {
+                const(char)[] pattern = r.str();
+                if (!r.fail)
+                    sync.inbound_unsub(peer, pattern);
+                break;
+            }
+
+            case Verb.enum_req:
+            {
+                const(char)[] type = r.str();
+                uint seq = cast(uint)r.varint();
+                if (!r.fail)
+                    sync.inbound_enum_req(peer, type, seq);
+                break;
+            }
+
+            case Verb.enum_:
+            {
+                const(char)[] type = r.str();
+                uint seq = cast(uint)r.varint();
+                Variant members = r.variant();
+                if (!r.fail)
+                    sync.inbound_enum(peer, type, members, seq);
+                break;
+            }
+
+            case Verb.history_req:
+            {
+                const(char)[] path = r.str();
+                ulong from_ms = r.varint();
+                ulong to_ms = r.varint();
+                uint max_points = cast(uint)r.varint();
+                uint seq = cast(uint)r.varint();
+                if (!r.fail)
+                    sync.inbound_history_req(peer, path, from_ms, to_ms, max_points, seq);
+                break;
+            }
+
+            case Verb.history:
+                // node-to-node history recall isn't wired up yet - no outbound
+                // requester exists to correlate this response with.
+                log.info("sync/bin: inbound history frame from '", peer.name[], "' - ignored");
+                break;
+
+            case Verb.log_sub:
+            {
+                ubyte sev = r.u8();
+                const(char)[] tag = r.str();
+                if (r.fail)
+                    break;
+                bool off = sev == 0xFF;
+                if (!off && sev > Severity.max)
+                {
+                    log.warning("sync/bin: bad log_sub severity ", sev);
+                    break;
+                }
+                sync.inbound_log_sub(peer, off ? Severity.info : cast(Severity)sev, off, tag);
+                break;
+            }
+
+            case Verb.log:
+            {
+                const(char)[] line = r.str();
+                if (!r.fail)
+                    sync.inbound_log(peer, line);
+                break;
+            }
+
+            case Verb.time_req:
+            {
+                uint seq = cast(uint)r.varint();
+                if (!r.fail)
+                    sync.inbound_time_req(peer, seq);
+                break;
+            }
+
+            case Verb.time_resp:
+            {
+                uint seq = cast(uint)r.varint();
+                ulong recv_ns = r.varint();
+                ulong xmit_ns = r.varint();
+                uint ver = cast(uint)r.varint();
+                if (!r.fail)
+                    sync.inbound_time_resp(peer, seq, recv_ns, xmit_ns, ver);
+                break;
+            }
+
+            case Verb.time_push:
+            {
+                uint ver = cast(uint)r.varint();
+                long delta = r.zigzag();
+                if (!r.fail)
+                    sync.inbound_time_push(peer, ver, delta);
+                break;
+            }
+
+            case Verb.hello:
+            {
+                uint ver = cast(uint)r.varint();
+                const(char)[] host = r.str();
+                ubyte caps = r.u8();
+                uint max_frame = cast(uint)r.varint();
+                if (!r.fail)
+                    sync.inbound_hello(peer, ver, host, caps, max_frame);
+                break;
+            }
+
+            case Verb.model_sub:
+            {
+                uint seq = cast(uint)r.varint();
+                bool once = r.u8() != 0;
+                ulong from_ms = r.varint();
+                ulong to_ms = r.varint();
+                size_t count = cast(size_t)r.varint();
+                if (r.fail || count > max_frame_size)
+                    break;
+                Array!(const(char)[]) patterns;
+                foreach (i; 0 .. count)
+                    patterns ~= r.str();
+                if (!r.fail)
+                    sync.inbound_model_sub(peer, seq, patterns[], once, from_ms, to_ms);
+                break;
+            }
+
+            case Verb.model_unsub:
+            {
+                size_t count = cast(size_t)r.varint();
+                if (r.fail || count > max_frame_size)
+                    break;
+                Array!(const(char)[]) patterns;
+                foreach (i; 0 .. count)
+                    patterns ~= r.str();
+                if (!r.fail)
+                    sync.inbound_model_unsub(peer, patterns[]);
+                break;
+            }
+
+            case Verb.type_format:
+            {
+                uint ft = cast(uint)r.varint();
+                WireFormat wf;
+                wf.type = r.str();
+                wf.series = r.str();
+                wf.count = r.u8();
+                wf.rate = cast(uint)r.varint();
+                wf.unit = r.str();
+                wf.enum_name = r.str();
+                wf.min = r.variant();
+                wf.max = r.variant();
+                wf.step = r.variant();
+                if (!r.fail)
+                    sync.inbound_type_format(peer, ft, wf);
+                break;
+            }
+
+            case Verb.type_enum:
+            {
+                const(char)[] name = r.str();
+                size_t count = cast(size_t)r.varint();
+                if (r.fail || count > max_frame_size)
+                    break;
+                Variant members;
+                foreach (i; 0 .. count)
+                {
+                    const(char)[] key = r.str();
+                    long value = r.zigzag();
+                    if (r.fail)
+                        break;
+                    members.insert(key, Variant(value));
+                }
+                if (!r.fail)
+                    sync.inbound_type_enum(peer, name, members);
+                break;
+            }
+
+            case Verb.add:
+            {
+                SyncHandle h = r.varint();
+                const(char)[] path = r.str();
+                const(char)[] node_class = r.str();
+                bool has_element = r.u8() != 0;
+                uint ft = uint.max;
+                const(char)[] access, mode;
+                Variant v;
+                ulong t_ms = 0;
+                if (has_element)
+                {
+                    ft = cast(uint)r.varint();
+                    access = r.str();
+                    mode = r.str();
+                    v = r.variant();
+                    t_ms = r.varint();
+                }
+                if (!r.fail)
+                    sync.inbound_model_add(peer, h, path, node_class, ft, access, mode, v.isNull ? null : &v, t_ms);
+                break;
+            }
+
+            case Verb.val:
+            {
+                SyncHandle h = r.varint();
+                r.varint();   // lost - informational, mirror ignores it (same as JSON)
+                size_t count = cast(size_t)r.varint();
+                if (r.fail || count > max_frame_size)
+                    break;
+                foreach (i; 0 .. count)
+                {
+                    ulong t_ms = r.varint();
+                    Variant v = r.variant();
+                    if (r.fail)
+                        break;
+                    sync.inbound_val(peer, h, v, t_ms);
+                }
+                break;
+            }
+
+            case Verb.model_set:
+            {
+                uint seq = cast(uint)r.varint();
+                SyncHandle h = r.varint();
+                const(char)[] path = r.str();
+                bool reset_ = r.u8() != 0;
+                Variant v = r.variant();
+                if (!r.fail)
+                    sync.inbound_model_set(peer, seq, h, path, v.isNull ? null : &v, reset_);
+                break;
+            }
+
+            case Verb.res:
+            {
+                uint seq = cast(uint)r.varint();
+                r.variant();   // optional value - inbound_res doesn't take one (same as JSON)
+                if (!r.fail)
+                    sync.inbound_res(peer, seq);
+                break;
+            }
+
+            case Verb.err:
+            {
+                uint seq = cast(uint)r.varint();
+                const(char)[] code = r.str();
+                const(char)[] text = r.str();
+                if (!r.fail)
+                    sync.inbound_err(peer, seq, code, text);
+                break;
+            }
+        }
+
+        if (r.fail)
+            log.warning("sync/bin: truncated or malformed '", enum_key_name!Verb(verb), "' frame from '", peer.name[], "'");
+    }
+
+    // Per-peer per-tick property flush
+    //
+    // One set/reset frame per dirty property; the frames are a few bytes each
+    // so per-object packing buys little against the verb's simplicity.
+
+    override void tick_dirty(SyncPeer peer)
+    {
+        foreach (obj; peer._bound[])
+        {
+            if (obj._is_remote)
+                continue;
+
+            ushort slot = sync.find_sync_slot(obj, peer);
+            if (slot == sync_slot_none)
+                continue;
+
+            ref ss = sync_state(slot);
+            ulong dirty = ss.props_dirty;
+            if (!dirty)
+                continue;
+
+            ulong set_bits = dirty & obj.props_set;
+
+            ulong sent_bits = 0;
+            auto props = obj.properties();
+            foreach (i, p; props)
+            {
+                ulong mask = ulong(1) << i;
+                if (!(dirty & mask))
+                    continue;
+
+                if (set_bits & mask)
+                    encode_set(peer, obj, i, 0);
+                else
+                {
+                    debug assert_reset_matches_init(obj, *p);
+                    encode_reset(peer, obj.id, p.name[], 0);
+                }
+
+                if (_last_drop)
+                {
+                    ss.props_dirty &= ~sent_bits;
+                    return;
+                }
+                sent_bits |= mask;
+            }
+            ss.props_dirty &= ~sent_bits;
+        }
+    }
+
+private:
+    Array!ubyte _buf;
+    bool _last_drop;
+
+    void begin_frame(Verb verb)
+    {
+        _buf.clear();
+        _buf ~= verb;
+    }
+
+    void send_frame(SyncPeer peer)
+    {
+        _last_drop = peer.transmit_frame(_buf[], false) < 0;
+        if (_last_drop)
+        {
+            // event-driven encodes (state/cmd/result/error/sub/...) have no retry path!!
+            // a drop here means the peer permanently misses this event.
+            log.warning("dropped frame to peer (", _buf.length, "B): verb=", enum_key_name!Verb(cast(Verb)_buf[0]));
+        }
+    }
+}
+
+
+private:
+
+import urt.meta.enuminfo : enum_key_from_value;
+
+// constraint scalars are typed by their format; read stride bytes like compare_scalar does
+Variant scalar_variant(ref const Scalar s, ValueType t)
+{
+    final switch (t) with (ValueType)
+    {
+        case bool_: return Variant(*cast(const(bool)*)s.raw.ptr);
+        case u8:    return Variant(*cast(const(ubyte)*)s.raw.ptr);
+        case s8:    return Variant(*cast(const(byte)*)s.raw.ptr);
+        case u16:   return Variant(*cast(const(ushort)*)s.raw.ptr);
+        case s16:   return Variant(*cast(const(short)*)s.raw.ptr);
+        case u32:   return Variant(*cast(const(uint)*)s.raw.ptr);
+        case s32:   return Variant(*cast(const(int)*)s.raw.ptr);
+        case u64:   return Variant(*cast(const(ulong)*)s.raw.ptr);
+        case s64:   return Variant(*cast(const(long)*)s.raw.ptr);
+        case f32:   return Variant(*cast(const(float)*)s.raw.ptr);
+        case f64:   return Variant(*cast(const(double)*)s.raw.ptr);
+        case char_:
+        case user:  assert(false, "constraint on non-numeric type");
+    }
+}
+
+alias enum_key_name = enum_key_from_value;
+
+// Variant codec: tag byte + payload. Values the codec doesn't model natively
+// travel as their string form (tag str), matching the JSON channel's fidelity.
+enum Tag : ubyte
+{
+    nil,
+    false_,
+    true_,
+    uint_,     // varint
+    int_,      // zigzag varint (negative values)
+    f64,       // 8 bytes LE
+    str,       // varint length + bytes
+    arr,       // varint count + elements
+    map,       // varint count + (str key, value) pairs
+}
+
+void put_varint(ref Array!ubyte buf, ulong v)
+{
+    while (v >= 0x80)
+    {
+        buf ~= cast(ubyte)(v | 0x80);
+        v >>= 7;
+    }
+    buf ~= cast(ubyte)v;
+}
+
+void put_zigzag(ref Array!ubyte buf, long v)
+    => buf.put_varint((ulong(v) << 1) ^ ulong(v >> 63));
+
+void put_f64(ref Array!ubyte buf, double d)
+{
+    ubyte[8] bytes = *cast(const(ubyte[8])*)&d;
+    buf ~= bytes[];
+}
+
+void put_str(ref Array!ubyte buf, const(char)[] s)
+{
+    buf.put_varint(s.length);
+    buf ~= cast(const(ubyte)[])s;
+}
+
+void put_variant(ref Array!ubyte buf, ref const Variant v)
+{
+    if (v.isNull)
+        buf ~= Tag.nil;
+    else if (v.isBool)
+        buf ~= v.asBool ? Tag.true_ : Tag.false_;
+    else if (v.isString)
+    {
+        buf ~= Tag.str;
+        buf.put_str(v.asString());
+    }
+    else if (v.isArray)
+    {
+        buf ~= Tag.arr;
+        buf.put_varint(v.length());
+        foreach (i; 0 .. v.length())
+            buf.put_variant(v[i]);
+    }
+    else if (v.isObject)
+    {
+        size_t count = 0;
+        foreach (k, ref m; v)
+            ++count;
+        buf ~= Tag.map;
+        buf.put_varint(count);
+        foreach (k, ref m; v)
+        {
+            buf.put_str(k);
+            buf.put_variant(m);
+        }
+    }
+    else if (v.isNumber && !v.is_enum && !v.isQuantity)
+    {
+        if (v.isDouble)
+        {
+            buf ~= Tag.f64;
+            buf.put_f64(v.asDouble);
+        }
+        else if (v.isUlong && v.asUlong > long.max)
+        {
+            buf ~= Tag.uint_;
+            buf.put_varint(v.asUlong);
+        }
+        else if (v.asLong < 0)
+        {
+            buf ~= Tag.int_;
+            buf.put_zigzag(v.asLong);
+        }
+        else
+        {
+            buf ~= Tag.uint_;
+            buf.put_varint(v.asLong);
+        }
+    }
+    else
+    {
+        // quantities, enums, user types: string form; receivers parse
+        buf ~= Tag.str;
+        ptrdiff_t len = v.toString(null, null, null);
+        if (len <= 0)
+        {
+            buf.put_str(null);
+            return;
+        }
+        buf.put_varint(len);
+        v.toString(cast(char[])buf.extend(len), null, null);
+    }
+}
+
+struct Reader
+{
+nothrow @nogc:
+
+    const(ubyte)[] buf;
+    size_t pos;
+    bool fail;
+
+    ubyte u8()
+    {
+        if (pos >= buf.length)
+        {
+            fail = true;
+            return 0;
+        }
+        return buf[pos++];
+    }
+
+    ulong varint()
+    {
+        ulong v = 0;
+        uint shift = 0;
+        for (;;)
+        {
+            ubyte b = u8();
+            if (fail)
+                return 0;
+            v |= ulong(b & 0x7F) << shift;
+            if (!(b & 0x80))
+                return v;
+            shift += 7;
+            if (shift >= 64)
+            {
+                fail = true;
+                return 0;
+            }
+        }
+    }
+
+    long zigzag()
+    {
+        ulong v = varint();
+        return long(v >> 1) ^ -long(v & 1);
+    }
+
+    double f64()
+    {
+        if (pos + 8 > buf.length)
+        {
+            fail = true;
+            return 0;
+        }
+        double d = *cast(const(double)*)(buf.ptr + pos);
+        pos += 8;
+        return d;
+    }
+
+    const(char)[] str()
+    {
+        size_t n = cast(size_t)varint();
+        if (fail || pos + n > buf.length)
+        {
+            fail = true;
+            return null;
+        }
+        const(char)[] s = cast(const(char)[])buf[pos .. pos + n];
+        pos += n;
+        return s;
+    }
+
+    // depth-limited: a hostile frame can't recurse the stack away
+    Variant variant(uint depth = 0)
+    {
+        enum max_depth = 16;
+        if (depth > max_depth)
+        {
+            fail = true;
+            return Variant();
+        }
+
+        ubyte tag = u8();
+        if (fail || tag > Tag.max)
+        {
+            fail = true;
+            return Variant();
+        }
+        final switch (cast(Tag)tag) with (Tag)
+        {
+            case nil:
+                return Variant();
+            case false_:
+                return Variant(false);
+            case true_:
+                return Variant(true);
+            case uint_:
+            {
+                ulong v = varint();
+                return v <= long.max ? Variant(long(v)) : Variant(v);
+            }
+            case int_:
+                return Variant(zigzag());
+            case f64:
+                return Variant(this.f64());
+            case str:
+                return Variant(this.str());
+            case arr:
+            {
+                size_t count = cast(size_t)varint();
+                if (fail || count > buf.length - pos)
+                {
+                    fail = true;
+                    return Variant();
+                }
+                Variant a;
+                foreach (i; 0 .. count)
+                {
+                    Variant e = variant(depth + 1);
+                    if (fail)
+                        return Variant();
+                    a.asArray ~= e.move;
+                }
+                return a.move;
+            }
+            case map:
+            {
+                size_t count = cast(size_t)varint();
+                if (fail || count > buf.length - pos)
+                {
+                    fail = true;
+                    return Variant();
+                }
+                Variant m;
+                foreach (i; 0 .. count)
+                {
+                    const(char)[] key = this.str();
+                    Variant e = variant(depth + 1);
+                    if (fail)
+                        return Variant();
+                    m.insert(key, e.move);
+                }
+                return m.move;
+            }
+        }
+    }
+}
+
+
+unittest
+{
+    Array!ubyte buf;
+
+    // varint + zigzag round-trip across the value range
+    foreach (ulong v; [ulong(0), 1, 127, 128, 300, 0xFFFF, 0xFFFF_FFFF, ulong.max])
+    {
+        buf.clear();
+        buf.put_varint(v);
+        Reader r = Reader(buf[]);
+        assert(r.varint() == v && !r.fail);
+    }
+    foreach (long v; [long(0), -1, 1, -64, 63, long.min, long.max])
+    {
+        buf.clear();
+        buf.put_zigzag(v);
+        Reader r = Reader(buf[]);
+        assert(r.zigzag() == v && !r.fail);
+    }
+
+    // variant round-trip: scalars, strings, nesting
+    // (values avoid the literals 0/1, which D converts to bool, selecting Variant's bool ctor)
+    Variant v;
+    v.asArray ~= Variant(42);
+    v.asArray ~= Variant(-7);
+    v.asArray ~= Variant(101.5);
+    v.asArray ~= Variant("hello");
+    v.asArray ~= Variant(true);
+    Variant m;
+    m.insert("a", Variant(5));
+    m.insert("b", Variant("two"));
+    v.asArray ~= m.move;
+
+    buf.clear();
+    buf.put_variant(v);
+    Reader r = Reader(buf[]);
+    Variant o = r.variant();
+    assert(!r.fail);
+    assert(o.length == 6);
+    assert(o[0].asLong == 42);
+    assert(o[1].asLong == -7);
+    assert(o[2].asDouble == 101.5);
+    assert(o[3].asString == "hello");
+    assert(o[4].isTrue);
+    assert(o[5]["a"].asLong == 5);
+    assert(o[5]["b"].asString == "two");
+
+    // truncation must fail, not crash
+    Reader t = Reader(buf[0 .. 3]);
+    t.variant();
+    assert(t.fail);
+}

--- a/src/manager/sync/package.d
+++ b/src/manager/sync/package.d
@@ -19,7 +19,6 @@ module manager.sync;
 //     hook (analogous to register_object_lifecycle_handler) when needed.
 //   - inbound_enum doesn't correlate pending enum_req forwards - currently
 //     latent (no outbound enum_req emitter exists yet).
-//   - Binary encoder not implemented (deferred to BL808 D0/M0 shmem work).
 //
 // Soft / wasteful but correct:
 //
@@ -76,6 +75,7 @@ import manager.features;
 import manager.log;
 import manager.syslog;
 import manager.system : hostname;
+import manager.sync.binary_encoder;
 import manager.sync.encoder;
 import manager.sync.json_encoder;
 import manager.sync.peer;
@@ -141,6 +141,8 @@ nothrow @nogc:
 
         g_json_encoder = defaultAllocator.allocT!JsonEncoder(this);
         g_encoders[SyncEncoderKind.json] = g_json_encoder;
+        g_binary_encoder = defaultAllocator.allocT!BinaryEncoder(this);
+        g_encoders[SyncEncoderKind.binary] = g_binary_encoder;
 
         g_app.console.register_collection!SyncPeer();
         static if (has_http)


### PR DESCRIPTION
Implements the binary SyncEncoder (encoder=binary on a SyncPeer), covering the full verb surface of the JSON channel: registry, mirror lifecycle, property sync, commands, logs, time sync, and the model plane (type interning, add/val blocks, backfill).

Wire shape: [verb u8][fields]. Integers are LEB128 varints (zigzag where signed), strings length-prefixed, values a small tagged Variant codec (null/bool/varint/zigzag/f64/string/array/map). Types the codec doesn't model natively (quantities, enums, user types) travel as their string form, matching the JSON channel's fidelity. Verbs JSON overloads by field-shape (set/model_set, sub/model_sub, type format/enum) get distinct verb bytes. Decode is bounds-checked with a depth-limited Variant reader; truncated or malformed frames fail cleanly.

Frames transmit with is_text=false, so they ride any raw-frame BaseInterface transport: serial, UDP, and eventually the BL808 shmem ring.

Codec has unittest coverage (varint/zigzag ranges, nested variant round-trip, truncation). Not yet exercised against a live second node.
