### PR TITLE
Element-backed properties: BaseObject properties as data-model elements

### DIFF
--- a/docs/PROP_ELEMENTS.draft.md
+++ b/docs/PROP_ELEMENTS.draft.md
@@ -1,0 +1,338 @@
+# Property Projection: BaseObject properties as data-model elements
+
+Status: partially built. This is the design for the convergence step the sync protocol draft
+defers to ("gated on the property-projection work in id.d"): object properties stop being ad-hoc
+getter/setter pairs with hand-rolled dedup and dirty tracking, and become elements in the
+data-model space.
+
+Built: the `Elem!` declaration form, the per-object element block, synthesized get/set/reset with
+Default/Min/Max/Check/OnChange, the proxy side-effect gate, and SerialStream's framing properties
+as the first migration. Not built: the descriptor split, reference properties, state-machine
+properties, and the retirement of the per-object sync delta machinery. Deviations from this
+document where it describes the built part are called out inline.
+
+## What exists that this stands on
+
+- id.d:24 already specifies the identity: property projections COMPUTE their EID as
+  `(obj CID, Prop! index)` -- a compile-time literal, no lookup, no cache. Element index 0 is the
+  container, so properties claim indices 1..N and dynamic/profile elements allocate above.
+- `Constraint` (series.d) already carries min/max/step plus a `check_fn` escape hatch, hangs off
+  `DataFormat`, and is enforced nowhere. The sync draft notes constraint enforcement and the
+  min/max/step `type`-frame fields "land together".
+- `register_value_format!T` already maps the property-type vocabulary: bool, integers, floats,
+  enums (with `enum_info` so the wire gets the dictionary), String/text, Duration (s64
+  nanoseconds), Quantity, and registered user pods.
+- The Element write path already provides everything setters hand-roll today: held-series dedup
+  (`held_repeat`), timestamping, subscriber delivery with previous+new value, commit-scope frame
+  coherence, the per-tick dirty sweep, and (via the sync branch) per-peer pending-EID feeds.
+- The sync `set` verb is already specified to serve "element writes and object property writes"
+  as one thing, with `res {seq, value}` carrying the authority's applied value.
+
+## The shape
+
+### Storage: the element IS the store
+
+A migrated property has no member field. `BaseObject` gains one pointer to an
+`Element[num_props]` block, allocated in one piece at construction and sized from the type's
+static property table; a property is reached by indexing it with `prop_index!(T, "baud")` -- a
+compile-time literal. Reads and writes go through Element's typed door (`read!T` / `try_write!T`),
+which is the counterpart of the boxed `value`/`try_set` pair: same records, same constraint gate,
+no Variant. Nothing outside Element reinterprets a record, so the type check lives once, where the
+format is (`scalar_type!T == data_format.type`, which sees through an enum to its base -- a
+size-based check would alias `u32` with `f32`).
+Prop index == element index, so `eid` is `_id.element(prop_index!(T, "baud") + 1)`
+(index 0 being the container), also a constant. A small block header (the owning object) would let
+an `Element*` recover its owner and index by arithmetic, which is what makes `parent`/`_eid`
+derivable rather than stored.
+
+As built, property elements mint no EID: nothing resolves an object-CID container, so a minted
+handle would deref to null. It lands with the model-surface exposure that needs it, together with
+the resolve path. The change handler recovers its index by subtracting the block base, so the
+header is not needed yet either.
+
+Also as built, the block is sized by the type's TOTAL property count, not its element-backed
+count, because the prop index is the slot index. SerialStream has 22 properties of which 5 are
+element-backed, so it allocates 2288 bytes to use 520. The waste shrinks as migration proceeds
+and vanishes when a class is fully migrated, but a per-type prop-index -> slot map (a byte per
+property in `CollectionTypeInfo`, one extra indirection per access) removes it now if the
+transitional cost bites.
+
+Per-type metadata moves into `CollectionTypeInfo` (computed once at type registration, when
+formats can be interned): per-property `FormatId`, `Constraint*`, declared default, and hooks.
+Property elements never allocate a `SeriesStore` unless someone asks for retention.
+
+### Element layout: the descriptor split
+
+Element is ~104 bytes on x86-64, but only ~48 of that is per-instance value state:
+
+| field | bytes | class |
+|---|---|---|
+| `id` `name` `desc` `display_unit` (4x String) | 32 | identity / schema |
+| `_eid`, `parent` | 16 | identity |
+| `access` `sampling_mode` `format` (+pad) | 8 | schema |
+| `last_update`, `_latest`, `_last_update` | 24 | value state |
+| `_subs`, `_history` | 16 | value state |
+| `_dirty` `_flags` (+pad) | 8 | value state |
+
+For a property projection every identity/schema byte is shared per collection type: `id` is the
+property name (an interned StringLit), desc/display_unit/format/access/sampling are declaration
+constants, `_eid` is computable (id.d:24 -- that is its point), and `parent` is derivable when the
+cells sit in one per-object block with a small header (owner + arithmetic recovers the index).
+
+So the layout move is a descriptor split: `Element` becomes
+`{ const ElementDesc* desc; ...value state... }` with `ElementDesc` carrying
+id/name/desc/display_unit/format/access/sampling. Property cells land around 48-56 bytes, and the
+same split compresses profile-created device elements -- N devices materialized from one profile
+currently duplicate identical schema Strings per element; with the split they share one descriptor
+table per profile version, which id.d already plans ("profile elements take their template index,
+deterministic per profile version") and component.d's `FieldTemplate` stub half-starts. On a busy
+instance the profile-element savings likely exceed what property migration adds.
+
+Also audit the `last_update` / `_last_update` pair (they diverge only through held-repeat and
+`force_update` stamping); if one can derive from the other, that is 8 more bytes per element.
+
+### Declaration
+
+Two forms coexist in one `Properties` list so migration is per-property, not per-class:
+
+```d
+alias Properties = AliasSeq!(
+    // element-backed: no member function pair, no member field
+    Elem!("baud", uint, Default!9600, Min!300, Max!921600, OnChange!restart),
+    Elem!("protocol", ModbusProtocol, Check!protocol_check, OnChange!restart),
+
+    // legacy form: hand-written getter/setter, unchanged, not element-backed (yet)
+    Prop!("stream", stream),
+);
+```
+
+`Elem!` carries: name, type, optional `Default!`, optional `Min!`/`Max!` (folded into the
+format's `Constraint`), optional `Check!` function, optional `OnChange!` member function,
+optional `ReadOnly`, and the `Category!`/`PropFlags!` presentation metadata the legacy form takes
+positionally.
+
+`ReadOnly` means read-only *to the outside*, not immutable: the owning object still pokes the
+value in. That asymmetry is the whole point for derived state -- link status, counters, and
+eventually `running`/`status` -- so the two directions take different doors. The external entries
+(`BaseObject.set`, `reset`, and therefore the console, sync inbound, and collection create)
+refuse with the same "is read-only" message a getter-only legacy property produces; the owner
+writes through `prop_write`, which calls the property's setter directly and does not consult the
+flag. The element's `Access` follows the declaration (`read` vs `read_write`), so the model
+surface serves the truth once property elements are exposed on it.
+
+Owner writes still mark `_props_set`, deliberately: that bit is what makes a mirror receive the
+value, and a proxy cannot recompute derived state (the same reason the encoders emit set
+read-only properties).
+
+No `Step!`: `Constraint.check` honours min/max and `check_fn` only, so a declared step would not
+validate. `Constraint.step` remains for profile-driven formats, where it is wire/UI metadata
+rather than a promise.
+
+Typed accessors are hand-written one-liners over `prop_read!(Type, name)` /
+`prop_write!(Type, name)` rather than generated by a mixin, so internal call sites keep reading
+`baud()` and assigning `baud = x`. Both resolve the declaration at compile time, so the accessor
+never restates the property's type: `ElemType!(Type, name)` is the declaration's. A mixin would
+remove the remaining two lines per property but has to invent accessor names (`"baud-rate"` ->
+`baud_rate`) and their const-ness; that is the only reason it is not done here.
+
+### Validation: two layers, both before commit
+
+Every writer lands on one typed function, `elem_apply!T`, holding the declared type. It runs:
+
+1. **Per-prop check function**: `const(char)[] function(ref T value)` -- static, typed, may
+   normalise (rewrite the value through the ref) or reject (return the error). It sees
+   `Parity.mark`, not a Variant. Instance-dependent validation does not belong here; that is
+   `validate()`'s job, unchanged.
+2. **Universal constraint**, inside `Element.try_write` -- min/max from the declaration, enforced
+   in the data model for every writer (console, sync `set`, automation, internal code). This is
+   the same enforcement point the element write path needs anyway for remote `set` on ordinary
+   elements; property projection inherits it. Constraint also rides the `type` frame as UI/schema
+   metadata, so remote UIs can range-check before sending.
+
+**Variant is not part of that path.** It appears at exactly one place, and only because a Variant
+is what genuinely arrives there: the by-name entry (`BaseObject.set`, hence the console, sync
+inbound, and collection create) converts once to the declared type and joins the typed function.
+The owner's `prop_write!(Type, name)` resolves its declaration at compile time and calls straight
+in. Element's type-erased value currency is `Scalar`, not `Variant` -- `Constraint.check` already
+takes a `Scalar`, and `Scalar.of(v)` stores a typed value into one -- so nothing in the
+enforcement chain ever wanted boxing.
+
+**And the machinery instantiates per value type, never per property.** Everything
+property-specific -- element slot, check, on_change, format, read-only -- is data in the
+`Property` table, and the get/set function pointers receive the `Property` they were reached
+through (every call site was already iterating `properties()`, so the metadata pointer was
+already in hand). Ten `uint` properties across ten classes share one `elem_set!uint`; the getter
+is one function for the whole program, because boxing follows the element's runtime format. The
+optional hooks are exactly the per-declaration residue: a `Check!` costs one thin shim restoring
+the declared type from the erased pointer, an `OnChange!` target costs one trampoline shared by
+every property that names it, and the one-shot format interner stays per-declaration because it
+caches its `FormatId`.
+
+Only then does the value commit to the element. A rejected write never touches the store and the
+error string flows back exactly as setter error strings do today.
+
+### Dedup, dirty, notify: free, and better
+
+The element write path replaces, per setter, the hand-written:
+
+- `if (_x == value) return;`      -> held-series dedup (equal write advances timestamps only,
+                                     fires nothing)
+- `mark_set!(T, "prop")()`        -> element dirty sweep + per-peer pending-EID sets
+- per-channel `SyncState` bitmask -> dissolves entirely; the object mirror's
+                                     `attach_delta_slot`/`props_dirty` machinery retires with it
+- subscriber notification         -> `SampleUpdate` delivery with previous+new value and
+                                     commit-scope coherence
+
+A behavioural improvement becomes *available*, but is not free: because side effects are
+subscriber deliveries, wrapping a multi-property command in a commit scope would coalesce them,
+so `/interface/modbus/set inv baud=19200 protocol=rtu` would restart once after both apply
+rather than once per property. Nothing collects that today -- the only `open_commit()` in the
+tree is `ComponentLink.populate()`, and the console opens no scope around command execution, so
+each set still delivers immediately and restarts independently, exactly as the old setters did.
+Claim it by opening a scope around console command execution (and around the named-argument loop
+in collection create), not by anything in the property machinery.
+
+### Side effects: the real migration surface
+
+Today's setters interleave three concerns; validation and commit are covered above. What remains
+is side effects, and they become one of:
+
+- **`OnChange!"restart"`** -- by far the dominant pattern; a declared hook the property table
+  stores as a member-function pointer, invoked on actual change (dedup'd writes skip it, exactly
+  as the early-return does today).
+- **Self-subscription** -- the object subscribes to its own property element for anything richer
+  (derived state like `_support_simultaneous_requests`, reference-swap teardown). The handler
+  sees previous and new value in the update, which is more than today's setters get.
+
+Deliberately NOT provided: an arbitrary imperative body in the write path. If a property needs
+one, it stays on the legacy `Prop!` form until it can be decomposed.
+
+### The special properties
+
+- **`name`** -- identity, lives in the IdAllocator; rename is structural, not a value write.
+  Never migrates.
+- **`disabled`** -- drives the state machine bits directly; stays bespoke.
+- **`type`** -- a per-type constant; schema, not state.
+- **ObjectRef properties** (`stream=`, `iface=`) -- migrate early, not late. Storage is trivial:
+  `EID(cid, 0)` in the 8-byte Scalar; the typed accessor wraps it back into `ObjectRef!T`
+  semantics (table deref, null when tombstoned) and held-dedup is a raw compare. What is missing
+  is edge vocabulary only: a fourth member of the DataFormat descriptor union
+  (`const(CollectionTypeInfo)*` beside unit/enum_info/user_type) meaning "reference to collection
+  type X", so `from_variant` converts name -> id at the console/sync edge, the wire carries the
+  name (principle 1), and the write path type-checks the target's CID type bits. Bonus:
+  `IdAllocator.reserve` means assigning a name that does not exist yet stores a reserved id that
+  auto-binds on claim -- the structural fix the startup-latency TODO (base.d:33) asks for falls
+  out of element-backed refs for free. The subscription-lifecycle pattern (unsubscribe old /
+  subscribe new / restart) maps onto a change handler that receives previous+new.
+
+### Derived state-machine views: the hard part
+
+`running`, `status`, and `flags` are not stored values with dirty bits; they are pull-computed
+views over the state-machine bits, and `mark_set` on them means "tell mirrors to re-read the
+getter". An element is a push model: something must WRITE the value at the moment it changes.
+The change sites are uneven:
+
+- **`running`** is clean: `set_online`/`set_offline` are exactly the transition points; they
+  become ordinary element writes.
+- **`status`** is nearly clean: `status_message` is a pure function of `_state` (plus
+  `_fail_reason`, which is always assigned before the transition that exposes it), so one write
+  in `set_state` after the transition covers every site. Held dedup then makes the "probably
+  over-dirty's" HACK comment precise instead of apologetic: redundant writes cost nothing and
+  notify nobody. The state-transition *event* additionally lands as a `point` element, per the
+  sync draft ("`state` becomes a built-in event node on every object"); `StateSignal`
+  subscription becomes element subscription for consumers that only want online/offline.
+- **`flags` does not migrate.** It folds in `validate()`, a live pull that can flip with no
+  local event at all -- a referenced dependency comes into existence and nothing on this object
+  runs. Note today's mirror is ALREADY stale in that case (no `mark_set` fires when a dependency
+  materializes elsewhere), so a push element would lose nothing, but it cannot be made correct
+  either without a write site that does not exist. `flags` is a presentation aggregate for
+  `print`; it stays a legacy computed property and peers compose it from
+  `status`/`running`/`disabled`.
+- The constructor's `mark_set(name/type/flags)` seeding is initial-sync knowledge; it becomes
+  configured-bit seeding, with the wrinkle that construction runs before collection insertion.
+
+And one pre-existing sharp edge this migration steps on directly: **element teardown vs deferred
+machinery**. `g_dirty_elements` and the pending-update queue hold raw `Element*`, and
+`teardown()` purges neither. Today object death with elements is rare; property cells embedded in
+every object make it routine, and an object destroyed inside a commit scope would leave freed
+pointers in both lists. Either teardown unlinks from both, or property-element memory reaps on
+the same deferred schedule as the object (`defer_free` already exists for exactly this ordering
+problem). This is a prerequisite build item, not a footnote.
+
+### `_props_set`, defaults, reset
+
+`_props_set` conflates "explicitly configured" (config export, schema) with "changed" (sync
+dirty). The dirty half dissolves into the element sweep. The configured half becomes one bit per
+element ("written by a configurer" vs "holding its declared default") -- config export lists
+exactly the configured set, as today.
+
+Declared `Default!` replaces the synthesised `init_val` (which derives from the getter's return
+TYPE's `.init` and is fragile by its own admission -- `assert_reset_matches_init` exists because
+divergence "would silently desync mirrors"). Reset writes the declared default through the normal
+write path: constraint-checked, dedup'd, change-hooked, and the sync `res` carries the applied
+value, per the sync draft's authority-side reset semantics. The whole "receiver infers post-reset
+value" fragility is deleted rather than fixed.
+
+### Console and paths
+
+`get`/`set`/`print`/`gather` walk the same `Property` table; for element-backed entries the
+GetFun/SetFun are synthesized against the element instead of member functions. Names, categories,
+suggest-completion, and the CLI surface are unchanged.
+
+In the model space, properties appear under the object's node: `interface.modbus:inv.baud`.
+Collections become namespaces (per the sync draft's convergence table), so the pattern grammar,
+`sub`, `set`, and automation triggers (`on="@..."` element URIs) all apply to configuration for
+free -- an automation can watch a config property with the same mechanism it watches a battery
+voltage. This is an emergent capability, not extra work.
+
+One wrinkle: `Element.parent` is a `Component`, and property elements have no component tree.
+Path derivation for a property element must root at the owning object (container name from the
+CID, segment from the property name). Either `Element.parent` generalises to an EID (id.d's
+"paths resolve by composition" direction) or property elements carry a null parent and path
+logic branches on container class. Decide when building; the former is the structural fix.
+
+## Migration order
+
+1. **Constraint enforcement in the element write path** + min/max/step/default on the `type`
+   frame. Standalone, already a declared pending item on the sync branch, benefits ordinary
+   elements immediately.
+2. **Per-type property metadata**: `CollectionTypeInfo` gains FormatId/Constraint/default/hooks
+   per property; formats interned at type registration.
+3. **The element block on BaseObject** + `Elem!` declaration form + `mixin ElemAccessors` +
+   synthesized element-backed GetFun/SetFun. Legacy `Prop!` untouched beside it.
+4. **Element teardown unlinks from the dirty list and pending-update queue** (or reaps on the
+   `defer_free` schedule) -- prerequisite for objects that die carrying elements.
+5. **Migrate leaf value properties** class by class (baud, mtu, timeouts, booleans, enums,
+   comment). Delete member fields, delete `mark_set` calls, declare `OnChange`/checks. Each class
+   is a small, verifiable diff.
+6. **The reference descriptor** (`CollectionTypeInfo*` slot in the DataFormat union + name<->id
+   edge conversion), then ObjectRef properties; pending references via `IdAllocator.reserve`
+   retire the synchronous-tick HACK.
+7. **State machine writes `running`/`status`/state-event as elements** (see the derived-views
+   section; `flags` deliberately stays behind). Last of the migrations because the change sites
+   are lifecycle-entangled. These are the first real `ReadOnly` users: the state machine pokes,
+   the operator reads.
+8. **Retire the per-object property sync machinery**: `SyncState`, `attach_delta_slot`,
+   `props_dirty`, `_props_set` dirty half; the object mirror's property verbs dissolve per the
+   sync draft's convergence table.
+
+## Costs and open questions
+
+- **RAM on TINY targets.** The descriptor split (above) is the answer to Element's ~104-byte
+  weight: property cells land near 48 bytes and profile elements shrink too, so a modest object
+  population costs ~25KB rather than ~50KB, partially repaid by deleted member fields and the
+  retired `SyncState` array. Still worth a real measurement on the BL808 profile before step 5
+  proceeds far -- sibling sync is precisely the BL808 case, so compiling property elements out
+  under TINY forfeits the point.
+- **Getter cost.** A field read becomes an indexed load + Scalar reinterpret. Irrelevant at 20Hz
+  control rates; only worth thought if a property read lands on a packet path (none do today).
+- **Startup ordering.** Writes apply eagerly and deliver lazily, so `validate()` reading freshly
+  set properties inside the startup-script synchronous tick still sees applied values. But
+  OnChange-by-subscription defers `restart()` to end of commit; the interaction with the
+  synchronous-tick HACK in collection_commands.d (base.d:33 TODO) needs a test the moment the
+  first migrated class lands.
+- **Normalising checks vs wire acks.** The check lambda may rewrite the value; sync `set` must
+  ack the APPLIED value. The sync draft already specifies exactly this (`res {seq, value}`), so
+  the two designs agree; just do not ack before the check runs.
+- **Property categories/flags** (`*`, `d`, `h`) carry over to the `Elem!` form unchanged; they
+  are presentation metadata and orthogonal to storage.

--- a/docs/TAPS_AND_TUNNELS.draft.md
+++ b/docs/TAPS_AND_TUNNELS.draft.md
@@ -1,0 +1,221 @@
+# Taps and Tunnels: remote interfaces and capture views
+
+Status: design exploration on ow/dm-props. Companion to SYNC_PROTOCOL.draft.md (the model plane)
+and PROP_ELEMENTS.draft.md (properties as elements). Nothing here is built.
+
+Two demands look like one ("remote interfaces should be accessible as if they were our own") but
+have opposite requirements, and forcing one mechanism to serve both would wreck it for each:
+
+| | participation (bind to a remote port) | observation (capture view) |
+|---|---|---|
+| direction | bidirectional | rx-only |
+| loss | unacceptable (transactions) | acceptable, must be HONEST |
+| latency | per-frame, low | per-tick flush is fine |
+| consumer | a protocol binding / the fabric | a passive UI, read-only |
+| natural home | packet fabric | model plane |
+
+## Taps: capture is a point-series element
+
+Every Stream and BaseInterface grows a built-in element (`tap`), `SeriesKind.point`, whose records
+are the frames (interfaces) or read/write chunks (streams). This is the series contract's declared
+direction ("waveform/byte/packet taps host the same formats without becoming elements") taken one
+step further: the tap IS an element, because then the whole built model surface serves capture
+with no new verbs:
+
+- `sub {mode:all}` -- live follow (`mode:all` is already forced for point series; no coalescing).
+- `sub {once, from, to}` -- historical capture query over whatever retention holds.
+- `retention` -- the capture window, set per tap, zero when nobody asked.
+- `lost` -- overrun honesty; a capture that skipped frames says so instead of lying.
+- Access -- taps are `Access.read`; a passive UX is just a subscriber, no participant machinery.
+- Remote -- a satellite's tap mirrors through the hub like any element; the UX cannot tell.
+
+The existing producers converge instead of multiplying: serial's `has_tap`/`write_to_log` sites
+and the PCAP tap/server become writers (or consumers) of the same element. One capture spine,
+three faces: wireshark via pcap_server, UX via sync, recorder via db.
+
+Costs: one Element per stream/interface (~100 bytes today, ~48 after the descriptor split), zero
+series storage until someone sets retention or subscribes. Record writes only happen while a
+subscriber or cursor exists (the `_subs`/cursor checks already gate this shape cheaply).
+
+### Substrate gaps (the actual work)
+
+1. **Dynamic blob records.** Text records exist (TextRecord: embed or String handle); the
+   equivalent dynamic `u8` blob record (count=0) is declared in the format vocabulary but not
+   implemented in the store. Packet payloads need it. Same embed-or-handle shape as text.
+2. **The tap record format.** Bytes plus a small fixed prefix: direction (rx/tx) and, for
+   interfaces, enough framing identity to decode (the interface's PacketType plays the role of
+   pcap's linktype, cited by the tap's DataFormat so a viewer knows how to parse). Keep it
+   opaque bytes past the prefix; protocol-aware decode is a viewer concern, not a store concern.
+3. **Wire form for blobs.** `owsig.container_serialisable` must pass the blob format; the JSON
+   encoder needs a bytes encoding (hex or base64); the binary encoder carries them raw.
+4. **Rate bounding.** A busy CAN bus is thousands of frames/s; `rate`/`deadband` do not apply to
+   point series by design. The protections are retention ceilings plus `lost` -- same posture as
+   flow control in the sync draft: honesty over buffering. A JSON/websocket viewer that cannot
+   keep up sees `lost`, not silent gaps.
+
+## Tunnels: participation is a packet-fabric interface
+
+The load-bearing case: a switch-tier satellite (`FEATURES=switch`, the BL808 M0 shape) has the
+niche port but NO protocol modules by design; the master has the protocols but not the port.
+"Run the binding where the port is" is not available on that tier, so the master must reach the
+remote port -- and a protocol transaction cannot ride a feed that flushes at end of commit each
+tick (up to one tick of latency per hop per direction, and model feeds may coalesce or report
+loss; both are wrong for request/response).
+
+So participation does not touch the model plane at all. The shape is a **proxy interface** on
+the master plus a **dataplane channel** on the peer link, and most of it already exists:
+
+**The proxy is the is_remote mirror.** Remote objects already suppress their entire backend:
+`do_update()` and `restart()` early-out on `is_remote`, so startup/shutdown/update never run,
+and lifecycle state arrives via `set_remote_state`. With element-backed properties the property
+half dissolves into ordinary element sync: a proxy's property elements ARE mirrored elements. A
+write at the proxy routes to the authority and the element updates when the applied value echoes
+back (the sync draft's non-optimistic `set` contract); side effects are authority-only -- the
+proxy's `prop_element_changed` skips `on_change` hooks on remotes (built), so an echo never runs
+reconfigure-in-place handlers against hardware that is not there.
+
+**One connection, two prioritized channels.** Control verbs and dataplane frames interleave on
+one foreign transport: one socket to authenticate and reconnect, dataplane frames as their own
+frame kind that jumps the sender's queue. Head-of-line blocking is bounded by `max_frame`, which
+`hello` already negotiates -- a peer carrying a tunnel negotiates it down. On the sibling
+transport the answer inverts: no interleaving, a separate packet-sized SPSC ring beside the
+control ring. "Two channels per peer" is the abstraction; whether they share a pipe is the
+transport's decision.
+
+**Forwarding is subscription-driven, and the machinery lives in the tunnel endpoint, not in
+Stream/Interface.** `BaseInterface.subscribe(handler, PacketFilter)` already is the dispatch. A
+consumer binding to the proxy causes a subscribe control message upstream; the satellite's
+tunnel endpoint then registers an ordinary local subscriber on the real interface whose handler
+encodes onto the dataplane channel (and unregisters on unsubscribe or peer loss, the standard
+subscribe/unsubscribe discipline). The fabric classes stay completely unaware of remoteness.
+Consequences: the `PacketFilter` travels with the subscription, so filtering happens satellite-
+side and the tunnel carries only matching packets; traffic is demand-driven, so an unbound proxy
+costs zero bytes (better than an always-on L2 bridge). TX mirrors it: the proxy's `send()`
+encodes onto the dataplane channel, the satellite endpoint injects into the real interface.
+
+- The master-side proxy presents as a local interface: MAC, MTU, PacketType of the remote (all
+  mirrored properties). A Modbus/CAN/whatever binding attaches to it by name, with sequence
+  correlation, address translation, and PCP priority working unchanged. Zero new binding
+  concepts.
+- Transport classes per the sync draft: foreign (TCP/websocket = reliable, adds RTT) and sibling
+  (the D0/M0 shmem rings from the tickless-queue plan = the fast path). Same abstraction at
+  every class; only the pipe underneath changes.
+
+Configuration shape (sketch): the master drives it -- `/interface/tunnel add name=sat-can
+peer=sat0 remote=can1` -- or the proxy simply materializes when the peer's interface mirrors in,
+and binding to it arms the forwarding subscription. Explicit satellite-side config is only
+needed until collection-method `call` lands.
+
+**Stream tunnels** are the same concept one layer down: a Stream subclass over the peer link, the
+satellite piping its serial port into its end, the master seeing an ordinary local Stream that a
+ModbusInterface (or anything stream-backed) attaches to. Simpler than the interface tunnel (a
+byte pipe, no packet framing), and probably the first one to build; the choice of layer is the
+operator's -- tunnel the port (stream) when the master should own framing, tunnel the interface
+when the satellite already frames.
+
+What tunnels deliberately do NOT promise: distributed clock-perfect timestamping (tap records on
+the satellite carry satellite time, disciplined by the existing time verbs), or multi-hop mesh
+routing (star topologies, same posture as the mirror).
+
+## Link classes: the tunnel protocol
+
+The peer contract is "N prioritized channels"; what makes that stand up on a given medium is the
+link adaptor underneath, and the media split three ways:
+
+- **Stream transports** (TCP, websocket, TLS): already reliable and ordered. Channels are frame
+  kinds multiplexed on the stream; NO link protocol is added. Running an ARQ over a reliable
+  stream is the classic TCP-over-TCP pathology: the outer retransmit timer fires against the
+  inner one's stalls and latency melts down. If it is a stream, mux and nothing else.
+- **Sibling rings** (BL808 D0/M0 shmem): lossless by construction; one SPSC ring per channel.
+- **Lossy media** (UART/RS485, UDP, raw 802.15.4): this is where the tunnel protocol lives, and
+  the established protocol is already in the tree: **CPC** (protocol/cpc, 1.7k lines, live).
+  Numbered endpoints each with their own seq/ack window, a system endpoint, CRC-16 framing that
+  assumes only an 8-bit-clean pipe, and PCP-priority scheduling ACROSS endpoints with strict
+  FIFO within one -- which is precisely the "two prioritized channels" contract. Endpoint 1 =
+  sync verbs (reliable), endpoints 2..n = dataplane channels. It does ASH's job but multiplexes;
+  ashv2 stays where it is (EZSP-specific) and does not generalise.
+
+**Reliability is asymmetric by design.** The control channel needs ARQ: verbs are stateful and
+loss is corruption. The dataplane mostly does NOT want it: a retransmitted CAN frame arrives
+late and stale, real buses drop frames, and every protocol above already owns its loss story
+(Modbus retries on timeout, CAN bindings are event-shaped, taps report `lost`). So dataplane
+channels are **sequenced but unreliable**: loss is detected and counted -- feeding the same
+`lost` honesty the model plane uses -- not repaired. CPC's frame vocabulary already splits this
+way (numbered i-frames vs unnumbered u-frames); the in-tree implementation currently exercises
+the reliable class only.
+
+Per-medium mapping:
+
+| medium | adaptor |
+|---|---|
+| TCP / websocket / TLS | channel mux on the stream, nothing else |
+| shmem ring | ring per channel |
+| UART / RS485 | CPC frames on the byte pipe (native habitat) |
+| UDP | one CPC frame per datagram; ARQ covers datagram loss, no reassembly |
+| raw 802.15.4 | one CPC frame per MPDU; MAC acks assist, CPC ARQ finishes |
+| Thread proper | that IS an IPv6/UDP network: use the UDP adaptor |
+
+(Raw-15.4 has a pleasing recursion: the radio co-processor link itself speaks CPC, so a leaf
+tunnelled over 15.4 is CPC framed inside a radio driven via CPC.)
+
+**Multi-drop and datagram lowering.** Media split along two axes: byte-pipe vs datagram, and
+point-to-point vs shared. That factoring localises both extensions:
+
+- **Byte-pipe multidrop (RS485/RS422)** is the ONLY case needing an address byte -- 15.4 has MAC
+  addresses and CAN's ID space is the addressing, so only a shared byte pipe has nowhere to say
+  who a frame is for (the reason HDLC grew its address byte). The extension: one station-address
+  byte in the frame header on multidrop links, absent (stock CPC wire format) on point-to-point.
+  ARQ state becomes per (station, endpoint). The larger need is media access: 485 is half-duplex,
+  so the bus runs HDLC-NRM style -- the primary polls, secondaries speak only when addressed,
+  acks piggyback on poll responses. CPC's primary/secondary asymmetry, a liability on symmetric
+  point-to-point links, is an asset here: a multidrop bus wants exactly one master. Costs to
+  record: poll cadence bounds leaf-originated (dataplane/event) latency, and turnaround uses the
+  de-gpio machinery SerialStream already carries.
+- **Datagram media (CAN, 802.15.4, UDP) shed the byte framing.** Flag/length/HCS exist to
+  delimit a byte pipe; a datagram medium delimits and CRCs itself. CPC-the-frame-model
+  (endpoints, numbered vs unnumbered classes, seq/ack where wanted) survives; addressing moves
+  into the medium's own header.
+- **CAN specifically wants LESS protocol.** The controller already does CRC, per-frame ack, and
+  automatic retransmission -- keep sequence numbers to DETECT silent rx-overrun drops, but
+  retransmission logic nearly vanishes (the ARQ-over-reliable rule in softened form). Encode
+  (priority, station, channel) into the CAN ID, priority in the high bits: bus arbitration then
+  IS the cross-channel priority scheduler, in hardware. Segmentation past 8/64-byte payloads is
+  the one real need; ISO-TP (ISO 15765-2) per (station, channel) is the established answer.
+
+**Alternatives considered.** Everything credible here is HDLC-descended; the choice is which
+descendant. Raw HDLC supplies the I/U-frame vocabulary (CPC's numbered/unnumbered split IS that
+split) but no channel mux -- its address byte is multidrop polling -- and its 0x7E byte-stuffing
+is strictly worse than CPC's length-prefixed frames. LAPB is the prior art for symmetric roles
+(the one delta CPC needs) but has no mux and no ecosystem. PPP (in tree) is the OTHER
+architecture: no link reliability by design, because its answer is "run IP and use sockets" --
+correct if a leaf carries the IP stack anyway, unavailable on switch-tier leaves and heavy on a
+slow wire. L2TP, QUIC, and SCTP are all too big for a leaf but are convergent evolution for the
+asymmetry chosen above: reliable control beside sequenced-lossy data (L2TP's channel split,
+QUIC's datagrams-beside-streams, PR-SCTP). COBS is noted as a framing primitive should a
+non-CPC path ever need stuffing-free framing.
+
+Deltas the in-tree CPC needs to serve OpenWatt-to-OpenWatt links, all on its existing TODO
+trajectory or small: symmetric roles (today it is host-primary to Silabs-secondary; two OpenWatt
+peers need a role negotiation or one end adopting the secondary's system-endpoint protocol),
+u-frame support for the unreliable dataplane class, and tx window > 1 for media with real
+latency (window is 1 today, matching Silabs host libraries; fine for UART, poor for UDP RTTs).
+
+## Where they meet
+
+- A tap on the master-side tunnel endpoint captures remote traffic through the local model plane.
+- Or the UX subscribes to the satellite's own tap through hub fan-out, and never touches the
+  tunnel. Both work; the second keeps capture traffic off the master when the viewer connects to
+  the hub anyway.
+- A binding on a tunnel plus a tap on the same tunnel is the "confirm the niche protocol makes
+  sense" workflow: watch the exact bytes the binding is transacting, live, from the UX.
+
+## Build order
+
+1. Dynamic blob records in the series store (tap-independent; the recorder wants them too).
+2. Tap element on Stream + BaseInterface, fed from the existing tap/log sites; local UX capture
+   via the already-built `sub`/`val` surface. This alone delivers the capture view for local
+   interfaces end to end.
+3. Blob wire encoding + serialisability verdicts; remote capture falls out via mirroring.
+4. Tunnel interface over a foreign peer link (TCP first); satellite attach via explicit config.
+5. Sibling-ring tunnel backend when the BL808 dataplane work lands ([[tickless_event_queue_packet_batching]]).
+6. PCAP server and recorder re-plumb onto tap elements (deleting their private capture paths).

--- a/src/manager/base.d
+++ b/src/manager/base.d
@@ -6,6 +6,7 @@ import urt.log;
 import urt.map;
 import urt.meta;
 import urt.meta.enuminfo : bitfield;
+import urt.mem.alloc : alloc, free;
 import urt.mem.string;
 import urt.mem.temp;
 import urt.variant;
@@ -16,7 +17,9 @@ import urt.traits : Parameters, ReturnType, Unqual;
 import urt.util : min;
 
 import manager.console.argument;
+import manager.element : Access, Element, SampleUpdate, SamplingMode;
 import manager.id;
+import manager.series : DataFormat, FormatId, register_format, valid;
 import manager.value;
 
 public import manager.collection : CID, Collection, CollectionType, collection_type_info, CollectionTypeInfo;
@@ -100,13 +103,34 @@ template Prop(string name, alias member, string category = null, string flags = 
     enum f = flags;
 }
 
+template Elem(string name, PropType, options...)
+{
+    enum is_elem = true;
+    enum n = name;
+    alias T = PropType;
+    alias opts = options;
+}
+
+// no Step: Constraint.check honours min/max and check_fn only, so a declared step would not validate
+template Default(alias v)   { enum kind = "default";   alias value = v; }
+template Min(alias v)       { enum kind = "min";       alias value = v; }
+template Max(alias v)       { enum kind = "max";       alias value = v; }
+template Check(alias f)     { enum kind = "check";     alias fn = f; }
+struct ReadOnly             { enum kind = "read_only"; }
+template OnChange(alias f)  { enum kind = "on_change"; alias fn = f; }
+template Category(string s) { enum kind = "category";  enum value = s; }
+template PropFlags(string s){ enum kind = "flags";     enum value = s; }
+
 struct Property
 {
-    alias GetFun = Variant function(BaseObject i) nothrow @nogc;
-    alias SetFun = StringResult function(ref const Variant value, BaseObject i) nothrow @nogc;
+    alias GetFun = Variant function(BaseObject i, ref const Property p) nothrow @nogc;
+    alias SetFun = StringResult function(ref const Variant value, BaseObject i, ref const Property p) nothrow @nogc;
     alias ResetFun = void function(BaseObject i) nothrow @nogc;
     alias DefaultFun = Variant function() nothrow @nogc;
     alias SuggestFun = Array!String function(const(char)[] arg) nothrow @nogc;
+    alias FormatFun = FormatId function() nothrow @nogc;
+    alias ChangeFun = void function(BaseObject i) nothrow @nogc;
+    alias CheckFun = const(char)[] function(void* value) nothrow @nogc; // value is a `ref T` of the declared type
 
     String name;
     String[2] type; // up to 2 types (sometimes like enum + string, or enum + int)
@@ -115,7 +139,13 @@ struct Property
     SetFun set;
     DefaultFun init_val;
     SuggestFun suggest;
+    FormatFun elem_format;  // non-null = element-backed; interns the format on first call
+    ChangeFun on_change;
+    CheckFun check;
+    ushort index;           // == element slot in the property block
     ubyte flags;
+    // not `set is null` like a legacy read-only property: the owner still writes through it
+    bool read_only;
 
     static Property create(string name, alias member, string category = null, string flags = null)()
     {
@@ -125,9 +155,7 @@ struct Property
         Property prop;
         prop.name = StringLit!name;
         prop.category = category ? StringLit!category : String();
-        prop.flags = flags.contains('*') ? 1 : 0; // always
-        prop.flags |= flags.contains('d') ? 2 : 0; // default
-        prop.flags |= flags.contains('h') ? 4 : 0; // hidden
+        prop.flags = parse_prop_flags(flags);
 
         alias Getters = FilterOverloads!(IsGetter, member);
         alias Setters = FilterOverloads!(IsSetter, member);
@@ -170,6 +198,47 @@ struct Property
         // synthesise suggest
         static if (Suggests.length > 0)
             prop.suggest = &SynthSuggest!Suggests;
+
+        return prop;
+    }
+
+    static Property create_elem(alias Decl, size_t index)()
+    {
+        alias T = Decl.T;
+
+        Property prop;
+        prop.name = StringLit!(Decl.n);
+
+        alias Cat = FindElemOpt!("category", Decl.opts);
+        static if (Cat.length)
+            prop.category = StringLit!(Cat[0].value);
+
+        alias Fl = FindElemOpt!("flags", Decl.opts);
+        static if (Fl.length)
+            prop.flags = parse_prop_flags(Fl[0].value);
+
+        prop.read_only = FindElemOpt!("read_only", Decl.opts).length != 0;
+
+        enum type = type_for!T;
+        static if (type)
+            prop.type[0] = StringLit!type;
+
+        prop.index = cast(ushort)index;
+        prop.get = &elem_get;
+        prop.set = &elem_set!T;
+        prop.init_val = &ElemDefault!Decl;
+        prop.elem_format = &ElemFormat!Decl;
+
+        static if (is(typeof(suggest_completion!T)))
+            prop.suggest = &suggest_completion!T;
+
+        alias Chk = FindElemOpt!("check", Decl.opts);
+        static if (Chk.length)
+            prop.check = &CheckShim!(Chk[0].fn, T);
+
+        alias Change = FindElemOpt!("on_change", Decl.opts);
+        static if (Change.length)
+            prop.on_change = &ElemOnChange!(Change[0].fn);
 
         return prop;
     }
@@ -216,6 +285,19 @@ nothrow @nogc:
         _props_set |= ulong(1) << prop_index!(typeof(this), "name") |
                       ulong(1) << prop_index!(typeof(this), "type") |
                       ulong(1) << prop_index!(typeof(this), "flags");
+
+        build_prop_elements();
+    }
+
+    ~this()
+    {
+        if (!_prop_elements)
+            return;
+        foreach (i, p; _typeInfo.properties)
+            if (p.elem_format)
+                _prop_elements[i].teardown();
+        free((cast(void*)_prop_elements)[0 .. _typeInfo.properties.length * Element.sizeof]);
+        _prop_elements = null;
     }
 
     // Properties...
@@ -293,6 +375,24 @@ nothrow @nogc:
     final const(Property*)[] properties() const
         => _typeInfo.properties;
 
+    final ref inout(Element) prop_element(size_t index) inout
+    {
+        debug assert(_prop_elements && _typeInfo.properties[index].elem_format, "property is not element-backed");
+        return _prop_elements[index];
+    }
+
+    ElemType!(Type, prop) prop_read(Type, string prop)() const
+        => prop_element(prop_index!(Type, prop)).read!(ElemType!(Type, prop));
+
+    void prop_write(Type, string prop)(auto ref ElemType!(Type, prop) value)
+    {
+        enum index = prop_index!(Type, prop);
+        StringResult r = elem_apply(this, *_typeInfo.properties[index], value);
+        debug assert(r, tconcat("write to property '", prop, "' refused: ", r.message));
+        if (r)
+            _props_set |= ulong(1) << index;
+    }
+
     // get and set and reset (to default) properties
     final Variant get(scope const(char)[] property)
     {
@@ -302,7 +402,7 @@ nothrow @nogc:
             {
                 // some properties aren't get-able...
                 if (p.get)
-                    return p.get(this);
+                    return p.get(this, *p);
                 return Variant();
             }
         }
@@ -316,9 +416,9 @@ nothrow @nogc:
         {
             if (p.name[] == property)
             {
-                if (!p.set)
+                if (!p.set || p.read_only)
                     return StringResult(tconcat("Property '", property, "' is read-only"));
-                auto r = p.set(value, this);
+                auto r = p.set(value, this, *p);
                 if (r)
                 {
                     // safety-net tracking for old-style classes; for new-style
@@ -348,8 +448,10 @@ nothrow @nogc:
         {
             if (p.name[] == property)
             {
+                if (p.read_only)
+                    return;
                 if (p.set && p.init_val)
-                    p.set(p.init_val(), this);
+                    p.set(p.init_val(), this, *p);
                 _props_set &= ~(ulong(1) << i);
                 mark_dirty(i);
                 return;
@@ -391,7 +493,7 @@ nothrow @nogc:
             }
 
             if (add_item)
-                props.emplaceBack(p.name[], p.get(this));
+                props.emplaceBack(p.name[], p.get(this, *p));
         }
         return Variant(props[]);
     }
@@ -494,6 +596,56 @@ private:
     const CacheString _type; // TODO: DELETE THIS MEMBER!!!
     package CID _id;
     String _comment;
+    Element* _prop_elements;
+
+    void build_prop_elements()
+    {
+        const(Property*)[] props = _typeInfo.properties;
+        bool any = false;
+        foreach (p; props)
+        {
+            if (p.elem_format)
+            {
+                any = true;
+                break;
+            }
+        }
+        if (!any)
+            return;
+
+        void[] mem = alloc(props.length * Element.sizeof);
+        (cast(ubyte[])mem)[] = 0;
+        _prop_elements = cast(Element*)mem.ptr;
+
+        foreach (i, p; props)
+        {
+            if (!p.elem_format)
+                continue;
+            ref Element e = _prop_elements[i];
+            e.id = p.name;
+            e.format = p.elem_format();
+            e.access = p.read_only ? Access.read : Access.read_write;
+            e.sampling_mode = SamplingMode.config;
+            // no EID: id.d's (object CID, prop index + 1) has no resolver, so it would deref to null
+            if (p.init_val)
+            {
+                Variant def = p.init_val();
+                if (!def.isNull)
+                    e.try_set(def);
+            }
+            e.subscribe(&prop_element_changed); // after the default write: defaults are not changes
+        }
+    }
+
+    void prop_element_changed(ref const SampleUpdate update)
+    {
+        size_t index = update.element - _prop_elements;
+        ref const Property p = *_typeInfo.properties[index];
+        // a proxy's elements carry the authority's echo; reacting locally would drive absent hardware
+        if (p.on_change && !_is_remote)
+            p.on_change(this);
+        mark_dirty(index);
+    }
 }
 
 class ActiveObject : BaseObject
@@ -1067,11 +1219,51 @@ template MaterialProperties(Type)
         assert(__ctfe);
         Property[Count] r;
         static foreach (i; 0 .. Count)
-            r[i] = Property.create!(Type.Properties[i].n, Type.Properties[i].p, Type.Properties[i].c, Type.Properties[i].f)();
+        {
+            static if (is(typeof(Type.Properties[i].is_elem)))
+                r[i] = Property.create_elem!(Type.Properties[i], prop_index!(Type, Type.Properties[i].n))();
+            else
+                r[i] = Property.create!(Type.Properties[i].n, Type.Properties[i].p, Type.Properties[i].c, Type.Properties[i].f)();
+        }
         return r;
     }
     __gshared const MaterialProperties = _make();
 }
+
+// '*' always, 'd' default, 'h' hidden
+ubyte parse_prop_flags(string flags) pure
+{
+    ubyte r = flags.contains('*') ? 1 : 0;
+    r |= flags.contains('d') ? 2 : 0;
+    r |= flags.contains('h') ? 4 : 0;
+    return r;
+}
+
+template FindElemOpt(string kind, Opts...)
+{
+    alias FindElemOpt = AliasSeq!();
+    static foreach (Opt; Opts)
+        static if (Opt.kind == kind)
+            FindElemOpt = AliasSeq!(FindElemOpt, Opt);
+}
+
+template elem_decl(Type, string prop)
+{
+    static if (has_local_properties!Type)
+    {
+        static foreach (P; Type.Properties)
+            static if (is(typeof(P.is_elem)) && P.n == prop)
+                alias local = P;
+    }
+    static if (is(typeof(local)))
+        alias elem_decl = local;
+    else static if (is(Type S == super) && !is(S[0] == Object))
+        alias elem_decl = elem_decl!(S[0], prop);
+    else
+        static assert(false, "no element-backed property '" ~ prop ~ "' on " ~ Type.stringof);
+}
+
+alias ElemType(Type, string prop) = elem_decl!(Type, prop).T;
 
 auto all_properties_impl(Type, size_t allocCount)()
 {
@@ -1137,7 +1329,7 @@ template HasSuggest(alias Func)
 }
 
 
-Variant SynthGetter(Getters...)(BaseObject item) nothrow @nogc
+Variant SynthGetter(Getters...)(BaseObject item, ref const Property) nothrow @nogc
 {
     static assert(Getters.length == 1, "Only one getter overload is allowed for a property");
     alias Getter = Getters[0];
@@ -1151,7 +1343,7 @@ Variant SynthGetter(Getters...)(BaseObject item) nothrow @nogc
         return to_variant(__traits(child, instance, Getter)());
 }
 
-StringResult SynthSetter(Setters...)(ref const Variant value, BaseObject item) nothrow @nogc
+StringResult SynthSetter(Setters...)(ref const Variant value, BaseObject item, ref const Property) nothrow @nogc
 {
     alias Type = __traits(parent, Setters[0]);
     Type instance = cast(Type)item;
@@ -1181,6 +1373,83 @@ StringResult SynthSetter(Setters...)(ref const Variant value, BaseObject item) n
     if (Setters.length == 1)
         return StringResult(error);
     return StringResult(tconcat("Couldn't set property '" ~ __traits(identifier, Setters[0]) ~ "' with value: ", value));
+}
+
+// The machinery instantiates per value type, never per property: everything property-specific
+// travels as data in the Property. Only a declared Check! costs a per-declaration shim.
+Variant elem_get(BaseObject item, ref const Property p) nothrow @nogc
+    => item._prop_elements[p.index].value;
+
+StringResult elem_apply(T)(BaseObject item, ref const Property p, auto ref T value) nothrow @nogc
+{
+    if (p.check)
+    {
+        if (const(char)[] error = p.check(&value))
+            return StringResult(error);
+    }
+    return StringResult(item._prop_elements[p.index].try_write(value));
+}
+
+StringResult elem_set(T)(ref const Variant value, BaseObject item, ref const Property p) nothrow @nogc
+{
+    T arg;
+    if (const(char)[] error = from_variant(value, arg))
+        return StringResult(error);
+    return elem_apply(item, p, arg.move);
+}
+
+const(char)[] CheckShim(alias fn, T)(void* value) nothrow @nogc
+    => fn(*cast(T*)value);
+
+Variant ElemDefault(alias Decl)() nothrow @nogc
+{
+    alias Def = FindElemOpt!("default", Decl.opts);
+    static if (Def.length)
+        return to_variant(cast(Decl.T)Def[0].value);
+    else static if (__traits(compiles, { Decl.T v = Decl.T.init; return to_variant(v); }))
+        return to_variant(Decl.T.init);
+    else
+        return Variant();
+}
+
+FormatId ElemFormat(alias Decl)() nothrow @nogc
+{
+    __gshared FormatId cached = FormatId.invalid;
+    if (cached.valid)
+        return cached;
+
+    import manager.sample : register_constraint;
+    import manager.series : Constraint, data_format_of, Scalar;
+
+    DataFormat format = data_format_of!(Decl.T)();
+
+    alias Mn = FindElemOpt!("min", Decl.opts);
+    alias Mx = FindElemOpt!("max", Decl.opts);
+    static if (Mn.length || Mx.length)
+    {
+        Constraint c;
+        static if (Mn.length)
+        {
+            c.min = Scalar.of(cast(Decl.T)Mn[0].value);
+            c.has |= Constraint.Has.min;
+        }
+        static if (Mx.length)
+        {
+            c.max = Scalar.of(cast(Decl.T)Mx[0].value);
+            c.has |= Constraint.Has.max;
+        }
+        format.constraint = register_constraint(c);
+    }
+
+    cached = register_format(format);
+    return cached;
+}
+
+void ElemOnChange(alias fn)(BaseObject item) nothrow @nogc
+{
+    alias Type = __traits(parent, fn);
+    Type instance = cast(Type)cast(void*)item; // static cast: the handler only ever binds to its own class
+    __traits(child, instance, fn)();
 }
 
 Variant SynthDefault(alias Getter)() nothrow @nogc
@@ -1222,3 +1491,118 @@ template SynthSuggest(Setters...)
         }
     }
 }
+
+
+version (unittest)
+{
+    private enum TestMode : ubyte { idle, run, fault }
+
+    private final class ElemTestObject : BaseObject
+    {
+        alias Properties = AliasSeq!(Elem!("gain", uint, Default!7, Min!1, Max!10, OnChange!bump),
+                                     Elem!("mode", TestMode, Default!(TestMode.idle)),
+                                     Elem!("label", String),
+                                     Elem!("link", bool, ReadOnly),
+                                     Elem!("offset", uint));
+    nothrow @nogc:
+
+        uint changes;
+
+        this(const CollectionTypeInfo* type_info, CID id, ObjectFlags flags = ObjectFlags.none)
+        {
+            super(type_info, id, flags);
+        }
+
+        void bump()
+        {
+            ++changes;
+        }
+    }
+}
+
+unittest
+{
+    import urt.mem.allocator : defaultAllocator;
+
+    __gshared CollectionTypeInfo test_ti;
+    test_ti = CollectionTypeInfo(StringLit!"elem-test", String(), cast(CollectionType)0,
+                                 all_properties!ElemTestObject(), null, null, false);
+
+    ElemTestObject o = defaultAllocator().allocT!ElemTestObject(&test_ti, CID(1));
+    enum gain = prop_index!(ElemTestObject, "gain");
+
+    // declared defaults apply at construction and are not "changes"
+    assert(o.prop_read!(ElemTestObject, "gain") == 7);
+    assert(o.get("gain").asLong == 7);
+    assert(o.changes == 0);
+    assert(!(o.props_set & (ulong(1) << gain)));
+
+    // console-shaped writes convert, validate, store, and notify
+    Variant v = Variant(5);
+    assert(o.set("gain", v));
+    assert(o.prop_read!(ElemTestObject, "gain") == 5);
+    assert(o.changes == 1);
+    assert(o.props_set & (ulong(1) << gain));
+
+    // held dedup: an equal write is not a change
+    assert(o.set("gain", v));
+    assert(o.changes == 1);
+
+    // constraints refuse with their own message; nothing stores, nothing notifies
+    Variant big = Variant(20);
+    StringResult r = o.set("gain", big);
+    assert(r.failed && r.message == "above maximum");
+    assert(o.prop_read!(ElemTestObject, "gain") == 5);
+    assert(o.changes == 1);
+
+    // enums arrive as strings from the console
+    Variant mode = Variant("run");
+    assert(o.set("mode", mode));
+    assert(o.prop_read!(ElemTestObject, "mode") == TestMode.run);
+
+    // text properties store through the same path
+    Variant label = Variant("charger");
+    assert(o.set("label", label));
+    assert(o.prop_read!(ElemTestObject, "label") == "charger");
+
+    // typed internal writes ride the same path
+    o.prop_write!(ElemTestObject, "gain")(9u);
+    assert(o.prop_read!(ElemTestObject, "gain") == 9);
+    assert(o.changes == 2);
+
+    // reset restores the declared default through the ordinary write path
+    o.reset("gain");
+    assert(o.prop_read!(ElemTestObject, "gain") == 7);
+    assert(o.changes == 3);
+    assert(!(o.props_set & (ulong(1) << gain)));
+
+    // per-T synthesis: same-typed properties share one setter, and the getter is universal
+    enum offset = prop_index!(ElemTestObject, "offset");
+    assert(o.properties[gain].set is o.properties[offset].set);
+    assert(o.properties[gain].set !is o.properties[prop_index!(ElemTestObject, "mode")].set);
+    assert(o.properties[gain].get is o.properties[prop_index!(ElemTestObject, "label")].get);
+
+    // read-only: refused at both external entries, still written by the owner
+    enum link = prop_index!(ElemTestObject, "link");
+    Variant on = Variant(true);
+    StringResult ro = o.set("link", on);
+    assert(ro.failed && ro.message == "Property 'link' is read-only");
+    assert(o.prop_read!(ElemTestObject, "link") == false);
+    o.prop_write!(ElemTestObject, "link")(true);
+    assert(o.prop_read!(ElemTestObject, "link") == true);
+    o.reset("link");
+    assert(o.prop_read!(ElemTestObject, "link") == true);
+    assert(o.prop_element(link).access == Access.read);
+    assert(o.prop_element(gain).access == Access.read_write);
+
+    defaultAllocator().freeT(o);
+
+    // a proxy (is_remote) stores echoed values but never runs on_change side effects
+    ElemTestObject proxy = defaultAllocator().allocT!ElemTestObject(&test_ti, CID(2), ObjectFlags.remote);
+    Variant echoed = Variant(3);
+    assert(proxy.set("gain", echoed));
+    assert(proxy.prop_read!(ElemTestObject, "gain") == 3);
+    assert(proxy.changes == 0);
+    defaultAllocator().freeT(proxy);
+}
+

--- a/src/manager/console/collection_commands.d
+++ b/src/manager/console/collection_commands.d
@@ -556,7 +556,7 @@ void populate_collection_table(ref Table table, BaseCollection collection)
                 continue;
             if (!prop_visible(p.flags, proplist, p.name[]))
                 continue;
-            table.cell(p.get(item));
+            table.cell(p.get(item, *p));
         }
     }
 }

--- a/src/manager/element.d
+++ b/src/manager/element.d
@@ -767,6 +767,20 @@ public:
 
     void teardown()
     {
+        // deferred machinery holds raw Element pointers; a dying element must vanish from both
+        if (_status & Flags.dirty_listed)
+        {
+            g_dirty_elements.removeFirstSwapLast(&this);
+            _status &= ~Flags.dirty_listed;
+        }
+        for (size_t i = 0; i < g_pending_updates.length; )
+        {
+            if (g_pending_updates[i].element is &this)
+                g_pending_updates.remove(i);
+            else
+                ++i;
+        }
+
         release_register();
         if (_history)
         {
@@ -1943,6 +1957,20 @@ unittest
         w.close_series_cursor(wc);
         w.teardown();
     }
+
+    // teardown mid-commit: the dying element's pending updates and dirty listing must vanish
+    add_feed_listener();
+    Element dying;
+    dying.format = register_format(f64_held);
+    begin_commit();
+    dying.write_sample(1.0, from_unix_time_ns(1_000));
+    assert(g_pending_updates.length == 1);
+    assert(g_dirty_elements[].contains(&dying));
+    dying.teardown();
+    assert(g_pending_updates.empty);
+    assert(!g_dirty_elements[].contains(&dying));
+    end_commit();
+    remove_feed_listener();
 
     // TODO: regular-series test returns once regular write_records() and rate-aware tick() are built
 }

--- a/src/manager/element.d
+++ b/src/manager/element.d
@@ -270,6 +270,52 @@ nothrow @nogc:
     Variant value() @property const
         => record_value();
 
+    T read(T)() const
+    {
+        static if (is(T == String))
+        {
+            debug assert(data_format.is_text, "element does not hold text");
+            debug assert(!_history, "text series has no String handle; read const(char)[]");
+            return _last_update == SysTime() ? String() : text_register;
+        }
+        else static if (is(T : const(char)[]))
+        {
+            debug assert(data_format.is_text, "element does not hold text");
+            return text_value();
+        }
+        else
+        {
+            debug assert(data_format.is_scalar, "element record does not fit the scalar register");
+            debug assert(scalar_type!T == data_format.type, "element type mismatch");
+            return *cast(const(T)*)_latest.raw.ptr;
+        }
+    }
+
+    const(char)[] try_write(T)(auto ref T v, SysTime t = getSysTime(), Subscriber who = null)
+    {
+        assert(format.valid, "element has no data format");
+        static if (is(T == String) || is(T : const(char)[]))
+        {
+            if (!data_format.is_text)
+                return "incompatible value";
+            store_sample(v, t, who);
+            return null;
+        }
+        else
+        {
+            if (!data_format.is_scalar || scalar_type!T != data_format.type)
+                return "incompatible value";
+            static if (is(T Base == enum))
+                Scalar s = Scalar.of(cast(Base)v);
+            else
+                Scalar s = Scalar.of(v);
+            if (const(char)[] error = data_format.constraint ? data_format.constraint.check(s, *data_format) : null)
+                return error;
+            store_record(s.raw[0 .. data_format.stride], t, who);
+            return null;
+        }
+    }
+
     void value(T)(auto ref T v, SysTime timestamp = getSysTime(), Subscriber who = null)
     {
         assert(format.valid, "element has no data format");

--- a/src/manager/series.d
+++ b/src/manager/series.d
@@ -102,6 +102,14 @@ template value_type_of(T)
     else static if (is(U == char))   enum value_type_of = ValueType.char_;
 }
 
+template scalar_type(T)
+{
+    static if (is(Unqual!T Base == enum))
+        enum scalar_type = value_type_of!Base;
+    else
+        enum scalar_type = value_type_of!T;
+}
+
 FormatId register_value_format(T)(auto ref const T value)
 {
     static if (is(Unqual!T == Variant))
@@ -111,27 +119,29 @@ FormatId register_value_format(T)(auto ref const T value)
 }
 
 FormatId register_value_format(T)()
+    => register_format(data_format_of!T());
+
+DataFormat data_format_of(T)()
 {
     alias U = Unqual!T;
     static if (is_boolean!U || is_some_int!U || is_some_float!U)
-        return register_format(DataFormat(value_type_of!U, SeriesKind.held));
+        return DataFormat(value_type_of!U, SeriesKind.held);
     else static if (is(U Base == enum))
-        return register_format(DataFormat(value_type_of!Base, SeriesKind.held, enum_info!U.make_void()));
+        return DataFormat(value_type_of!Base, SeriesKind.held, enum_info!U.make_void());
     else static if (is(U == String) || is(U : const(char)[]))
     {
         DataFormat format = DataFormat(ValueType.char_, SeriesKind.held);
         format.count = 0;
-        return register_format(format);
+        return format;
     }
     else static if (is(U == Duration))
-        return register_format(DataFormat(ValueType.s64, SeriesKind.held, Nanosecond));
+        return DataFormat(ValueType.s64, SeriesKind.held, Nanosecond);
     else static if (is(U == Quantity!(N, scale), N, ScaledUnit scale))
-        return register_format(DataFormat(value_type_of!N, SeriesKind.held, scale));
+        return DataFormat(value_type_of!N, SeriesKind.held, scale);
     else static if (ValidUserType!U)
     {
         alias registered = MakeTypeDetails!U;   // registration rides its shared static this
-        return register_format(DataFormat(ValueType.user, SeriesKind.held,
-                                          &find_type_details(TypeDetailsFor!U.type_id)));
+        return DataFormat(ValueType.user, SeriesKind.held, &find_type_details(TypeDetailsFor!U.type_id));
     }
     else
         static assert(false, "value needs an explicit record format");

--- a/src/manager/sync/binary_encoder.d
+++ b/src/manager/sync/binary_encoder.d
@@ -112,7 +112,7 @@ nothrow @nogc:
             if (!(set_bits & (ulong(1) << i)) || !p.get || p.name[] == "type")
                 continue;
             _buf.put_str(p.name[]);
-            Variant v = p.get(obj);
+            Variant v = p.get(obj, *p);
             _buf.put_variant(v);
         }
         _buf.put_str(null);
@@ -171,7 +171,7 @@ nothrow @nogc:
         begin_frame(Verb.set);
         _buf.put_varint(peer.handle_of(obj));
         _buf.put_str(p.name[]);
-        Variant v = p.get(obj);
+        Variant v = p.get(obj, *p);
         _buf.put_variant(v);
         _buf.put_varint(seq);
         send_frame(peer);

--- a/src/manager/sync/encoder.d
+++ b/src/manager/sync/encoder.d
@@ -112,7 +112,7 @@ debug void assert_reset_matches_init(BaseObject obj, ref const Property p) nothr
 {
     if (!p.get || !p.init_val)
         return;
-    Variant cur = p.get(obj);
+    Variant cur = p.get(obj, p);
     Variant iv = p.init_val();
     assert(cur == iv, "encode_reset: prop value diverges from init_val - receiver assumes init");
 }
@@ -135,7 +135,7 @@ nothrow @nogc:
 
     // Mirror protocol - object lifecycle
 
-    // Encoder walks obj.properties() and reads each via p.get(obj) while
+    // Encoder walks obj.properties() and reads each via p.get while
     // encoding. No pre-extracted prop list is passed in.
     abstract void encode_bind(SyncPeer peer, BaseObject obj, uint seq);
     abstract void encode_unbind(SyncPeer peer, CID target, uint seq);

--- a/src/manager/sync/json_encoder.d
+++ b/src/manager/sync/json_encoder.d
@@ -134,7 +134,7 @@ nothrow @nogc:
         _buf.append(",\"prop\":");
         write_str(p.name[]);
         _buf.append(",\"value\":");
-        Variant v = p.get(obj);
+        Variant v = p.get(obj, *p);
         write_variant(v);
         if (seq)
             _buf.append(",\"seq\":", seq);
@@ -1008,7 +1008,7 @@ private:
                 _buf ~= ',';
             write_str(p.name[]);
             _buf ~= ':';
-            Variant val = p.get(obj);
+            Variant val = p.get(obj, *p);
             write_variant(val);
         }
         if (any)

--- a/src/router/stream/serial.d
+++ b/src/router/stream/serial.d
@@ -82,41 +82,27 @@ struct ModemLines
     bool cts, dsr, dcd, ri; // what the peer presents
 }
 
-struct SerialParams
-{
-    this(int baud)
-    {
-        this.baud_rate = baud;
-    }
-
-    uint baud_rate = 9600;
-    ubyte data_bits = 8;
-    StopBits stop_bits = StopBits.one;
-    Parity parity = Parity.none;
-    FlowControl flow_control = FlowControl.none;
-}
-
 class SerialStream : Stream
 {
     version (Embedded)
         alias Properties = AliasSeq!(Prop!("device", device),
-                                     Prop!("baud-rate", baud_rate),
-                                     Prop!("data-bits", data_bits),
-                                     Prop!("parity", parity),
-                                     Prop!("stop-bits", stop_bits),
-                                     Prop!("flow-control", flow_control),
-                                     Prop!("tx-gpio", tx_gpio),
-                                     Prop!("rx-gpio", rx_gpio),
-                                     Prop!("rts-gpio", rts_gpio),
-                                     Prop!("cts-gpio", cts_gpio),
-                                     Prop!("de-gpio", de_gpio));
+                                     Elem!("baud-rate", uint, Default!9600, Min!1, OnChange!restart),
+                                     Elem!("data-bits", ubyte, Default!8, Min!5, Max!9, OnChange!restart),
+                                     Elem!("parity", Parity, Default!(Parity.none), Check!parity_check, OnChange!restart),
+                                     Elem!("stop-bits", StopBits, Default!(StopBits.one), OnChange!restart),
+                                     Elem!("flow-control", FlowControl, Default!(FlowControl.none), OnChange!flow_control_changed),
+                                     Elem!("tx-gpio", byte, Default!(-1), OnChange!restart),
+                                     Elem!("rx-gpio", byte, Default!(-1), OnChange!restart),
+                                     Elem!("rts-gpio", byte, Default!(-1), OnChange!restart),
+                                     Elem!("cts-gpio", byte, Default!(-1), OnChange!restart),
+                                     Elem!("de-gpio", byte, Default!(-1), OnChange!restart));
     else
         alias Properties = AliasSeq!(Prop!("device", device),
-                                     Prop!("baud-rate", baud_rate),
-                                     Prop!("data-bits", data_bits),
-                                     Prop!("parity", parity),
-                                     Prop!("stop-bits", stop_bits),
-                                     Prop!("flow-control", flow_control));
+                                     Elem!("baud-rate", uint, Default!9600, Min!1, OnChange!restart),
+                                     Elem!("data-bits", ubyte, Default!8, Min!5, Max!8, OnChange!restart),
+                                     Elem!("parity", Parity, Default!(Parity.none), OnChange!restart),
+                                     Elem!("stop-bits", StopBits, Default!(StopBits.one), OnChange!restart),
+                                     Elem!("flow-control", FlowControl, Default!(FlowControl.none), OnChange!flow_control_changed));
 nothrow @nogc:
 
     enum type_name = "serial";
@@ -163,80 +149,50 @@ nothrow @nogc:
         }
     }
 
-    final uint baud_rate() const pure
-        => _params.baud_rate;
-    final StringResult baud_rate(uint value)
+    final uint baud_rate() const
+        => prop_read!(SerialStream, "baud-rate");
+    final void baud_rate(uint value)
+        => prop_write!(SerialStream, "baud-rate")(value);
+
+    final ubyte data_bits() const
+        => prop_read!(SerialStream, "data-bits");
+    final void data_bits(ubyte value)
+        => prop_write!(SerialStream, "data-bits")(value);
+
+    final Parity parity() const
+        => prop_read!(SerialStream, "parity");
+    final void parity(Parity value)
+        => prop_write!(SerialStream, "parity")(value);
+
+    final StopBits stop_bits() const
+        => prop_read!(SerialStream, "stop-bits");
+    final void stop_bits(StopBits value)
+        => prop_write!(SerialStream, "stop-bits")(value);
+
+    final FlowControl flow_control() const
+        => prop_read!(SerialStream, "flow-control");
+    final void flow_control(FlowControl value)
+        => prop_write!(SerialStream, "flow-control")(value);
+
+    version (Embedded)
     {
-        if (value == 0)
-            return StringResult("baud rate must be greater than 0");
-        if (_params.baud_rate == value)
-        {
-            mark_set!(typeof(this), "baud-rate")();
-            return StringResult.success;
-        }
-        _params.baud_rate = value;
-        mark_set!(typeof(this), "baud-rate");
-        restart();
-        return StringResult.success;
+        final byte tx_gpio() const
+            => prop_read!(SerialStream, "tx-gpio");
+        final byte rx_gpio() const
+            => prop_read!(SerialStream, "rx-gpio");
+        final byte rts_gpio() const
+            => prop_read!(SerialStream, "rts-gpio");
+        final byte cts_gpio() const
+            => prop_read!(SerialStream, "cts-gpio");
+        final byte de_gpio() const
+            => prop_read!(SerialStream, "de-gpio");
+
+        static const(char)[] parity_check(ref Parity value)
+            => value > Parity.odd ? "UART only supports none, even, or odd parity" : null;
     }
 
-    uint data_bits() const pure
-        => _params.data_bits;
-    StringResult data_bits(uint value)
+    void flow_control_changed()
     {
-        version (Embedded)
-            enum uint max_data_bits = 9;
-        else
-            enum uint max_data_bits = 8;
-        if (value < 5 || value > max_data_bits)
-            return StringResult(max_data_bits == 9 ? "data bits must be between 5 and 9" : "data bits must be between 5 and 8");
-        if (_params.data_bits == cast(ubyte)value)
-        {
-            mark_set!(typeof(this), "data-bits")();
-            return StringResult.success;
-        }
-        _params.data_bits = cast(ubyte)value;
-        mark_set!(typeof(this), "data-bits");
-        restart();
-        return StringResult.success;
-    }
-
-    Parity parity() const pure
-        => _params.parity;
-    const(char)[] parity(Parity value)
-    {
-        version (Embedded)
-        {
-            if (value > Parity.odd)
-                return "UART only supports none, even, or odd parity";
-        }
-        if (_params.parity == value)
-            return null;
-        _params.parity = value;
-        mark_set!(typeof(this), "parity");
-        restart();
-        return null;
-    }
-
-    StopBits stop_bits() const pure
-        => _params.stop_bits;
-    void stop_bits(StopBits value)
-    {
-        if (_params.stop_bits == value)
-            return;
-        _params.stop_bits = value;
-        mark_set!(typeof(this), "stop-bits");
-        restart();
-    }
-
-    FlowControl flow_control() const pure
-        => _params.flow_control;
-    void flow_control(FlowControl value)
-    {
-        if (_params.flow_control == value)
-            return;
-        _params.flow_control = value;
-        mark_set!(typeof(this), "flow-control");
         // reconfigure the open port in place rather than restart(): a close/reopen cycles the modem
         // lines the peer sees, which both disturbs flow-control-sensitive devices (Silabs NCPs stop
         // transmitting) and makes runtime flow-control experiments unrepresentative
@@ -246,54 +202,6 @@ nothrow @nogc:
         {
             if (!running || !configure_port(false))
                 restart();
-        }
-    }
-
-    version (Embedded)
-    {
-        final byte tx_gpio() const pure
-            => _tx_gpio;
-        final void tx_gpio(byte value)
-        {
-            _tx_gpio = value;
-            mark_set!(typeof(this), "tx-gpio");
-            restart();
-        }
-
-        final byte rx_gpio() const pure
-            => _rx_gpio;
-        final void rx_gpio(byte value)
-        {
-            _rx_gpio = value;
-            mark_set!(typeof(this), "rx-gpio");
-            restart();
-        }
-
-        final byte rts_gpio() const pure
-            => _rts_gpio;
-        final void rts_gpio(byte value)
-        {
-            _rts_gpio = value;
-            mark_set!(typeof(this), "rts-gpio");
-            restart();
-        }
-
-        final byte cts_gpio() const pure
-            => _cts_gpio;
-        final void cts_gpio(byte value)
-        {
-            _cts_gpio = value;
-            mark_set!(typeof(this), "cts-gpio");
-            restart();
-        }
-
-        final byte de_gpio() const pure
-            => _de_gpio;
-        final void de_gpio(byte value)
-        {
-            _de_gpio = value;
-            mark_set!(typeof(this), "de-gpio");
-            restart();
         }
     }
 
@@ -337,22 +245,22 @@ nothrow @nogc:
             __gshared immutable bm.Parity[5] parity_map = [ bm.Parity.none, bm.Parity.even, bm.Parity.odd, bm.Parity.none, bm.Parity.none ];
 
             bm.UartConfig cfg;
-            cfg.baud_rate = _params.baud_rate;
-            cfg.data_bits = _params.data_bits;
-            cfg.stop_bits = stop_bits_map[_params.stop_bits];
-            cfg.parity = parity_map[_params.parity];
-            if (_tx_gpio >= 0)
-                cfg.tx_gpio = cast(ubyte)_tx_gpio;
-            if (_rx_gpio >= 0)
-                cfg.rx_gpio = cast(ubyte)_rx_gpio;
-            if (_rts_gpio >= 0)
-                cfg.rts_gpio = cast(ubyte)_rts_gpio;
-            if (_cts_gpio >= 0)
-                cfg.cts_gpio = cast(ubyte)_cts_gpio;
-            if (_de_gpio >= 0)
+            cfg.baud_rate = baud_rate;
+            cfg.data_bits = data_bits;
+            cfg.stop_bits = stop_bits_map[stop_bits];
+            cfg.parity = parity_map[parity];
+            if (tx_gpio >= 0)
+                cfg.tx_gpio = cast(ubyte)tx_gpio;
+            if (rx_gpio >= 0)
+                cfg.rx_gpio = cast(ubyte)rx_gpio;
+            if (rts_gpio >= 0)
+                cfg.rts_gpio = cast(ubyte)rts_gpio;
+            if (cts_gpio >= 0)
+                cfg.cts_gpio = cast(ubyte)cts_gpio;
+            if (de_gpio >= 0)
             {
                 cfg.rs485.enabled = true;
-                cfg.rs485.de_gpio = cast(ubyte)_de_gpio;
+                cfg.rs485.de_gpio = cast(ubyte)de_gpio;
             }
 
             Result opened;
@@ -424,17 +332,17 @@ nothrow @nogc:
 
             dcb._bf = 1;
 
-            dcb.BaudRate = DWORD(_params.baud_rate);
-            dcb.ByteSize = _params.data_bits;
+            dcb.BaudRate = DWORD(baud_rate);
+            dcb.ByteSize = data_bits;
 
-            if (_params.stop_bits == StopBits.one)
+            if (stop_bits == StopBits.one)
                 dcb.StopBits = ONESTOPBIT;
-            else if (_params.stop_bits == StopBits.one_point_five)
+            else if (stop_bits == StopBits.one_point_five)
                 dcb.StopBits = ONE5STOPBITS;
-            else if (_params.stop_bits == StopBits.two)
+            else if (stop_bits == StopBits.two)
                 dcb.StopBits = TWOSTOPBITS;
 
-            switch (_params.parity)
+            switch (parity)
             {
                 case Parity.none:   dcb.Parity = NOPARITY;      break;
                 case Parity.even:   dcb.Parity = EVENPARITY;    break;
@@ -443,12 +351,12 @@ nothrow @nogc:
                 case Parity.space:  dcb.Parity = SPACEPARITY;   break;
                 default: assert(false);
             }
-            if (_params.parity != Parity.none)
+            if (parity != Parity.none)
                 dcb._bf |= 2; // fParity: set to enable parity checking?
 
             // RTS idles asserted ("host ready") in the non-hardware modes: we always have receive
             // buffer, and peers that honor RTS/CTS (Silabs NCPs) stop transmitting if it idles low
-            switch (_params.flow_control)
+            switch (flow_control)
             {
                 case FlowControl.none:
                     dcb._bf &= ~4; // fOutxCtsFlow
@@ -535,9 +443,9 @@ nothrow @nogc:
             {
                 // other Posix: standard rates only, via the classic cfsetospeed/Bxxx path.
                 speed_t speed;
-                if (!posix_baud(_params.baud_rate, speed))
+                if (!posix_baud(baud_rate, speed))
                 {
-                    log.error("unsupported serial baud rate ", _params.baud_rate);
+                    log.error("unsupported serial baud rate ", baud_rate);
                     return false;
                 }
                 if (cfsetospeed(&tty, speed) != 0 || cfsetispeed(&tty, speed) != 0)
@@ -545,7 +453,7 @@ nothrow @nogc:
             }
 
             tty.c_cflag &= ~(PARENB | PARODD | CMSPAR);
-            final switch (_params.parity)
+            final switch (parity)
             {
                 case Parity.none:
                     break;
@@ -564,30 +472,30 @@ nothrow @nogc:
             }
 
             tty.c_cflag &= ~CSTOPB;
-            if (_params.stop_bits == StopBits.two)
+            if (stop_bits == StopBits.two)
                 tty.c_cflag |= CSTOPB;
-            else if (_params.stop_bits == StopBits.one_point_five)
+            else if (stop_bits == StopBits.one_point_five)
             {
                 log.error("1.5 stop bits are not supported on Posix");
                 return false;
             }
 
             tty.c_cflag &= ~CSIZE;
-            switch (_params.data_bits)
+            switch (data_bits)
             {
                 case 5: tty.c_cflag |= CS5; break;
                 case 6: tty.c_cflag |= CS6; break;
                 case 7: tty.c_cflag |= CS7; break;
                 case 8: tty.c_cflag |= CS8; break;
                 default:
-                    log.error("unsupported data bits: ", _params.data_bits);
+                    log.error("unsupported data bits: ", data_bits);
                     return false;
             }
 
             tty.c_cflag &= ~CRTSCTS;
             tty.c_cflag |= CREAD | CLOCAL;
             tty.c_iflag &= ~(IXON | IXOFF | IXANY);
-            final switch (_params.flow_control)
+            final switch (flow_control)
             {
                 case FlowControl.none:
                     break;
@@ -619,9 +527,9 @@ nothrow @nogc:
                 return false;
             version (linux)
             {
-                if (!set_linux_custom_baud(_fd, _params.baud_rate))
+                if (!set_linux_custom_baud(_fd, baud_rate))
                 {
-                    log.error("failed to set baud rate ", _params.baud_rate);
+                    log.error("failed to set baud rate ", baud_rate);
                     return false;
                 }
             }
@@ -629,7 +537,7 @@ nothrow @nogc:
             // RTS idles asserted ("host ready") in the non-hardware modes: we always have receive
             // buffer, and peers that honor RTS/CTS (Silabs NCPs) stop transmitting if it idles low
             int dtr_bit = TIOCM_DTR, rts_bit = TIOCM_RTS;
-            final switch (_params.flow_control)
+            final switch (flow_control)
             {
                 case FlowControl.none:
                     ioctl(_fd, TIOCMBIC, &dtr_bit);
@@ -963,8 +871,8 @@ nothrow @nogc:
     final bool set_rts(bool asserted)
     {
         // RTS is owned by the UART under hardware (RTS/CTS) flow control; refuse rather than fight it
-        assert(_params.flow_control != FlowControl.hardware, "cannot drive RTS manually while hardware flow control owns it");
-        if (_params.flow_control == FlowControl.hardware)
+        assert(flow_control != FlowControl.hardware, "cannot drive RTS manually while hardware flow control owns it");
+        if (flow_control == FlowControl.hardware)
             return false;
         version (Windows)
             return _h_com != INVALID_HANDLE_VALUE && EscapeCommFunction(_h_com, asserted ? SETRTS : CLRRTS) != 0;
@@ -982,8 +890,8 @@ nothrow @nogc:
     final bool set_dtr(bool asserted)
     {
         // DTR is owned by the UART under DSR/DTR flow control
-        assert(_params.flow_control != FlowControl.dsr_dtr, "cannot drive DTR manually while DSR/DTR flow control owns it");
-        if (_params.flow_control == FlowControl.dsr_dtr)
+        assert(flow_control != FlowControl.dsr_dtr, "cannot drive DTR manually while DSR/DTR flow control owns it");
+        if (flow_control == FlowControl.dsr_dtr)
             return false;
         version (Windows)
             return _h_com != INVALID_HANDLE_VALUE && EscapeCommFunction(_h_com, asserted ? SETDTR : CLRDTR) != 0;
@@ -1064,15 +972,6 @@ private:
     }
 
     String _device;
-    SerialParams _params;
-    version (Embedded)
-    {
-        byte _tx_gpio = -1;
-        byte _rx_gpio = -1;
-        byte _rts_gpio = -1;
-        byte _cts_gpio = -1;
-        byte _de_gpio = -1;
-    }
 
     version (Windows)
     {


### PR DESCRIPTION
Properties become elements. An `Elem!(name, T, options...)` entry in a class's `Properties` list declares a property with no member field and no getter/setter pair: the value lives in an `Element` slot of a per-object block, indexed by the compile-time prop index. Dedup, change notification, and dirty tracking come from the element instead of being hand-rolled per setter.

This is the convergence step `SYNC_PROTOCOL.draft.md` defers to ("gated on the property-projection work in id.d"). Two design docs ship with it: `PROP_ELEMENTS.draft.md` (this work, written against what actually got built) and `TAPS_AND_TUNNELS.draft.md` (the remote-interface/capture design that motivated the proxy semantics here).

## The six movements

| commit | what |
|---|---|
| `d98a19d` | design doc |
| `32fd0b1` | fix: dying elements unlink from the dirty list and pending-update queue |
| `a1caa0d` | Element gains a typed door: `read!T` / `try_write!T` beside the boxed `value`/`try_set` |
| `cbc111d` | the `Elem!` declaration + per-object property block, synthesised per value type |
| `e464494` | first migration: SerialStream's framing properties |
| `205a89f` | taps-and-tunnels design doc |

Each commit builds clean on its own (verified by walking the series); 128/128 unit tests at the tip; all 16 CI targets green, including the ESP32/baremetal builds that compile the `version (Embedded)` serial path.

## Shape

- **Typed end-to-end.** `Element.read!T`/`try_write!T` are the missing typed pair beside the boxed `value`/`try_set`: same records, same held dedup, same constraint gate, no Variant. The type check lives once, inside Element (`scalar_type!T == data_format.type`, which sees through enums; a size-based check would alias `u32` with `f32`). Variant survives at exactly one place: the by-name entry, where the console and the wire genuinely arrive holding one.
- **Synthesis is per value type, never per property.** The get/set function pointers receive the `Property` they were reached through (every caller already held it), and per-property facts -- element slot, check, on_change, read-only, format -- are data. Ten `uint` properties across ten classes share one `elem_set!uint`; the getter is a single function program-wide. A declared `Check!` costs one shim; an `OnChange!` target costs one trampoline shared by all its users. The unittest asserts the pointer sharing.
- **`ReadOnly` = read-only to the outside, not immutable.** External entries (console, sync inbound, collection create, reset) refuse; the owning object still pokes derived state in via `prop_write`, and the element's `Access` follows the declaration. Owner writes still mark `_props_set`, because a mirror cannot recompute derived state.
- **Proxies never run side effects**: an `is_remote` object stores the authority's echo but never fires `OnChange!`, matching the state machine's existing suppression.

## What a reviewer should push on

**Block sizing.** The slot index is the prop index, so the block is sized by TOTAL property count: SerialStream has 22 properties, 5 migrated, so it allocates 2288 bytes to use 520. Shrinks as migration proceeds, vanishes at full migration; a per-type slot map (byte per property, one indirection) removes it now if wanted.

**Element is ~104 bytes**; the descriptor split (shared `ElementDesc` per type/profile) is designed, not built, and also compresses profile-created device elements.

**Behaviour changes in the serial migration.** Range refusals carry the constraint's message ("above maximum") instead of bespoke text; `baud_rate`/`data_bits` setters narrow from `StringResult` to `void` (a rejected write from D code asserts in debug); `data_bits` narrows `uint` -> `ubyte`.

**Deliberate omissions**: no `Step!` (Constraint.check honours min/max + check_fn only; a declared step would be silently unvalidated) and no EID minted (id.d's `(object CID, prop index + 1)` has no resolver yet -- fixing resolve to dispatch on container class is the agreed next step). Multi-property writes do NOT coalesce side effects: the mechanism supports it, but the console opens no commit scope, so each set restarts independently exactly as before.

## Not built (follow-ups)

EID minting + container-class resolve; descriptor split; reference (`ObjectRef`) properties via a `CollectionTypeInfo*` slot in the DataFormat union (pending refs via `IdAllocator.reserve` retire the sync-tick HACK); state-machine properties (`running`/`status` as ReadOnly elements; `flags` never migrates); console commit scope for coalesced restarts; retirement of the per-object `SyncState` delta machinery.