### PR TITLE
Stop log history exhausting the heap on Tiny targets

### DIFF
--- a/src/manager/log.d
+++ b/src/manager/log.d
@@ -109,8 +109,18 @@ class LogModule : Module
 nothrow @nogc:
 
     enum max_consumers = 16;
-    enum delivery_queue_size = 128;
-    enum max_history_messages = 1024;
+    version (Tiny)
+    {
+        enum delivery_queue_size = 32;
+        enum max_history_messages = 32;
+        enum default_history_messages = 0;
+    }
+    else
+    {
+        enum delivery_queue_size = 128;
+        enum max_history_messages = 1024;
+        enum default_history_messages = max_history_messages;
+    }
 
     override void init()
     {
@@ -345,7 +355,7 @@ private:
     uint _delivery_count;
     uint _delivery_dropped;
     uint _history_count;
-    uint _history_limit = max_history_messages;
+    uint _history_limit = default_history_messages;
     Severity _history_max_severity = Severity.info;
     Severity _global_max_severity = Severity.trace;
 
@@ -376,6 +386,12 @@ private:
             return;
 
         StoredLogMessage* record = defaultAllocator().allocT!StoredLogMessage();
+        if (!record)
+        {
+            // Can't report the failure: reporting logs, and logging allocates down this path.
+            ++_delivery_dropped;
+            return;
+        }
         record.message.assign(msg);
         record.source = pending ? _source : null;
         record.pending = pending;


### PR DESCRIPTION
`LogModule` retained 1024 records regardless of target: roughly 100KB of history against the ~40KB a SmartEVSE has free. A once-a-second heartbeat consumed the store in about three and a half minutes, after which every allocation failed.

Tiny now keeps live delivery and records nothing until asked, with the cap at 32 if history is enabled.

`enqueue` also stored through a failed allocation, which is what turned exhaustion into a `StoreProhibited` panic. It drops and counts the record instead. Reporting the failure is not an option, because that logs, and logging allocates down the path that just failed -- `log_alloc_oom`'s re-entrancy guard made the second allocation fail *silently*, which is exactly what produced the null store.

Delivery buffering itself is left alone and is legitimate: sinks drain on their own `update()` tick and can stall mid-write, so a record must outlive the `write_log` call, and it is already bounded by `delivery_queue_size`. Only history was unbounded.

Measured on hardware over eight minutes:

| | before | after |
|---|---|---|
| used | 212 -> 220 KB climbing | 185-186 KB flat |
| largest free block | 13 -> 3 KB collapsing | 38 KB steady |
| outcome | crash at ~3.5 min | 8m+, zero reboots |
