### PR TITLE
Route ESP-IDF diagnostics into OpenWatt logs

### DIFF
--- a/openwatt.vcxproj
+++ b/openwatt.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -81,6 +81,7 @@
     <DCompile Include="src\driver\baremetal\wifi.d" />
     <DCompile Include="src\driver\ble.d" />
     <DCompile Include="src\driver\esp32\system.d" />
+    <DCompile Include="src\driver\esp32\idf_log_bridge.d" />
     <DCompile Include="src\driver\esp32\watchdog.d" />
     <DCompile Include="src\driver\ethernet.d" />
     <DCompile Include="src\driver\linux\ble.d" />

--- a/openwatt.vcxproj.filters
+++ b/openwatt.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="conf">
@@ -292,6 +292,9 @@
       <Filter>src\driver</Filter>
     </DCompile>
     <DCompile Include="src\driver\esp32\system.d">
+      <Filter>src\driver\esp32</Filter>
+    </DCompile>
+    <DCompile Include="src\driver\esp32\idf_log_bridge.d">
       <Filter>src\driver\esp32</Filter>
     </DCompile>
     <DCompile Include="src\driver\esp32\watchdog.d">

--- a/platforms/esp32-common/main.cmake
+++ b/platforms/esp32-common/main.cmake
@@ -39,6 +39,7 @@ idf_component_register(SRCS "${ESP32_SYS_DIR}/main.c"
                             "${ESP32_SYS_DIR}/littlefs_port.c"
                             "${LITTLEFS_DIR}/lfs.c"
                             "${LITTLEFS_DIR}/lfs_util.c"
+                            "${ESP32_SYS_DIR}/idf_log.c"
                             "${URT_INTERNAL_DIR}/mbedtls.c"
                        INCLUDE_DIRS ""
                        PRIV_REQUIRES ${MAIN_PRIV_REQUIRES}

--- a/src/driver/esp32/idf_log_bridge.d
+++ b/src/driver/esp32/idf_log_bridge.d
@@ -1,0 +1,344 @@
+module driver.esp32.idf_log_bridge;
+
+import urt.log : Severity;
+
+version (ESP8266) {}
+else version (Espressif) version = ESPIDFLogBridge;
+
+version (ESPIDFLogBridge)
+{
+    import urt.atomic : atomicLoad, atomicStore, cas, MemoryOrder;
+    import urt.driver.esp32.idf_log;
+    import urt.log : write_log;
+    import urt.mem.allocator : defaultAllocator;
+    import urt.time;
+
+    import manager;
+    import manager.plugin;
+}
+
+nothrow @nogc:
+
+
+version (ESPIDFLogBridge)
+{
+class IDFLogBridgeModule : Module
+{
+    mixin DeclareModule!"esp-idf-log";
+nothrow @nogc:
+
+    override void init()
+    {
+        void[] memory = defaultAllocator().alloc(LineAssembler.sizeof * max_sources,
+                                                 LineAssembler.alignof);
+        if (!memory.ptr)
+        {
+            log.error("Failed to allocate ESP-IDF log assembly buffers");
+            return;
+        }
+        _lines = cast(LineAssembler*)memory.ptr;
+        reset_lines();
+        atomicStore!(MemoryOrder.relaxed)(_drain_pending, 0u);
+        atomicStore!(MemoryOrder.release)(g_bridge, cast(size_t)cast(void*)this);
+        idf_log_set_ready_callback(&idf_log_ready);
+        _open = idf_log_open();
+        if (!_open)
+        {
+            idf_log_set_ready_callback(null);
+            atomicStore!(MemoryOrder.release)(g_bridge, 0);
+            log.error("Failed to capture ESP-IDF logs");
+        }
+    }
+
+    override void deinit()
+    {
+        if (_open)
+            idf_log_close();
+        idf_log_set_ready_callback(null);
+        atomicStore!(MemoryOrder.release)(g_bridge, 0);
+        atomicStore!(MemoryOrder.relaxed)(_drain_pending, 0u);
+        _open = false;
+        if (_lines)
+        {
+            defaultAllocator().free((cast(void*)_lines)[0 .. LineAssembler.sizeof * max_sources]);
+            _lines = null;
+        }
+    }
+
+private:
+    enum max_sources = 8;
+    enum max_line_length = 512;
+
+    LineAssembler* _lines;
+    shared uint _drain_pending;
+    uint _activity;
+    uint _drop_generation;
+    bool _have_drop_generation;
+    bool _open;
+
+    void request_drain()
+    {
+        if (g_app is null || !cas(&_drain_pending, 0u, 1u))
+            return;
+        MonoTime now = getTime();
+        bool queued = g_app.try_post_event(&g_drain_sweep.event, now, EventPriority.bulk);
+        if (!queued)
+            queued = g_app.try_post_event(&g_drain_sweep.event, now, EventPriority.control);
+        if (!queued)
+            atomicStore!(MemoryOrder.release)(_drain_pending, 0u);
+    }
+
+    void drain(MonoTime)
+    {
+        atomicStore!(MemoryOrder.release)(_drain_pending, 0u);
+        IdfLogChunk chunk = void;
+        while (idf_log_receive(chunk))
+            consume(chunk);
+
+        uint dropped = idf_log_take_drops();
+        if (dropped != 0)
+        {
+            reset_lines();
+            _have_drop_generation = false;
+            write_log(Severity.warning, "esp-idf", null, "Capture dropped ", dropped,
+                      dropped == 1 ? " log fragment" : " log fragments");
+        }
+    }
+
+    void consume(scope ref IdfLogChunk chunk)
+    {
+        if (!_have_drop_generation)
+        {
+            _drop_generation = chunk.drop_generation;
+            _have_drop_generation = true;
+        }
+        else if (_drop_generation != chunk.drop_generation)
+        {
+            reset_lines();
+            _drop_generation = chunk.drop_generation;
+        }
+
+        LineAssembler* line = line_for(chunk.task);
+        foreach (c; chunk.text)
+        {
+            if (c == '\r' || c == '\n')
+            {
+                emit(*line);
+                continue;
+            }
+            if (line.length < line.data.length)
+                line.data[line.length++] = c;
+            else
+                line.truncated = true;
+        }
+        if (chunk.truncated)
+        {
+            line.truncated = true;
+            emit(*line);
+        }
+    }
+
+    LineAssembler* line_for(void* task)
+    {
+        foreach (ref line; _lines[0 .. max_sources])
+        {
+            if (line.used && line.task is task)
+            {
+                line.activity = ++_activity;
+                return &line;
+            }
+        }
+        foreach (ref line; _lines[0 .. max_sources])
+        {
+            if (!line.used || line.length == 0)
+                return assign(line, task);
+        }
+
+        LineAssembler* oldest = &_lines[0];
+        foreach (ref line; _lines[1 .. max_sources])
+            if (line.activity < oldest.activity)
+                oldest = &line;
+        oldest.truncated = true;
+        emit(*oldest);
+        return assign(*oldest, task);
+    }
+
+    LineAssembler* assign(ref LineAssembler line, void* task)
+    {
+        line.task = task;
+        line.length = 0;
+        line.activity = ++_activity;
+        line.used = true;
+        line.truncated = false;
+        return &line;
+    }
+
+    void emit(ref LineAssembler line)
+    {
+        if (line.length == 0 && !line.truncated)
+            return;
+
+        size_t length = line.length;
+        if (line.truncated)
+        {
+            enum marker = " [truncated]";
+            if (length > line.data.length - marker.length)
+                length = line.data.length - marker.length;
+            line.data[length .. length + marker.length] = marker[];
+            length += marker.length;
+        }
+        ParsedIDFLine parsed = parse_idf_line(line.data[0 .. length]);
+        write_log(parsed.severity, "esp-idf", parsed.tag, parsed.message);
+        line.length = 0;
+        line.truncated = false;
+    }
+
+    void reset_lines()
+    {
+        foreach (ref line; _lines[0 .. max_sources])
+        {
+            line.task = null;
+            line.length = 0;
+            line.activity = 0;
+            line.used = false;
+            line.truncated = false;
+        }
+    }
+}
+
+private:
+struct LineAssembler
+{
+    void* task;
+    uint activity;
+    ushort length;
+    bool used;
+    bool truncated;
+    char[IDFLogBridgeModule.max_line_length] data = void;
+}
+
+__gshared shared(size_t) g_bridge;
+
+struct DrainSweep
+{
+    void event(MonoTime when) nothrow @nogc
+    {
+        size_t bridge = atomicLoad!(MemoryOrder.acquire)(g_bridge);
+        if (bridge != 0)
+            (cast(IDFLogBridgeModule)cast(void*)bridge).drain(when);
+    }
+}
+__gshared DrainSweep g_drain_sweep;
+
+void idf_log_ready()
+{
+    size_t bridge = atomicLoad!(MemoryOrder.acquire)(g_bridge);
+    if (bridge != 0)
+        (cast(IDFLogBridgeModule)cast(void*)bridge).request_drain();
+}
+}
+
+
+private:
+struct ParsedIDFLine
+{
+    Severity severity;
+    const(char)[] tag;
+    const(char)[] message;
+}
+
+ParsedIDFLine parse_idf_line(const(char)[] input)
+{
+    const(char)[] line = strip_ansi(input);
+    ParsedIDFLine result = { severity: Severity.info, message: line };
+    if (line.length < 2 || line[1] != ' ')
+        return result;
+
+    switch (line[0])
+    {
+        case 'E': result.severity = Severity.error; break;
+        case 'W': result.severity = Severity.warning; break;
+        case 'I': result.severity = Severity.info; break;
+        case 'D': result.severity = Severity.debug_; break;
+        case 'V': result.severity = Severity.trace; break;
+        default: return result;
+    }
+
+    line = line[2 .. $];
+    if (line.length > 0 && line[0] == '(')
+    {
+        size_t close;
+        for (close = 1; close < line.length && line[close] != ')'; ++close) {}
+        if (close < line.length)
+        {
+            line = line[close + 1 .. $];
+            if (line.length > 0 && line[0] == ' ')
+                line = line[1 .. $];
+        }
+    }
+
+    result.message = line;
+    for (size_t i; i + 1 < line.length; ++i)
+    {
+        if (line[i] != ':' || line[i + 1] != ' ')
+            continue;
+        result.tag = line[0 .. i];
+        result.message = line[i + 2 .. $];
+        break;
+    }
+    return result;
+}
+
+const(char)[] strip_ansi(const(char)[] input)
+{
+    const(char)[] line = input;
+    while (line.length >= 3 && line[0] == '\x1b' && line[1] == '[')
+    {
+        size_t end = csi_end(line);
+        if (end == 0)
+            break;
+        line = line[end .. $];
+    }
+    while (line.length >= 3 && line[$ - 1] >= '@' && line[$ - 1] <= '~')
+    {
+        size_t start = line.length - 2;
+        while (start > 0 && line[start] != '\x1b')
+            --start;
+        if (line[start] != '\x1b' || start + 1 >= line.length || line[start + 1] != '[')
+            break;
+        line = line[0 .. start];
+    }
+    return line;
+}
+
+size_t csi_end(const(char)[] text)
+{
+    for (size_t i = 2; i < text.length; ++i)
+        if (text[i] >= '@' && text[i] <= '~')
+            return i + 1;
+    return 0;
+}
+
+
+unittest
+{
+    auto v1 = parse_idf_line("E (123) wifi: association failed");
+    assert(v1.severity == Severity.error);
+    assert(v1.tag == "wifi");
+    assert(v1.message == "association failed");
+
+    auto v2 = parse_idf_line("W storage: nearly full");
+    assert(v2.severity == Severity.warning);
+    assert(v2.tag == "storage");
+    assert(v2.message == "nearly full");
+
+    auto coloured = parse_idf_line("\x1b[0;32mI (7) boot: ready\x1b[0m");
+    assert(coloured.severity == Severity.info);
+    assert(coloured.tag == "boot");
+    assert(coloured.message == "ready");
+
+    auto raw = parse_idf_line("raw diagnostic");
+    assert(raw.severity == Severity.info);
+    assert(raw.tag is null);
+    assert(raw.message == "raw diagnostic");
+}

--- a/src/manager/package.d
+++ b/src/manager/package.d
@@ -843,39 +843,12 @@ nothrow @nogc:
     }
 
     bool post_event(EventHandler handler, MonoTime when, EventPriority priority = EventPriority.control)
-    {
-        import urt.atomic : atomicFetchAdd, atomicFetchSub, MemoryOrder;
-        import urt.log : writeError, writeWarning;
+        => enqueue_event(handler, when, priority, true);
 
-        bool ok;
-        final switch (priority)
-        {
-            case EventPriority.control:
-                atomicFetchAdd!(MemoryOrder.relaxed)(_priority_events_posted, 1);
-                ok = g_priority_events.enqueue(PendingEvent(handler, when));
-                if (!ok)
-                {
-                    atomicFetchSub!(MemoryOrder.relaxed)(_priority_events_posted, 1);
-                    atomicFetchAdd!(MemoryOrder.relaxed)(_priority_event_overflows, 1);
-                    writeError("priority event queue overflow handler=", cast(size_t)handler.funcptr, " ctx=", cast(size_t)handler.ptr);
-                }
-                break;
-            case EventPriority.bulk:
-                atomicFetchAdd!(MemoryOrder.relaxed)(_bulk_events_posted, 1);
-                ok = g_bulk_events.enqueue(PendingEvent(handler, when));
-                if (!ok)
-                {
-                    atomicFetchSub!(MemoryOrder.relaxed)(_bulk_events_posted, 1);
-                    atomicFetchAdd!(MemoryOrder.relaxed)(_bulk_event_overflows, 1);
-                    writeWarning("bulk event queue overflow handler=", cast(size_t)handler.funcptr, " ctx=", cast(size_t)handler.ptr);
-                }
-                break;
-        }
-        if (!ok)
-            return false;
-        _wake_event.set();
-        return true;
-    }
+    // Foreign producer callbacks use this form when entering the logger on an
+    // overflow would recurse into the producer that is being marshalled.
+    bool try_post_event(EventHandler handler, MonoTime when, EventPriority priority = EventPriority.control)
+        => enqueue_event(handler, when, priority, false);
 
     bool post_event_from_isr(EventHandler handler, EventPriority priority = EventPriority.control)
     {
@@ -1568,6 +1541,42 @@ nothrow @nogc:
 
 private:
 
+    bool enqueue_event(EventHandler handler, MonoTime when, EventPriority priority, bool report_overflow)
+    {
+        import urt.atomic : atomicFetchAdd, atomicFetchSub, MemoryOrder;
+        import urt.log : writeError, writeWarning;
+
+        bool ok;
+        final switch (priority)
+        {
+            case EventPriority.control:
+                atomicFetchAdd!(MemoryOrder.relaxed)(_priority_events_posted, 1);
+                ok = g_priority_events.enqueue(PendingEvent(handler, when));
+                if (!ok)
+                {
+                    atomicFetchSub!(MemoryOrder.relaxed)(_priority_events_posted, 1);
+                    atomicFetchAdd!(MemoryOrder.relaxed)(_priority_event_overflows, 1);
+                    if (report_overflow)
+                        writeError("priority event queue overflow handler=", cast(size_t)handler.funcptr, " ctx=", cast(size_t)handler.ptr);
+                }
+                break;
+            case EventPriority.bulk:
+                atomicFetchAdd!(MemoryOrder.relaxed)(_bulk_events_posted, 1);
+                ok = g_bulk_events.enqueue(PendingEvent(handler, when));
+                if (!ok)
+                {
+                    atomicFetchSub!(MemoryOrder.relaxed)(_bulk_events_posted, 1);
+                    atomicFetchAdd!(MemoryOrder.relaxed)(_bulk_event_overflows, 1);
+                    if (report_overflow)
+                        writeWarning("bulk event queue overflow handler=", cast(size_t)handler.funcptr, " ctx=", cast(size_t)handler.ptr);
+                }
+                break;
+        }
+        if (!ok)
+            return false;
+        _wake_event.set();
+        return true;
+}
     // Zero-ref profiles are retained: element descs and expressions
     // on surviving devices borrow the profile's string caches, so freeing needs
     // device-side ownership first. TODO: free when the last borrower dies.

--- a/src/manager/plugin.d
+++ b/src/manager/plugin.d
@@ -82,6 +82,13 @@ void register_modules(Application app)
     register_module!(manager.record)(app);
     register_module!(manager.sync)(app);
 
+    version (ESP8266) {}
+    else version (Espressif)
+    {
+        import driver.esp32.idf_log_bridge;
+        register_module!(driver.esp32.idf_log_bridge)(app);
+    }
+
     import router.port;
     register_module!(router.port)(app);
 


### PR DESCRIPTION
IDF components log through their own facility, so on a device the two streams arrive independently and only one of them obeys OpenWatt's sinks, filters and severity.

The bridge installs a vprintf hook, maps IDF's level onto a `Severity` and tags the message with the originating component, so IDF output lands wherever everything else does.

Branches from master. The `smartevse-v30` sdkconfig hunk from the original commit is held back for the SmartEVSE series.
