### PR TITLE
Feed the task watchdog on every Espressif target

### DIFF
--- a/src/driver/esp32/watchdog.d
+++ b/src/driver/esp32/watchdog.d
@@ -6,15 +6,13 @@ import urt.time : Duration;
 
 nothrow @nogc:
 
-version (ESP32_S3)
-    private extern(C) void ow_watchdog_feed() nothrow @nogc;
+private extern(C) void ow_watchdog_feed() nothrow @nogc;
 
 void watchdog_init(Duration timeout) {} // hardware watchdog task is started by the C runtime
 
 void watchdog_feed()
 {
-    version (ESP32_S3)
-        ow_watchdog_feed();
+    ow_watchdog_feed();
 }
 
 void watchdog_stop() {}


### PR DESCRIPTION
`app_main` arms the IDF task watchdog at 5s with `trigger_panic` and subscribes the main task, but the feed was gated behind `version (ESP32_S3)`. On a classic ESP32 `watchdog_feed` therefore compiled to an empty function: the watchdog was armed and never fed, and the board panicked and rebooted at exactly five seconds, forever.

`ow_watchdog_feed` is defined for every ESP32 variant, so the gate was wrong rather than incomplete.

Found on SmartEVSE hardware. The symptom was easy to misread -- the panic printed only a backtrace with no message, because the task-watchdog report goes through `ESP_LOGE`, which is compiled out at log level none. The reboot was pinned to `hb=4` -> `hb=5` on 9 consecutive boots and was unaffected by dropping the update rate 100 Hz -> 2 Hz or by removing every configured object, which is what identified it as a wall-clock timer rather than anything in the application.

Verified: 118+ heartbeats with no reboot after the fix.
