### PR TITLE
Keep the encoding table out of .data

### DIFF
--- a/src/manager/sample/codec.d
+++ b/src/manager/sample/codec.d
@@ -96,7 +96,7 @@ unittest
 
 private:
 
-__gshared Encoding[16] g_encodings;
+__gshared Encoding[16] g_encodings = void;
 __gshared ushort g_num_encodings;
 
 // six binary bytes yy MM dd hh mm ss in reading order


### PR DESCRIPTION
One non-zero-initialised field puts the whole global in flash as an image. The encoding table is populated before any read, so `= void` moves it to `.bss`.
