### PR TITLE
Interface caps: reliable/ordered delivery promises

### DIFF
--- a/docs/UX_TODO.md
+++ b/docs/UX_TODO.md
@@ -1,0 +1,11 @@
+# UX client task accumulator
+
+Client-visible changes land here as dated task sections; UX clients (sync consumers) work
+through them and remove sections as they are absorbed.
+
+## 2026-08-07: interfaces expose a `caps` property
+
+- All `/interface` collections gain a read-only `caps` bitfield property naming the
+  interface's transport promises: `ethernet`, `reliable` (acknowledged/retransmitted
+  delivery), `ordered` (in-order delivery). Clients rendering interface detail views may
+  surface it; absence of a flag means no promise, not a fault.

--- a/src/protocol/cpc/package.d
+++ b/src/protocol/cpc/package.d
@@ -127,6 +127,8 @@ nothrow @nogc:
     this(CID id, ObjectFlags flags = ObjectFlags.none)
     {
         super(collection_type_info!CPCInterface, id, flags);
+        _caps |= InterfaceCaps.reliable | InterfaceCaps.ordered;
+        mark_set!(typeof(this), "caps")();
 
         // max-l2mtu is the driver's payload cap; the 9-byte CPC framing is transport overhead, not counted
         // in the MTU (same as CAN/BLE). l2mtu defaults to the cap and is user-reducible; mtu derives from
@@ -1283,6 +1285,8 @@ nothrow @nogc:
     this(CID id, ObjectFlags flags = ObjectFlags.none)
     {
         super(collection_type_info!CPCEndpoint, id, flags);
+        _caps |= InterfaceCaps.reliable | InterfaceCaps.ordered;
+        mark_set!(typeof(this), "caps")();
 
         // same payload cap as the trunk (both carry the CPC payload; framing is the trunk's transport
         // overhead). max-l2mtu starts at the cap and is narrowed to the trunk's learned limit on connect.

--- a/src/protocol/ezsp/ashv2.d
+++ b/src/protocol/ezsp/ashv2.d
@@ -42,6 +42,8 @@ nothrow @nogc:
     this(CID id, ObjectFlags flags = ObjectFlags.none)
     {
         super(collection_type_info!ASHInterface, id, flags);
+        _caps |= InterfaceCaps.reliable | InterfaceCaps.ordered;
+        mark_set!(typeof(this), "caps")();
     }
 
     // Properties...

--- a/src/router/iface/ethernet.d
+++ b/src/router/iface/ethernet.d
@@ -39,6 +39,7 @@ protected:
     {
         super(typeInfo, id, flags);
         _caps |= InterfaceCaps.ethernet;
+        mark_set!(typeof(this), "caps")();
         mac = generate_mac_address(name[]);
     }
 

--- a/src/router/iface/package.d
+++ b/src/router/iface/package.d
@@ -6,6 +6,7 @@ import urt.map;
 import urt.lifetime;
 import urt.mem.ring;
 import urt.mem.string;
+import urt.meta.enuminfo : bitfield;
 import urt.si.unit;
 import urt.si.quantity;
 import urt.string;
@@ -48,10 +49,12 @@ enum PacketDirection : ubyte
     outgoing = 2
 }
 
-enum InterfaceCaps : ushort
+@bitfield enum InterfaceCaps : ushort
 {
     none     = 0,
     ethernet = 1 << 0, // attaches to an ethernet segment; marshals exotic packets over the OW ethertype
+    reliable = 1 << 1, // delivery is acknowledged and retransmitted; loss surfaces as an error, never silently
+    ordered  = 1 << 2, // frames are delivered in transmit order
 }
 
 enum MessageState
@@ -193,7 +196,8 @@ MACAddress generate_mac_address(const(char)[] name) pure
 
 class BaseInterface : ActiveObject
 {
-    alias Properties = AliasSeq!(Prop!("actual-mtu", actual_mtu, null, "d"),
+    alias Properties = AliasSeq!(Prop!("caps", caps),
+                                 Prop!("actual-mtu", actual_mtu, null, "d"),
                                  Prop!("mtu", mtu, null, "d"),
                                  Prop!("l2mtu", l2mtu),
                                  Prop!("max-l2mtu", max_l2mtu, null, "d"),
@@ -718,6 +722,7 @@ nothrow @nogc:
 
     override void pre_init()
     {
+        g_app.register_bitfield!InterfaceCaps();
         g_app.register_enum!ConnectionStatus();
         g_app.register_enum!LinkStatus();
         g_app.register_enum!VlanTag();


### PR DESCRIPTION
Extends `InterfaceCaps` with delivery-promise flags so consumers can ask an interface what its transport guarantees are:

- `reliable`: delivery is acknowledged and retransmitted; loss surfaces as an error, never silently
- `ordered`: frames are delivered in transmit order

`InterfaceCaps` is now a `@bitfield` enum, registered with the runtime, and exposed as a read-only `caps` property on all interfaces (UX_TODO.md notes the client-visible addition).

Flags are claimed conservatively: ASHInterface and CPCInterface/CPCEndpoint set `reliable|ordered` (both run ARQ with retransmit and per-channel FIFO). Everything else keeps `none` until audited; candidates for a follow-up pass include CAN (controller-level ack/retransmit), zigbee (APS acks), and I2C (completion-reported transactions, but PCP queueing breaks ordering).

The UDP interface (PR #460) needs no change: no promises is the default.