### PR TITLE
ether transport: MAC-addressed UDP and TCP through the normal stack

### DIFF
--- a/openwatt.vcxproj
+++ b/openwatt.vcxproj
@@ -262,6 +262,7 @@
     <DCompile Include="src\protocol\zigbee\zdo.d" />
     <DCompile Include="src\router\iface\address_table.d" />
     <DCompile Include="src\router\iface\bridge.d" />
+    <DCompile Include="src\router\iface\endpoint.d" />
     <DCompile Include="src\router\iface\ethernet.d" />
     <DCompile Include="src\router\iface\group.d" />
     <DCompile Include="src\router\iface\mac.d" />

--- a/openwatt.vcxproj.filters
+++ b/openwatt.vcxproj.filters
@@ -765,6 +765,9 @@
     <DCompile Include="src\protocol\ezsp\client.d">
       <Filter>src\protocol\ezsp</Filter>
     </DCompile>
+    <DCompile Include="src\router\iface\endpoint.d">
+      <Filter>src\router\iface</Filter>
+    </DCompile>
     <DCompile Include="src\router\iface\ethernet.d">
       <Filter>src\router\iface</Filter>
     </DCompile>

--- a/src/protocol/ip/package.d
+++ b/src/protocol/ip/package.d
@@ -257,6 +257,8 @@ enum IPEvent : ubyte
     error,          // connection reset / fatal error
 }
 
+private static immutable ubyte[6] zero_mac;
+
 alias TCPRecvHandler   = void delegate(TCPConnection* conn, const(void)[] data, MonoTime rx_time) nothrow @nogc;
 alias TCPEventHandler  = void delegate(TCPConnection* conn, IPEvent event) nothrow @nogc;
 alias TCPAcceptHandler = void delegate(TCPListener* listener, TCPConnection* conn, MonoTime rx_time) nothrow @nogc;
@@ -270,19 +272,28 @@ TCPConnection* tcp_connect(InetAddress remote, TCPRecvHandler on_recv, TCPEventH
             return null;     // TODO: ipv6
         if (remote.family == AddressFamily.ether)
         {
-            // an ether connection binds to a station address; the local mac names the interface
-            if (!local || local.family != AddressFamily.ether)
-                return null;
-            EthernetStation station = find_ether_station(MACAddress(local._a.ether.addr));
-            if (!station)
-                return null;
-            ensure_ether_tap(station);
+            // a bound local names the station; unbound floods the SYN and the peer's
+            // reply pins the source, so replies must be heard on every segment
+            if (local && local.family == AddressFamily.ether && !local.addr_any)
+            {
+                EthernetStation station = find_ether_station(MACAddress(local._a.ether.addr));
+                if (!station)
+                    return null;
+                ensure_ether_tap(station);
+            }
+            else
+                ether_request_tap_all();
         }
 
         TcpPcb* pcb = defaultAllocator().allocT!TcpPcb();
         tcp_assign_id(pcb);
         pcb.handle = TcpEndpointOwned;     // keep tcp_tick from auto-freeing it
-        pcb.local = local && local.family == remote.family ? *local : InetAddress(IPAddr.any, 0);
+        if (local && local.family == remote.family)
+            pcb.local = *local;
+        else if (remote.family == AddressFamily.ether)
+            pcb.local = InetAddress(zero_mac, 0);
+        else
+            pcb.local = InetAddress(IPAddr.any, 0);
         if (pcb.local.port == 0)
             pcb.local.port = allocate_tcp_port();
         pcb.remote = remote;
@@ -379,10 +390,15 @@ TCPListener* tcp_listen(InetAddress local, TCPAcceptHandler on_accept)
             return null;     // TODO: ipv6
         if (local.family == AddressFamily.ether)
         {
-            EthernetStation station = find_ether_station(MACAddress(local._a.ether.addr));
-            if (!station)
-                return null;
-            ensure_ether_tap(station);
+            if (local.addr_any)
+                ether_request_tap_all();    // any-listener: accept on every segment
+            else
+            {
+                EthernetStation station = find_ether_station(MACAddress(local._a.ether.addr));
+                if (!station)
+                    return null;
+                ensure_ether_tap(station);
+            }
         }
 
         TcpPcb* pcb = defaultAllocator().allocT!TcpPcb();
@@ -577,19 +593,24 @@ UDPEndpoint* udp_open(const(InetAddress)* local, const(InetAddress)* remote, UDP
 }
 
 // Datagrams addressed by (mac, port): same UDPEndpoint, backed by the ether transport
-// instead of a socket or PCB. The local address must be a station's mac; it names the
-// interface the endpoint is bound to.
-// TODO: no local address = wildcard listen across all ethernet stations
+// instead of a socket or PCB. A station's mac as the local address binds the endpoint
+// to that interface; a null local or the zero mac is a wildcard bind: receive on every
+// ethernet segment, egress by learned neighbour with unknown-unicast flooding.
 private UDPEndpoint* udp_open_ether(const(InetAddress)* local, const(InetAddress)* remote, UDPRecvHandler on_recv)
 {
-    if (!local || local.family != AddressFamily.ether)
+    if (local && local.family != AddressFamily.ether)
         return null;
     if (remote && remote.family != AddressFamily.ether)
         return null;
 
-    EthernetStation station = find_ether_station(MACAddress(local._a.ether.addr));
-    if (!station)
-        return null;
+    EthernetStation station;
+    ushort local_port = local ? local.port : 0;
+    if (local && !local.addr_any)
+    {
+        station = find_ether_station(MACAddress(local._a.ether.addr));
+        if (!station)
+            return null;
+    }
 
     UDPEndpoint* ep = defaultAllocator().allocT!UDPEndpoint();
     ep._on_recv = on_recv;
@@ -598,7 +619,7 @@ private UDPEndpoint* udp_open_ether(const(InetAddress)* local, const(InetAddress
         ep._remote = *remote;
         ep._connected = true;
     }
-    ep._ether = ether_open(station, local._a.ether.port, &ep.on_ether_recv,
+    ep._ether = ether_open(station, local_port, &ep.on_ether_recv,
                            remote ? MACAddress(remote._a.ether.addr) : MACAddress(),
                            remote ? remote._a.ether.port : 0);
     if (!ep._ether)

--- a/src/protocol/ip/package.d
+++ b/src/protocol/ip/package.d
@@ -266,21 +266,26 @@ TCPConnection* tcp_connect(InetAddress remote, TCPRecvHandler on_recv, TCPEventH
 {
     version (UseInternalIPStack)
     {
-        if (remote.family != AddressFamily.ipv4)
-            return null;     // in-tree stack TCP is v4-only for now...
+        if (remote.family != AddressFamily.ipv4 && remote.family != AddressFamily.ether)
+            return null;     // TODO: ipv6
+        if (remote.family == AddressFamily.ether)
+        {
+            // an ether connection binds to a station address; the local mac names the interface
+            if (!local || local.family != AddressFamily.ether)
+                return null;
+            EthernetStation station = find_ether_station(MACAddress(local._a.ether.addr));
+            if (!station)
+                return null;
+            ensure_ether_tap(station);
+        }
 
         TcpPcb* pcb = defaultAllocator().allocT!TcpPcb();
         tcp_assign_id(pcb);
         pcb.handle = TcpEndpointOwned;     // keep tcp_tick from auto-freeing it
-        if (local && local.family == AddressFamily.ipv4)
-        {
-            pcb.local_addr = local._a.ipv4.addr;
-            pcb.local_port = local._a.ipv4.port;
-        }
-        if (pcb.local_port == 0)
-            pcb.local_port = allocate_tcp_port();
-        pcb.remote_addr = remote._a.ipv4.addr;
-        pcb.remote_port = remote._a.ipv4.port;
+        pcb.local = local && local.family == remote.family ? *local : InetAddress(IPAddr.any, 0);
+        if (pcb.local.port == 0)
+            pcb.local.port = allocate_tcp_port();
+        pcb.remote = remote;
 
         TCPConnection* c = defaultAllocator().allocT!TCPConnection();
         c._pcb = pcb;
@@ -370,20 +375,26 @@ TCPListener* tcp_listen(InetAddress local, TCPAcceptHandler on_accept)
 {
     version (UseInternalIPStack)
     {
-        if (local.family != AddressFamily.ipv4)
-            return null;     // in-tree stack TCP is v4-only
+        if (local.family != AddressFamily.ipv4 && local.family != AddressFamily.ether)
+            return null;     // TODO: ipv6
+        if (local.family == AddressFamily.ether)
+        {
+            EthernetStation station = find_ether_station(MACAddress(local._a.ether.addr));
+            if (!station)
+                return null;
+            ensure_ether_tap(station);
+        }
 
         TcpPcb* pcb = defaultAllocator().allocT!TcpPcb();
         tcp_assign_id(pcb);
         pcb.handle = TcpEndpointOwned;
-        pcb.local_addr = local._a.ipv4.addr;
-        pcb.local_port = local._a.ipv4.port;
-        if (pcb.local_port == 0)
-            pcb.local_port = allocate_tcp_port();
+        pcb.local = local;
+        if (pcb.local.port == 0)
+            pcb.local.port = allocate_tcp_port();
 
         TCPListener* l = defaultAllocator().allocT!TCPListener();
         l._lpcb = pcb;
-        l._local = InetAddress(pcb.local_addr, pcb.local_port);
+        l._local = pcb.local;
         l._on_accept = on_accept;
         pcb.listen_owner = l;
         native_tcp_listen(pcb);     // sets state=listen, registers
@@ -626,7 +637,7 @@ nothrow @nogc:
     version (UseInternalIPStack)
     {
         InetAddress local()
-            => _pcb ? InetAddress(_pcb.local_addr, _pcb.local_port) : InetAddress();
+            => _pcb ? _pcb.local : InetAddress();
 
         ptrdiff_t send(const(void[])[] data...)
         {
@@ -916,7 +927,7 @@ private:
         void mark_connected()
         {
             _phase = Phase.open;
-            _remote = InetAddress(_pcb.remote_addr, _pcb.remote_port);
+            _remote = _pcb.remote;
             if (_on_event)
                 _on_event(&this, IPEvent.connected);
         }
@@ -1733,6 +1744,8 @@ nothrow @nogc:
             // TODO: register additional frame handlers when other L3 carriers land
             //       (PacketType._6lowpan, ppp/IPCP frame type, raw_ip tunnels).
 
+            set_ether_tcp_input(&ether_tcp_input);
+
             import protocol.ip.tcp : tcp_print;
             g_app.console.register_command!tcp_print("/protocol/ip/tcp", this, "print");
             g_app.console.register_command!neighbour_v4_print("/protocol/ip/neighbour", this, "print");
@@ -2038,10 +2051,18 @@ version (UseInternalIPStack)
         TCPConnection* c = defaultAllocator().allocT!TCPConnection();
         c._pcb = pcb;
         c._phase = TCPConnection.Phase.open;
-        c._remote = InetAddress(pcb.remote_addr, pcb.remote_port);
+        c._remote = pcb.remote;
         pcb.conn_owner = c;
         _tcp_conns ~= c;
         return c;
+    }
+
+    // Installed as the ether tap's tcp hook: segments addressed to a station arrive here.
+    void ether_tcp_input(MACAddress src, MACAddress dst, const(void)[] segment, MonoTime rx_time)
+    {
+        import protocol.ip.tcp : tcp_segment_input;
+        if (_stack_ptr)
+            tcp_segment_input(*_stack_ptr, InetAddress(src.b, 0), InetAddress(dst.b, 0), cast(const(ubyte)[])segment, rx_time);
     }
 }
 else version (Windows)

--- a/src/protocol/ip/package.d
+++ b/src/protocol/ip/package.d
@@ -32,6 +32,7 @@ version (UseInternalIPStack)
 }
 
 import router.iface;
+import router.iface.endpoint;
 import router.iface.ethernet;
 
 version(Windows)
@@ -458,6 +459,9 @@ TCPListener* tcp_listen(ushort port, TCPAcceptHandler on_accept)
 // when `remote` is set, send() targets it and the endpoint only delivers datagrams from that peer
 UDPEndpoint* udp_open(const(InetAddress)* local, const(InetAddress)* remote, UDPRecvHandler on_recv)
 {
+    if ((local && local.family == AddressFamily.ether) || (remote && remote.family == AddressFamily.ether))
+        return udp_open_ether(local, remote, on_recv);
+
     version (UseInternalIPStack)
     {
         // The in-tree stack does UDP over v4 only; deliver datagrams inline.
@@ -559,6 +563,40 @@ UDPEndpoint* udp_open(const(InetAddress)* local, const(InetAddress)* remote, UDP
         _udp_eps ~= ep;
         return ep;
     }
+}
+
+// Datagrams addressed by (mac, port): same UDPEndpoint, backed by the ether transport
+// instead of a socket or PCB. The local address must be a station's mac; it names the
+// interface the endpoint is bound to.
+// TODO: no local address = wildcard listen across all ethernet stations
+private UDPEndpoint* udp_open_ether(const(InetAddress)* local, const(InetAddress)* remote, UDPRecvHandler on_recv)
+{
+    if (!local || local.family != AddressFamily.ether)
+        return null;
+    if (remote && remote.family != AddressFamily.ether)
+        return null;
+
+    EthernetStation station = find_ether_station(MACAddress(local._a.ether.addr));
+    if (!station)
+        return null;
+
+    UDPEndpoint* ep = defaultAllocator().allocT!UDPEndpoint();
+    ep._on_recv = on_recv;
+    if (remote)
+    {
+        ep._remote = *remote;
+        ep._connected = true;
+    }
+    ep._ether = ether_open(station, local._a.ether.port, &ep.on_ether_recv,
+                           remote ? MACAddress(remote._a.ether.addr) : MACAddress(),
+                           remote ? remote._a.ether.port : 0);
+    if (!ep._ether)
+    {
+        defaultAllocator().freeT(ep);
+        return null;
+    }
+    _udp_eps ~= ep;
+    return ep;
 }
 
 
@@ -1368,12 +1406,18 @@ nothrow @nogc:
     version (UseInternalIPStack)
     {
         InetAddress local()
-            => _pcb ? InetAddress(_pcb.local_addr, _pcb.local_port) : InetAddress();
+        {
+            if (_ether)
+                return InetAddress(_ether.local.b, _ether.local_port);
+            return _pcb ? InetAddress(_pcb.local_addr, _pcb.local_port) : InetAddress();
+        }
 
         ptrdiff_t send(scope const(void)[] data)
         {
             if (_closing || !_connected)
                 return 0;
+            if (_ether)
+                return _ether.send(data);
             if (!udp_output(*_stack_ptr, _pcb.local_addr, _pcb.local_port,
                             v4_addr(_remote), port_of(_remote), cast(const(ubyte)[])data))
                 return 0;
@@ -1384,6 +1428,11 @@ nothrow @nogc:
         {
             if (_closing)
                 return 0;
+            if (_ether)
+            {
+                const(InetAddress.Ether)* e = to.as_ether;
+                return e ? _ether.sendto(MACAddress(e.addr), e.port, data) : 0;
+            }
             if (!udp_output(*_stack_ptr, _pcb.local_addr, _pcb.local_port,
                             v4_addr(to), port_of(to), cast(const(ubyte)[])data))
                 return 0;
@@ -1394,6 +1443,11 @@ nothrow @nogc:
         {
             if (_closing)
                 return;
+            if (_ether)
+            {
+                _ether.close();
+                _ether = null;
+            }
             if (_pcb)
                 _pcb.owner = null;     // stop delivery; pcb torn down by release() on sweep
             _closing = true;
@@ -1402,11 +1456,19 @@ nothrow @nogc:
     else version (Windows)
     {
         InetAddress local()
-            => InetAddress();   // TODO: getsockname
+        {
+            if (_ether)
+                return InetAddress(_ether.local.b, _ether.local_port);
+            return InetAddress();   // TODO: getsockname
+        }
 
         ptrdiff_t send(scope const(void)[] data)
         {
-            if (_closing || !_connected || _handle == INVALID_SOCKET || data.length == 0)
+            if (_closing || !_connected)
+                return 0;
+            if (_ether)
+                return _ether.send(data);
+            if (_handle == INVALID_SOCKET || data.length == 0)
                 return 0;
             sockaddr_in to = to_sockaddr_in(_remote);
             int n = ws_sendto(_handle, data.ptr, cast(int)data.length, 0, &to, cast(int)sockaddr_in.sizeof);
@@ -1415,7 +1477,14 @@ nothrow @nogc:
 
         ptrdiff_t sendto(scope const(void)[] data, InetAddress dst)
         {
-            if (_closing || _handle == INVALID_SOCKET || data.length == 0)
+            if (_closing)
+                return 0;
+            if (_ether)
+            {
+                const(InetAddress.Ether)* e = dst.as_ether;
+                return e ? _ether.sendto(MACAddress(e.addr), e.port, data) : 0;
+            }
+            if (_handle == INVALID_SOCKET || data.length == 0)
                 return 0;
             sockaddr_in to = to_sockaddr_in(dst);
             int n = ws_sendto(_handle, data.ptr, cast(int)data.length, 0, &to, cast(int)sockaddr_in.sizeof);
@@ -1427,6 +1496,11 @@ nothrow @nogc:
             if (_closing)
                 return;
             _closing = true;
+            if (_ether)
+            {
+                _ether.close();
+                _ether = null;
+            }
             if (_handle != INVALID_SOCKET)
             {
                 CancelIoEx(cast(HANDLE)_handle, null);
@@ -1439,6 +1513,8 @@ nothrow @nogc:
     {
         InetAddress local()
         {
+            if (_ether)
+                return InetAddress(_ether.local.b, _ether.local_port);
             InetAddress a;
             if (_socket)
                 _socket.get_socket_name(a);
@@ -1449,6 +1525,8 @@ nothrow @nogc:
         {
             if (_closing || !_connected)
                 return 0;
+            if (_ether)
+                return _ether.send(data);
             size_t sent;
             if (_socket.sendto(&_remote, &sent, data).failed)
                 return 0;
@@ -1459,6 +1537,11 @@ nothrow @nogc:
         {
             if (_closing)
                 return 0;
+            if (_ether)
+            {
+                const(InetAddress.Ether)* e = to.as_ether;
+                return e ? _ether.sendto(MACAddress(e.addr), e.port, data) : 0;
+            }
             size_t sent;
             if (_socket.sendto(&to, &sent, data).failed)
                 return 0;
@@ -1470,6 +1553,11 @@ nothrow @nogc:
             if (_closing)
                 return;
             _closing = true;
+            if (_ether)
+            {
+                _ether.close();
+                _ether = null;
+            }
             if (_watched)
             {
                 g_app.unwatch_io(_socket.handle);
@@ -1488,6 +1576,16 @@ private:
     bool _connected;
     InetAddress _remote;
     UDPRecvHandler _on_recv;
+    EtherEndpoint* _ether;
+
+    void on_ether_recv(EtherEndpoint*, const(void)[] data, MACAddress src, ushort src_port, MonoTime rx_time)
+    {
+        if (_on_recv)
+        {
+            InetAddress from = InetAddress(src.b, src_port);
+            _on_recv(&this, data, from, rx_time);
+        }
+    }
 
     version (UseInternalIPStack)
     {

--- a/src/protocol/ip/socket.d
+++ b/src/protocol/ip/socket.d
@@ -151,11 +151,9 @@ SocketResult c_bind(Socket socket, ref const InetAddress address)
 
     if (s.tcp)
     {
-        s.tcp.local_addr = address._a.ipv4.addr;
-        ushort port = address._a.ipv4.port;
-        if (port == 0)
-            port = allocate_ephemeral();
-        s.tcp.local_port = port;
+        s.tcp.local = address;
+        if (s.tcp.local.port == 0)
+            s.tcp.local.port = allocate_ephemeral();
         return SocketResult.success;
     }
     if (!s.udp)
@@ -176,8 +174,10 @@ SocketResult c_listen(Socket socket, uint backlog)
         return SocketResult.invalid_socket;
     if (!s.tcp)
         return SocketResult.invalid_argument;
-    if (s.tcp.local_port == 0)
-        s.tcp.local_port = allocate_ephemeral();
+    if (s.tcp.local.family == AddressFamily.unspecified)
+        s.tcp.local = InetAddress(IPAddr.any, 0);
+    if (s.tcp.local.port == 0)
+        s.tcp.local.port = allocate_ephemeral();
     tcp_listen(s.tcp);
     return SocketResult.success;
 }
@@ -194,15 +194,17 @@ SocketResult c_connect(Socket socket, ref const InetAddress address)
     {
         if (s.tcp.state != TcpState.closed)
             return SocketResult.already_connected;
-        if (s.tcp.local_port == 0)
-            s.tcp.local_port = allocate_ephemeral();
-        s.tcp.remote_addr = address._a.ipv4.addr;
-        s.tcp.remote_port = address._a.ipv4.port;
-        if (s.tcp.local_addr == IPAddr.any)
+        if (s.tcp.local.family == AddressFamily.unspecified)
+            s.tcp.local = InetAddress(IPAddr.any, 0);
+        if (s.tcp.local.port == 0)
+            s.tcp.local.port = allocate_ephemeral();
+        s.tcp.remote = address;
+        if (s.tcp.local.addr_any)
         {
-            s.tcp.local_addr = _stack.select_source_v4(s.tcp.remote_addr);
-            if (s.tcp.local_addr == IPAddr.any)
+            IPAddr src = _stack.select_source_v4(s.tcp.remote._a.ipv4.addr);
+            if (src == IPAddr.any)
                 return SocketResult.network_unreachable;
+            s.tcp.local = InetAddress(src, s.tcp.local.port);
         }
         if (!tcp_connect(*_stack, s.tcp))
             return SocketResult.failure;
@@ -242,7 +244,7 @@ SocketResult c_accept(Socket socket, out Socket connection, InetAddress* remote)
 
     connection = Socket(h);
     if (remote)
-        *remote = InetAddress(child.remote_addr, child.remote_port);
+        *remote = child.remote;
 
     s.tcp.accept_event = (s.tcp.accept_queue.length > 0);
     return SocketResult.success;
@@ -344,7 +346,7 @@ SocketResult c_recvfrom(Socket socket, void[] buffer, MsgFlags flags, InetAddres
         if (bytes_received)
             *bytes_received = n;
         if (from)
-            *from = InetAddress(s.tcp.remote_addr, s.tcp.remote_port);
+            *from = s.tcp.remote;
         if (n == 0)
         {
             // EOF on closed connection vs just-no-data-yet:
@@ -483,9 +485,9 @@ SocketResult c_get_peer_name(Socket socket, out InetAddress addr)
     auto s = lookup(socket);
     if (!s)
         return SocketResult.invalid_socket;
-    if (s.tcp && s.tcp.remote_port != 0)
+    if (s.tcp && s.tcp.remote.port != 0)
     {
-        addr = InetAddress(s.tcp.remote_addr, s.tcp.remote_port);
+        addr = s.tcp.remote;
         return SocketResult.success;
     }
     if (s.udp && s.udp.connected)
@@ -503,7 +505,7 @@ SocketResult c_get_socket_name(Socket socket, out InetAddress addr)
         return SocketResult.invalid_socket;
     if (s.tcp)
     {
-        addr = InetAddress(s.tcp.local_addr, s.tcp.local_port);
+        addr = s.tcp.local;
         return SocketResult.success;
     }
     if (s.udp)

--- a/src/protocol/ip/tcp.d
+++ b/src/protocol/ip/tcp.d
@@ -13,6 +13,8 @@ import urt.time;
 import manager.base : ActiveObject, StateSignal;
 
 import router.iface;
+import router.iface.endpoint;
+import router.iface.ethernet;
 import router.iface.packet;
 
 import protocol.ip : IPv4Header, IPProtocol, TCPConnection, TCPListener;
@@ -90,6 +92,7 @@ enum TcpOptionKind : ubyte
 
 enum size_t TcpDefaultMss     = 536;        // RFC 1122 minimum
 enum size_t TcpEthernetMss    = 1460;       // 1500 - 20 IP - 20 TCP
+enum size_t ether_transport_overhead = 5 + 13;  // ow framing + ether-transport header
 enum size_t TcpSendBufSize    = 8192;
 enum size_t TcpRecvBufSize    = 8192;
 enum size_t TcpAcceptQueueMax = 16;
@@ -153,11 +156,9 @@ struct TcpPcb
     // connection's lifetime amid mixed traffic. Assigned in tcp_assign_id.
     uint id;
 
-    // 4-tuple
-    IPAddr  local_addr;
-    ushort  local_port;
-    IPAddr  remote_addr;
-    ushort  remote_port;
+    // 4-tuple; the address family selects the network layer beneath the connection
+    InetAddress local;
+    InetAddress remote;
 
     TcpState state;
 
@@ -381,20 +382,23 @@ void tcp_listen(TcpPcb* pcb)
     pcb.rcv_wnd      = TcpRecvBufSize;
     tcp_register(pcb);
     version (DebugTCP)
-        log.trace("c", pcb.id, " listen :", pcb.local_port);
+        log.trace("c", pcb.id, " listen :", pcb.local.port);
 }
 
 bool tcp_connect(ref IPStack stack, TcpPcb* pcb)
 {
-    if (pcb.local_port == 0 || pcb.remote_port == 0)
+    if (pcb.local.port == 0 || pcb.remote.port == 0)
         return false;
     refresh_route(stack, pcb);
     if (!pcb.route_egress && !pcb.local_delivery)
         return false;
-    if (pcb.local_addr == IPAddr.any)
-        pcb.local_addr = stack.select_source_v4(pcb.remote_addr);
-    if (pcb.local_addr == IPAddr.any)
-        return false;
+    if (pcb.local.family == AddressFamily.ipv4 && pcb.local.addr_any)
+    {
+        IPAddr src = stack.select_source_v4(pcb.remote._a.ipv4.addr);
+        if (src == IPAddr.any)
+            return false;
+        pcb.local = InetAddress(src, pcb.local.port);
+    }
 
     pcb.snd_iss   = generate_iss();
     pcb.snd_una   = pcb.snd_iss;
@@ -404,7 +408,7 @@ bool tcp_connect(ref IPStack stack, TcpPcb* pcb)
     pcb.state     = TcpState.syn_sent;
     tcp_register(pcb);      // findable before SYN goes out, in case of synchronous loopback delivery
 
-    log.info("c", pcb.id, " connect ", pcb.local_addr, ':', pcb.local_port, " -> ", pcb.remote_addr, ':', pcb.remote_port, " egress=", pcb.route_egress ? pcb.route_egress.name[] : "<null>");
+    log.info("c", pcb.id, " connect ", pcb.local, " -> ", pcb.remote, " egress=", pcb.route_egress ? pcb.route_egress.name[] : "<null>");
 
     send_segment_at(stack, pcb, TcpFlag.syn, pcb.snd_iss, null);
     start_rtt_sample(pcb, pcb.snd_nxt);
@@ -414,7 +418,7 @@ bool tcp_connect(ref IPStack stack, TcpPcb* pcb)
 
 void tcp_close(ref IPStack stack, TcpPcb* pcb)
 {
-    log.info("c", pcb.id, " tcp_close called in state=", pcb.state, " (", pcb.local_port, "->:", pcb.remote_port, ")");
+    log.info("c", pcb.id, " tcp_close called in state=", pcb.state, " (", pcb.local.port, "->:", pcb.remote.port, ")");
 
     final switch (pcb.state) with (TcpState)
     {
@@ -566,6 +570,7 @@ private void tcp_app_deliver(TcpPcb* pcb, const(ubyte)[] bytes, MonoTime rx_time
 // -------------------------------------------------------------------------
 // Ingress
 
+// v4 ingress from the stack dispatch: strip the IP header, then the family-generic path.
 void tcp_input(ref IPStack stack, ref Packet pkt)
 {
     if (pkt.data.length < IPv4Header.sizeof + TcpHeader.sizeof)
@@ -582,6 +587,16 @@ void tcp_input(ref IPStack stack, ref Packet pkt)
         return;
 
     const(ubyte)[] tcp_seg = (cast(const(ubyte)*)pkt.data.ptr)[ip_hdr_len .. ip_total];
+    tcp_segment_input(stack, InetAddress(IPAddr(ip.src), 0), InetAddress(IPAddr(ip.dst), 0), tcp_seg, pkt.creation_time);
+}
+
+// Family-generic ingress: src/dst carry the network-layer addresses (ports zero here;
+// filled in from the TCP header), tcp_seg is the whole TCP segment. The ether tap
+// delivers here directly, and ipv6 ingress will land here too.
+void tcp_segment_input(ref IPStack stack, InetAddress src, InetAddress dst, const(ubyte)[] tcp_seg, MonoTime rx_time)
+{
+    if (tcp_seg.length < TcpHeader.sizeof)
+        return;
     const t = cast(const TcpHeader*)tcp_seg.ptr;
 
     size_t tcp_hdr_len = t.data_offset * 4;
@@ -589,31 +604,31 @@ void tcp_input(ref IPStack stack, ref Packet pkt)
         return;
 
     // Verify TCP checksum (pseudo-header + segment).
-    ushort pseudo = pseudo_header_checksum_v4(IPAddr(ip.src), IPAddr(ip.dst), IPProtocol.tcp, cast(ushort)tcp_seg.length);
+    ushort pseudo = transport_pseudo_checksum(src, dst, IPProtocol.tcp, cast(ushort)tcp_seg.length);
     ushort calc = internet_checksum(tcp_seg, pseudo);
     if (calc != 0)
         return;
 
-    ushort src_port = t.src_port.bigEndianToNative!ushort;
-    ushort dst_port = t.dst_port.bigEndianToNative!ushort;
-    uint   seq      = t.seq.bigEndianToNative!uint;
-    uint   ack      = t.ack.bigEndianToNative!uint;
-    uint   wnd      = t.window.bigEndianToNative!ushort;
-    ubyte  flags    = t.flags;
+    src.port = t.src_port.bigEndianToNative!ushort;
+    dst.port = t.dst_port.bigEndianToNative!ushort;
+    uint   seq   = t.seq.bigEndianToNative!uint;
+    uint   ack   = t.ack.bigEndianToNative!uint;
+    uint   wnd   = t.window.bigEndianToNative!ushort;
+    ubyte  flags = t.flags;
     const(ubyte)[] payload = tcp_seg[tcp_hdr_len .. $];
 
-    TcpPcb* pcb = find_pcb_4tuple(IPAddr(ip.dst), dst_port, IPAddr(ip.src), src_port);
+    TcpPcb* pcb = find_pcb_4tuple(dst, src);
     if (!pcb)
-        pcb = find_listener(IPAddr(ip.dst), dst_port);
+        pcb = find_listener(dst);
 
     if (!pcb)
     {
         if (!(flags & TcpFlag.rst))
-            send_rst_for_unknown(stack, IPAddr(ip.src), src_port, IPAddr(ip.dst), dst_port, seq, ack, flags, payload.length);
+            send_rst_for_unknown(stack, src, dst, seq, ack, flags, payload.length);
         return;
     }
 
-    process_segment(stack, pcb, ip, t, seq, ack, wnd, flags, payload, pkt.creation_time);
+    process_segment(stack, pcb, src, dst, t, seq, ack, wnd, flags, payload, rx_time);
 }
 
 
@@ -761,7 +776,7 @@ void tcp_handle_unreachable(ref IPStack stack, ubyte code, uint code_data,
                             IPAddr local, ushort local_port,
                             IPAddr remote, ushort remote_port)
 {
-    TcpPcb* pcb = find_pcb_4tuple(local, local_port, remote, remote_port);
+    TcpPcb* pcb = find_pcb_4tuple(InetAddress(local, local_port), InetAddress(remote, remote_port));
     if (!pcb)
         return;
 
@@ -799,7 +814,7 @@ void tcp_handle_unreachable(ref IPStack stack, ubyte code, uint code_data,
 
 private:
 
-void process_segment(ref IPStack stack, TcpPcb* pcb, const IPv4Header* ip, const TcpHeader* t,
+void process_segment(ref IPStack stack, TcpPcb* pcb, ref const InetAddress src, ref const InetAddress dst, const TcpHeader* t,
                      uint seq, uint ack, uint wnd, ubyte flags, const(ubyte)[] payload, MonoTime rx_time)
 {
     version (DebugTCPProto)
@@ -814,12 +829,11 @@ void process_segment(ref IPStack stack, TcpPcb* pcb, const IPv4Header* ip, const
             return;
         if (flags & TcpFlag.ack)
         {
-            send_rst_for_unknown(stack, IPAddr(ip.src), t.src_port.bigEndianToNative!ushort,
-                                 IPAddr(ip.dst), t.dst_port.bigEndianToNative!ushort, seq, ack, flags, payload.length);
+            send_rst_for_unknown(stack, src, dst, seq, ack, flags, payload.length);
             return;
         }
         if (flags & TcpFlag.syn)
-            spawn_child_from_listen(stack, pcb, ip, t, seq, wnd);
+            spawn_child_from_listen(stack, pcb, src, dst, t, seq, wnd);
         return;
     }
 
@@ -832,9 +846,7 @@ void process_segment(ref IPStack stack, TcpPcb* pcb, const IPv4Header* ip, const
             if (seq_le(ack, pcb.snd_iss) || seq_gt(ack, pcb.snd_nxt))
             {
                 if (!(flags & TcpFlag.rst))
-                    send_segment_raw(stack, pcb.local_addr, pcb.local_port,
-                                     pcb.remote_addr, pcb.remote_port,
-                                     ack, 0, TcpFlag.rst, 0, null);
+                    send_segment_raw(stack, pcb.local, pcb.remote, ack, 0, TcpFlag.rst, 0, null);
                 return;
             }
             acceptable_ack = true;
@@ -843,7 +855,7 @@ void process_segment(ref IPStack stack, TcpPcb* pcb, const IPv4Header* ip, const
         {
             if (acceptable_ack)
             {
-                log.warning("c", pcb.id, " RST during connect (refused) ", pcb.remote_addr, ':', pcb.remote_port);
+                log.warning("c", pcb.id, " RST during connect (refused) ", pcb.remote);
                 pcb.state = TcpState.closed;
                 pcb.error_event = true;
                 tcp_unregister(pcb);
@@ -895,7 +907,7 @@ void process_segment(ref IPStack stack, TcpPcb* pcb, const IPv4Header* ip, const
         if (pcb.state == TcpState.syn_received && pcb.parent)
         {
             // Refused passive open
-            log.warning("c", pcb.id, " RST during passive open from ", pcb.remote_addr, ':', pcb.remote_port);
+            log.warning("c", pcb.id, " RST during passive open from ", pcb.remote);
             remove_child(pcb.parent, pcb);
             pcb.state = TcpState.closed;
             tcp_unregister(pcb);
@@ -903,7 +915,7 @@ void process_segment(ref IPStack stack, TcpPcb* pcb, const IPv4Header* ip, const
         }
         else
         {
-            log.warning("c", pcb.id, " RST in state=", pcb.state, " from ", pcb.remote_addr, ':', pcb.remote_port);
+            log.warning("c", pcb.id, " RST in state=", pcb.state, " from ", pcb.remote);
             pcb.state = TcpState.closed;
             pcb.error_event = true;
             tcp_unregister(pcb);
@@ -1148,7 +1160,7 @@ void process_segment(ref IPStack stack, TcpPcb* pcb, const IPv4Header* ip, const
             {
                 case established:
                     pcb.state = close_wait;
-                    log.info("c", pcb.id, " peer FIN -> close_wait (", pcb.remote_addr, ':', pcb.remote_port, ")");
+                    log.info("c", pcb.id, " peer FIN -> close_wait (", pcb.remote, ")");
                     break;
                 case fin_wait_1:
                     if (pcb.fin_sent && pcb.snd_una == pcb.snd_nxt)
@@ -1180,7 +1192,7 @@ void process_segment(ref IPStack stack, TcpPcb* pcb, const IPv4Header* ip, const
 }
 
 
-void spawn_child_from_listen(ref IPStack stack, TcpPcb* listener, const IPv4Header* ip, const TcpHeader* t, uint seq, uint wnd)
+void spawn_child_from_listen(ref IPStack stack, TcpPcb* listener, ref const InetAddress src, ref const InetAddress dst, const TcpHeader* t, uint seq, uint wnd)
 {
     if (listener.child_list.length >= TcpAcceptQueueMax * 2)
         return;     // refuse, drop SYN
@@ -1189,11 +1201,9 @@ void spawn_child_from_listen(ref IPStack stack, TcpPcb* listener, const IPv4Head
     listener.child_list ~= child;
     tcp_register(child);                    // assigns id before any logging
 
-    child.local_addr  = IPAddr(ip.dst);
-    child.local_port  = listener.local_port;
-    child.remote_addr = IPAddr(ip.src);
-    child.remote_port = t.src_port.bigEndianToNative!ushort;
-    child.parent      = listener;
+    child.local  = dst;
+    child.remote = src;
+    child.parent = listener;
     child.snd_iss     = generate_iss();
     child.snd_una     = child.snd_iss;
     child.snd_nxt     = child.snd_iss + 1;          // SYN consumes one
@@ -1207,7 +1217,7 @@ void spawn_child_from_listen(ref IPStack stack, TcpPcb* listener, const IPv4Head
     parse_options(t, child);                // peer's MSS may lower send_mss further
 
     version (DebugTCP)
-        log.trace("c", child.id, " accept (SYN) :", child.local_port, "<-", child.remote_addr, ':', child.remote_port);
+        log.trace("c", child.id, " accept (SYN) :", child.local.port, "<-", child.remote);
 
     send_segment_at(stack, child, TcpFlag.syn | TcpFlag.ack, child.snd_iss, null);
     start_rtt_sample(child, child.snd_nxt);
@@ -1274,7 +1284,7 @@ void send_segment_at(ref IPStack stack, TcpPcb* pcb, ubyte flags, uint seq, cons
     version (DebugTCPProto)
         log.trace("c", pcb.id, " >> ", flags_str(flags), " seq=", seq, " ack=", ack_val, " len=", data.length, " wnd=", window);
 
-    send_segment_raw(stack, pcb.local_addr, pcb.local_port, pcb.remote_addr, pcb.remote_port,
+    send_segment_raw(stack, pcb.local, pcb.remote,
                      seq, ack_val, flags, window, data, advertise_mss,
                      pcb.route_egress, pcb.route_next_hop);
 
@@ -1287,42 +1297,29 @@ void send_segment_at(ref IPStack stack, TcpPcb* pcb, ubyte flags, uint seq, cons
 // Build and emit a fully-specified TCP segment. Used both via PCB and for
 // stateless RSTs to unknown 4-tuples. SYN segments include an MSS option;
 // `advertise_mss` is the value to put in the option (caller's responsibility).
-// `egress`/`next_hop` are optional pre-resolved route hints; when non-null we
-// take the fast path through output_v4_routed and skip route lookup.
-void send_segment_raw(ref IPStack stack, IPAddr src_addr, ushort src_port, IPAddr dst_addr, ushort dst_port,
+// `egress`/`next_hop` are optional pre-resolved route hints: for v4 they take the
+// fast path through output_v4_routed; for ether, egress is the station itself.
+void send_segment_raw(ref IPStack stack, ref const InetAddress src, ref const InetAddress dst,
                       uint seq, uint ack_val, ubyte flags, ushort window, const(ubyte)[] data,
                       ushort advertise_mss = 0, BaseInterface egress = null, IPAddr next_hop = IPAddr.any)
 {
     enum size_t max_packet = 1500;      // scratch buffer; segment must already be sized to MSS
+    enum size_t reserve = IPv4Header.sizeof;    // network-header space; enough for any family we emit
+                                                // TODO: ipv6 needs a 40-byte reserve when it lands here
 
     bool include_mss = (flags & TcpFlag.syn) != 0;
     size_t opt_len = include_mss ? 4 : 0;
-    size_t total = IPv4Header.sizeof + TcpHeader.sizeof + opt_len + data.length;
+    size_t tcp_total = TcpHeader.sizeof + opt_len + data.length;
+    size_t total = reserve + tcp_total;
     assert(total <= max_packet, "TCP segment exceeds output buffer; MSS must be set correctly");
     if (total > max_packet)
         return;
 
     ubyte[max_packet] buf = void;
 
-    auto ip = cast(IPv4Header*)buf.ptr;
-    ip.ver_ihl  = 0x45;
-    ip.tos      = 0;
-    ip.total_length = nativeToBigEndian(cast(ushort)total);
-    ushort ip_id = next_ip_id();
-    ip.ident = nativeToBigEndian(ip_id);
-    ip.flags_frag[0] = 0x40;        // DF: required for PMTU Discovery
-    ip.flags_frag[1] = 0;
-    ip.ttl      = 64;
-    ip.protocol = IPProtocol.tcp;
-    ip.checksum[] = 0;
-    ip.src      = src_addr.b;
-    ip.dst      = dst_addr.b;
-    ushort ihc = internet_checksum(buf[0 .. IPv4Header.sizeof]);
-    ip.checksum = nativeToBigEndian(ihc);
-
-    auto t = cast(TcpHeader*)(buf.ptr + IPv4Header.sizeof);
-    t.src_port = nativeToBigEndian(src_port);
-    t.dst_port = nativeToBigEndian(dst_port);
+    auto t = cast(TcpHeader*)(buf.ptr + reserve);
+    t.src_port = nativeToBigEndian(src.port);
+    t.dst_port = nativeToBigEndian(dst.port);
     t.seq = nativeToBigEndian(seq);
     t.ack = nativeToBigEndian(ack_val);
     ushort header_len = cast(ushort)(TcpHeader.sizeof + opt_len);
@@ -1335,31 +1332,74 @@ void send_segment_raw(ref IPStack stack, IPAddr src_addr, ushort src_port, IPAdd
     if (include_mss)
     {
         ushort mss = advertise_mss != 0 ? advertise_mss : cast(ushort)TcpEthernetMss;
-        ubyte* opt = buf.ptr + IPv4Header.sizeof + TcpHeader.sizeof;
+        ubyte* opt = buf.ptr + reserve + TcpHeader.sizeof;
         opt[0] = TcpOptionKind.mss;
         opt[1] = 4;
         opt[2..4] = mss.nativeToBigEndian;
     }
 
     if (data.length > 0)
-        buf[IPv4Header.sizeof + TcpHeader.sizeof + opt_len .. total] = data[];
+        buf[reserve + TcpHeader.sizeof + opt_len .. total] = data[];
 
-    ushort tcp_total = cast(ushort)(TcpHeader.sizeof + opt_len + data.length);
-    ushort pseudo = pseudo_header_checksum_v4(src_addr, dst_addr, IPProtocol.tcp, tcp_total);
-    ushort cc = internet_checksum(buf[IPv4Header.sizeof .. total], pseudo);
+    ushort pseudo = transport_pseudo_checksum(src, dst, IPProtocol.tcp, cast(ushort)tcp_total);
+    ushort cc = internet_checksum(buf[reserve .. total], pseudo);
     t.checksum = nativeToBigEndian(cc);
 
-    Packet pkt;
-    pkt.init!RawFrame(buf[0 .. total]);
-    if (egress)
-        stack.output_v4_routed(pkt, egress, next_hop);
-    else
-        stack.output_v4(pkt);
+    switch (src.family)
+    {
+        case AddressFamily.ipv4:
+        {
+            auto ip = cast(IPv4Header*)buf.ptr;
+            ip.ver_ihl  = 0x45;
+            ip.tos      = 0;
+            ip.total_length = nativeToBigEndian(cast(ushort)total);
+            ushort ip_id = next_ip_id();
+            ip.ident = nativeToBigEndian(ip_id);
+            ip.flags_frag[0] = 0x40;        // DF: required for PMTU Discovery
+            ip.flags_frag[1] = 0;
+            ip.ttl      = 64;
+            ip.protocol = IPProtocol.tcp;
+            ip.checksum[] = 0;
+            ip.src      = src._a.ipv4.addr.b;
+            ip.dst      = dst._a.ipv4.addr.b;
+            ushort ihc = internet_checksum(buf[0 .. IPv4Header.sizeof]);
+            ip.checksum = nativeToBigEndian(ihc);
+
+            Packet pkt;
+            pkt.init!RawFrame(buf[0 .. total]);
+            if (egress)
+                stack.output_v4_routed(pkt, egress, next_hop);
+            else
+                stack.output_v4(pkt);
+            break;
+        }
+
+        case AddressFamily.ether:
+        {
+            EthernetStation station = cast(EthernetStation)egress;
+            if (!station)
+                station = find_ether_station(MACAddress(src._a.ether.addr));
+            if (!station)
+                return;
+
+            Packet pkt;
+            ref h = pkt.init!EtherTransport(buf[reserve .. total]);
+            h.dst = MACAddress(dst._a.ether.addr);
+            h.src = MACAddress(src._a.ether.addr);
+            h.protocol = TransportProto.tcp;
+            station.forward(pkt);
+            break;
+        }
+
+        default:
+            // TODO: ipv6 header build + output_v6 lands here
+            break;
+    }
 }
 
 
 // RFC 793 §3.4: respond to a packet for a non-existent connection.
-void send_rst_for_unknown(ref IPStack stack, IPAddr src_addr, ushort src_port, IPAddr dst_addr, ushort dst_port,
+void send_rst_for_unknown(ref IPStack stack, ref const InetAddress src, ref const InetAddress dst,
                           uint seq, uint ack, ubyte flags, size_t payload_len)
 {
     ubyte rst_flags = TcpFlag.rst;
@@ -1382,7 +1422,7 @@ void send_rst_for_unknown(ref IPStack stack, IPAddr src_addr, ushort src_port, I
     }
 
     // Note: src/dst and addresses swap because we're replying.
-    send_segment_raw(stack, dst_addr, dst_port, src_addr, src_port, rst_seq, rst_ack, rst_flags, 0, null);
+    send_segment_raw(stack, dst, src, rst_seq, rst_ack, rst_flags, 0, null);
 }
 
 
@@ -1727,8 +1767,8 @@ public void tcp_print(Session session)
         t.add_row();
         t.cell(tconcat("c", pcb.id));
         t.cell(tconcat(pcb.state));
-        t.cell(tconcat(pcb.local_addr, ':', pcb.local_port));
-        t.cell(pcb.is_listener ? "*" : tconcat(pcb.remote_addr, ':', pcb.remote_port));
+        t.cell(tconcat(pcb.local));
+        t.cell(pcb.is_listener ? "*" : tconcat(pcb.remote));
         t.cell(tconcat(pcb.send_mss));
         t.cell(tconcat(pcb.snd_wnd));
         t.cell(tconcat(pcb.snd_nxt - pcb.snd_una, '/', cast(uint)pcb.send_buf.length));
@@ -1751,11 +1791,37 @@ public void tcp_print(Session session)
 // a route exists should check `pcb.route_egress !is null` afterwards.
 void refresh_route(ref IPStack stack, TcpPcb* pcb)
 {
+    if (pcb.remote.family == AddressFamily.ether)
+    {
+        // No routing at L2: the egress is the station named by the local address.
+        if (pcb.route_egress)
+            return;
+        EthernetStation station = find_ether_station(MACAddress(pcb.local._a.ether.addr));
+        if (!station)
+            return;
+        set_pcb_egress(pcb, station);
+
+        ushort link_mss = TcpEthernetMss;
+        uint mtu = station.actual_mtu;
+        enum uint ether_tcp_overhead = ether_transport_overhead + TcpHeader.sizeof;
+        if (mtu > ether_tcp_overhead)
+        {
+            uint cap = mtu - ether_tcp_overhead;
+            if (cap < link_mss)
+                link_mss = cast(ushort)cap;
+        }
+        if (pcb.send_mss == 0 || link_mss < pcb.send_mss)
+            pcb.send_mss = link_mss;
+        return;
+    }
+
+    // TODO: ipv6 route lookup plugs in here alongside v4
+
     uint cur_gen = route_generation();
     if (pcb.route_gen == cur_gen && (pcb.route_egress || pcb.local_delivery))
         return;
 
-    RouteResult r = stack.route_lookup_v4_dst(pcb.remote_addr);
+    RouteResult r = stack.route_lookup_v4_dst(pcb.remote._a.ipv4.addr);
     if (r.kind == RouteResult.Kind.local)
     {
         set_pcb_egress(pcb, null);
@@ -1849,27 +1915,29 @@ const(char)[] flags_str(ubyte f) @nogc nothrow
 }
 
 
-TcpPcb* find_pcb_4tuple(IPAddr l_addr, ushort l_port, IPAddr r_addr, ushort r_port)
+TcpPcb* find_pcb_4tuple(ref const InetAddress local, ref const InetAddress remote)
 {
     foreach (p; _pcbs[])
     {
         if (p.is_listener) continue;
-        if (p.local_port  != l_port) continue;
-        if (p.remote_port != r_port) continue;
-        if (p.remote_addr != r_addr) continue;
-        if (p.local_addr != IPAddr.any && p.local_addr != l_addr) continue;
+        if (p.local.family != local.family) continue;
+        if (p.local.port  != local.port) continue;
+        if (p.remote.port != remote.port) continue;
+        if (!p.remote.same_addr(remote)) continue;
+        if (!p.local.addr_any && !p.local.same_addr(local)) continue;
         return p;
     }
     return null;
 }
 
-TcpPcb* find_listener(IPAddr addr, ushort port)
+TcpPcb* find_listener(ref const InetAddress local)
 {
     foreach (p; _pcbs[])
     {
         if (!p.is_listener) continue;
-        if (p.local_port != port) continue;
-        if (p.local_addr != IPAddr.any && p.local_addr != addr) continue;
+        if (p.local.family != local.family) continue;
+        if (p.local.port != local.port) continue;
+        if (!p.local.addr_any && !p.local.same_addr(local)) continue;
         return p;
     }
     return null;
@@ -1918,4 +1986,32 @@ ushort pseudo_header_checksum_v4(IPAddr src, IPAddr dst, ubyte protocol, ushort 
     ph[9]      = protocol;
     ph[10..12] = transport_length.nativeToBigEndian;
     return internet_checksum(ph[]);
+}
+
+
+// Pseudo-header checksum for the segment's address family. Over ether both ends are us,
+// so the pseudo-header is our own definition: [src:6][dst:6][0][protocol][length:2].
+// TODO: udp_output/udp_input converge on this once UdpPcb adopts InetAddress addressing.
+ushort transport_pseudo_checksum(ref const InetAddress src, ref const InetAddress dst, ubyte protocol, ushort transport_length) pure
+{
+    switch (src.family)
+    {
+        case AddressFamily.ipv4:
+            return pseudo_header_checksum_v4(src._a.ipv4.addr, dst._a.ipv4.addr, protocol, transport_length);
+
+        case AddressFamily.ether:
+        {
+            ubyte[16] ph = void;
+            ph[0 .. 6]   = src._a.ether.addr;
+            ph[6 .. 12]  = dst._a.ether.addr;
+            ph[12]       = 0;
+            ph[13]       = protocol;
+            ph[14 .. 16] = transport_length.nativeToBigEndian;
+            return internet_checksum(ph[]);
+        }
+
+        default:
+            // TODO: ipv6 40-byte pseudo-header (RFC 2460)
+            return 0;
+    }
 }

--- a/src/protocol/ip/tcp.d
+++ b/src/protocol/ip/tcp.d
@@ -390,7 +390,9 @@ bool tcp_connect(ref IPStack stack, TcpPcb* pcb)
     if (pcb.local.port == 0 || pcb.remote.port == 0)
         return false;
     refresh_route(stack, pcb);
-    if (!pcb.route_egress && !pcb.local_delivery)
+    // ether needs no resolved egress up front: an unbound connect floods its SYN and the
+    // peer's reply pins the source (and with it the egress)
+    if (!pcb.route_egress && !pcb.local_delivery && pcb.remote.family != AddressFamily.ether)
         return false;
     if (pcb.local.family == AddressFamily.ipv4 && pcb.local.addr_any)
     {
@@ -627,6 +629,11 @@ void tcp_segment_input(ref IPStack stack, InetAddress src, InetAddress dst, cons
             send_rst_for_unknown(stack, src, dst, seq, ack, flags, payload.length);
         return;
     }
+
+    // Deferred source bind: an unbound local pins to the address the peer reached us at.
+    // (For ether this also selects the egress: refresh_route resolves it from the mac.)
+    if (!pcb.is_listener && pcb.local.addr_any)
+        pcb.local = dst;
 
     process_segment(stack, pcb, src, dst, t, seq, ack, wnd, flags, payload, rx_time);
 }
@@ -1341,14 +1348,14 @@ void send_segment_raw(ref IPStack stack, ref const InetAddress src, ref const In
     if (data.length > 0)
         buf[reserve + TcpHeader.sizeof + opt_len .. total] = data[];
 
-    ushort pseudo = transport_pseudo_checksum(src, dst, IPProtocol.tcp, cast(ushort)tcp_total);
-    ushort cc = internet_checksum(buf[reserve .. total], pseudo);
-    t.checksum = nativeToBigEndian(cc);
-
     switch (src.family)
     {
         case AddressFamily.ipv4:
         {
+            ushort pseudo = transport_pseudo_checksum(src, dst, IPProtocol.tcp, cast(ushort)tcp_total);
+            ushort cc = internet_checksum(buf[reserve .. total], pseudo);
+            t.checksum = nativeToBigEndian(cc);
+
             auto ip = cast(IPv4Header*)buf.ptr;
             ip.ver_ihl  = 0x45;
             ip.tos      = 0;
@@ -1376,18 +1383,42 @@ void send_segment_raw(ref IPStack stack, ref const InetAddress src, ref const In
 
         case AddressFamily.ether:
         {
-            EthernetStation station = cast(EthernetStation)egress;
-            if (!station)
-                station = find_ether_station(MACAddress(src._a.ether.addr));
-            if (!station)
-                return;
+            MACAddress src_mac = MACAddress(src._a.ether.addr);
+            MACAddress dst_mac = MACAddress(dst._a.ether.addr);
 
-            Packet pkt;
-            ref h = pkt.init!EtherTransport(buf[reserve .. total]);
-            h.dst = MACAddress(dst._a.ether.addr);
-            h.src = MACAddress(src._a.ether.addr);
-            h.protocol = TransportProto.tcp;
-            station.forward(pkt);
+            // an unbound source stamps the egress station's own address; the checksum
+            // covers the pseudo-header, so it is computed per emission
+            void emit(EthernetStation s)
+            {
+                MACAddress use_src = src_mac ? src_mac : s.mac;
+                ushort pseudo = pseudo_header_checksum_ether(use_src, dst_mac, IPProtocol.tcp, cast(ushort)tcp_total);
+                t.checksum[] = 0;
+                ushort cc = internet_checksum(buf[reserve .. total], pseudo);
+                t.checksum = nativeToBigEndian(cc);
+
+                Packet pkt;
+                ref h = pkt.init!EtherTransport(buf[reserve .. total]);
+                h.dst = dst_mac;
+                h.src = use_src;
+                h.protocol = TransportProto.tcp;
+                s.forward(pkt);
+            }
+
+            EthernetStation station = cast(EthernetStation)egress;
+            if (!station && src_mac)
+                station = find_ether_station(src_mac);
+            if (!station)
+                station = ether_neighbour_lookup(dst_mac);
+            if (station)
+                emit(station);
+            else
+            {
+                // unknown egress: flood every segment; ingress learning pins it after
+                foreach_ether_station((EthernetStation s) {
+                    if (s.running)
+                        emit(s);
+                });
+            }
             break;
         }
 
@@ -1793,12 +1824,21 @@ void refresh_route(ref IPStack stack, TcpPcb* pcb)
 {
     if (pcb.remote.family == AddressFamily.ether)
     {
-        // No routing at L2: the egress is the station named by the local address.
+        // No routing at L2: a bound local names the station directly; an unbound local
+        // uses the learned neighbour, and until one is known the send path floods.
         if (pcb.route_egress)
             return;
-        EthernetStation station = find_ether_station(MACAddress(pcb.local._a.ether.addr));
+        EthernetStation station;
+        if (!pcb.local.addr_any)
+            station = find_ether_station(MACAddress(pcb.local._a.ether.addr));
+        else
+            station = ether_neighbour_lookup(MACAddress(pcb.remote._a.ether.addr));
         if (!station)
+        {
+            if (pcb.send_mss == 0)
+                pcb.send_mss = TcpDefaultMss;   // flood path floor; corrected once the egress pins
             return;
+        }
         set_pcb_egress(pcb, station);
 
         ushort link_mss = TcpEthernetMss;
@@ -1989,8 +2029,21 @@ ushort pseudo_header_checksum_v4(IPAddr src, IPAddr dst, ubyte protocol, ushort 
 }
 
 
-// Pseudo-header checksum for the segment's address family. Over ether both ends are us,
-// so the pseudo-header is our own definition: [src:6][dst:6][0][protocol][length:2].
+// Pseudo-header checksum for ether-carried segments. Over ether both ends are us, so
+// the pseudo-header is our own definition: [src:6][dst:6][0][protocol][length:2].
+ushort pseudo_header_checksum_ether(MACAddress src, MACAddress dst, ubyte protocol, ushort transport_length) pure
+{
+    ubyte[16] ph = void;
+    ph[0 .. 6]   = src.b;
+    ph[6 .. 12]  = dst.b;
+    ph[12]       = 0;
+    ph[13]       = protocol;
+    ph[14 .. 16] = transport_length.nativeToBigEndian;
+    return internet_checksum(ph[]);
+}
+
+
+// Pseudo-header checksum for the segment's address family.
 // TODO: udp_output/udp_input converge on this once UdpPcb adopts InetAddress addressing.
 ushort transport_pseudo_checksum(ref const InetAddress src, ref const InetAddress dst, ubyte protocol, ushort transport_length) pure
 {
@@ -2000,15 +2053,7 @@ ushort transport_pseudo_checksum(ref const InetAddress src, ref const InetAddres
             return pseudo_header_checksum_v4(src._a.ipv4.addr, dst._a.ipv4.addr, protocol, transport_length);
 
         case AddressFamily.ether:
-        {
-            ubyte[16] ph = void;
-            ph[0 .. 6]   = src._a.ether.addr;
-            ph[6 .. 12]  = dst._a.ether.addr;
-            ph[12]       = 0;
-            ph[13]       = protocol;
-            ph[14 .. 16] = transport_length.nativeToBigEndian;
-            return internet_checksum(ph[]);
-        }
+            return pseudo_header_checksum_ether(MACAddress(src._a.ether.addr), MACAddress(dst._a.ether.addr), protocol, transport_length);
 
         default:
             // TODO: ipv6 40-byte pseudo-header (RFC 2460)

--- a/src/router/iface/endpoint.d
+++ b/src/router/iface/endpoint.d
@@ -68,13 +68,16 @@ nothrow @nogc:
 
 
 alias EtherRecvHandler = void delegate(EtherEndpoint* ep, const(void)[] data, MACAddress src, ushort src_port, MonoTime rx_time) nothrow @nogc;
+alias EtherTcpInput = void function(MACAddress src, MACAddress dst, const(void)[] segment, MonoTime rx_time) nothrow @nogc;
 
 
-// Open an ether-UDP datagram endpoint on an ethernet-framed interface, bound to a local port
-// (0 = ephemeral). Datagrams to the station MAC and broadcast are delivered; multicast
-// groups via join(). A remote restricts delivery to that peer and enables send().
-// The endpoint tracks its interface by reference; it rides out restarts, and re-attaches
-// if the interface is destroyed and later recreated with the same name.
+// TCP-over-ether segments are handed up through this hook; the IP module installs it
+// when the internal TCP machinery is present.
+void set_ether_tcp_input(EtherTcpInput handler)
+{
+    g_ether_tcp_input = handler;
+}
+
 // The station whose mac is `mac`, if any: ether local addresses name their interface.
 EthernetStation find_ether_station(MACAddress mac)
 {
@@ -90,6 +93,28 @@ EthernetStation find_ether_station(MACAddress mac)
     return null;
 }
 
+// One ether_transport subscription per station, demuxing to endpoints and the tcp hook.
+// Endpoints and pcbs bound to the station share it; the module sweep re-subscribes if
+// the station is destroyed and recreated with the same name.
+void ensure_ether_tap(EthernetStation station)
+{
+    foreach (t; _taps[])
+    {
+        if (t._iface.get is station)
+            return;
+    }
+    EtherTap* tap = defaultAllocator().allocT!EtherTap();
+    tap._iface = station;
+    tap.try_subscribe();
+    _taps ~= tap;
+}
+
+
+// Open an ether-UDP datagram endpoint on an ethernet-framed interface, bound to a local port
+// (0 = ephemeral). Datagrams to the station MAC and broadcast are delivered; multicast
+// groups via join(). A remote restricts delivery to that peer and enables send().
+// The endpoint tracks its interface by reference; it rides out restarts, and re-attaches
+// if the interface is destroyed and later recreated with the same name.
 EtherEndpoint* ether_open(EthernetStation iface, ushort port, EtherRecvHandler on_recv,
                           MACAddress remote = MACAddress(), ushort remote_port = 0)
 {
@@ -104,7 +129,7 @@ EtherEndpoint* ether_open(EthernetStation iface, ushort port, EtherRecvHandler o
     ep._remote = remote;
     ep._remote_port = remote_port;
     ep._on_recv = on_recv;
-    ep.try_subscribe();
+    ensure_ether_tap(iface);
     _ether_eps ~= ep;
     return ep;
 }
@@ -195,8 +220,76 @@ private:
     MACAddress _remote;
     ushort _remote_port;
     ushort _local_port;
-    bool _subscribed;
     bool _closing;
+
+    void deliver(ref const Packet p, ref const EtherTransport h, EthernetStation station)
+    {
+        if (_closing)
+            return;
+
+        const(ubyte)[] seg = cast(const(ubyte)[])p.data;
+        if (seg.length < UdpSegHeader.sizeof)
+            return;
+        const u = cast(const(UdpSegHeader)*)seg.ptr;
+        if (u.dst_port.bigEndianToNative!ushort != _local_port)
+            return;
+        ushort len = u.length.bigEndianToNative!ushort;
+        if (len < UdpSegHeader.sizeof || len > seg.length)
+            return;
+
+        if (h.dst != station.mac && !h.dst.is_broadcast && !(h.dst.is_multicast && _groups[].contains(h.dst)))
+            return;
+        ushort src_port = u.src_port.bigEndianToNative!ushort;
+        if (_remote && (h.src != _remote || src_port != _remote_port))
+            return;
+
+        _on_recv(&this, seg[UdpSegHeader.sizeof .. len], h.src, src_port, p.creation_time);
+    }
+}
+
+
+package:
+
+void update_ether_endpoints()
+{
+    for (size_t i = _ether_eps.length; i-- > 0; )
+    {
+        EtherEndpoint* ep = _ether_eps[i];
+        if (ep._closing)
+        {
+            defaultAllocator().freeT(ep);
+            _ether_eps.removeSwapLast(i);
+        }
+    }
+    foreach (tap; _taps[])
+    {
+        if (!tap._subscribed)
+            tap.try_subscribe();
+    }
+}
+
+
+private:
+
+enum encap_overhead = 5 + 13 + UdpSegHeader.sizeof;     // ow framing + ether-transport header + udp header
+
+// standard UDP header; over ether the checksum is unused (transmitted zero, ignored on receive)
+struct UdpSegHeader
+{
+    ubyte[2] src_port;      // big-endian
+    ubyte[2] dst_port;      // big-endian
+    ubyte[2] length;        // big-endian; header + data
+    ubyte[2] checksum;
+}
+static assert(UdpSegHeader.sizeof == 8);
+
+
+struct EtherTap
+{
+nothrow @nogc:
+
+    ObjectRef!EthernetStation _iface;
+    bool _subscribed;
 
     void try_subscribe()
     {
@@ -212,32 +305,31 @@ private:
 
     void on_packet(ref const Packet p, BaseInterface, PacketDirection dir, void*)
     {
-        if (_closing || dir != PacketDirection.incoming)
+        if (dir != PacketDirection.incoming)
             return;
-        EthernetStation i = _iface.get;
-        if (!i)
+        EthernetStation station = _iface.get;
+        if (!station)
             return;
         ref const h = p.hdr!EtherTransport;
-        if (h.protocol != TransportProto.udp)
-            return;
+        switch (h.protocol)
+        {
+            case TransportProto.udp:
+                foreach (ep; _ether_eps[])
+                {
+                    if (ep._iface.get is station)
+                        ep.deliver(p, h, station);
+                }
+                break;
 
-        const(ubyte)[] seg = cast(const(ubyte)[])p.data;
-        if (seg.length < UdpSegHeader.sizeof)
-            return;
-        const u = cast(const(UdpSegHeader)*)seg.ptr;
-        if (u.dst_port.bigEndianToNative!ushort != _local_port)
-            return;
-        ushort len = u.length.bigEndianToNative!ushort;
-        if (len < UdpSegHeader.sizeof || len > seg.length)
-            return;
+            case TransportProto.tcp:
+                // tcp is point-to-point; only segments addressed to this station matter
+                if (g_ether_tcp_input && h.dst == station.mac)
+                    g_ether_tcp_input(h.src, h.dst, p.data, p.creation_time);
+                break;
 
-        if (h.dst != i.mac && !h.dst.is_broadcast && !(h.dst.is_multicast && _groups[].contains(h.dst)))
-            return;
-        ushort src_port = u.src_port.bigEndianToNative!ushort;
-        if (_remote && (h.src != _remote || src_port != _remote_port))
-            return;
-
-        _on_recv(&this, seg[UdpSegHeader.sizeof .. len], h.src, src_port, p.creation_time);
+            default:
+                break;
+        }
     }
 
     void on_iface_state(ActiveObject, StateSignal signal)
@@ -249,48 +341,9 @@ private:
     }
 }
 
-
-package:
-
-void update_ether_endpoints()
-{
-    for (size_t i = _ether_eps.length; i-- > 0; )
-    {
-        EtherEndpoint* ep = _ether_eps[i];
-        if (ep._closing)
-        {
-            if (ep._subscribed)
-            {
-                if (EthernetStation iface = ep._iface.get)
-                {
-                    iface.unsubscribe(&ep.on_packet);
-                    iface.unsubscribe(&ep.on_iface_state);
-                }
-            }
-            defaultAllocator().freeT(ep);
-            _ether_eps.removeSwapLast(i);
-        }
-        else if (!ep._subscribed)
-            ep.try_subscribe();
-    }
-}
-
-
-private:
-
-enum encap_overhead = 5 + 13 + UdpSegHeader.sizeof;     // ow framing + mac-transport header + udp header
-
-// standard UDP header; over MAC the checksum is unused (transmitted zero, ignored on receive)
-struct UdpSegHeader
-{
-    ubyte[2] src_port;      // big-endian
-    ubyte[2] dst_port;      // big-endian
-    ubyte[2] length;        // big-endian; header + data
-    ubyte[2] checksum;
-}
-static assert(UdpSegHeader.sizeof == 8);
-
 __gshared Array!(EtherEndpoint*) _ether_eps;
+__gshared Array!(EtherTap*) _taps;
+__gshared EtherTcpInput g_ether_tcp_input;
 __gshared ushort _next_ephemeral = 49_152;
 
 ushort allocate_ephemeral()

--- a/src/router/iface/endpoint.d
+++ b/src/router/iface/endpoint.d
@@ -1,0 +1,325 @@
+module router.iface.endpoint;
+
+import urt.array;
+import urt.endian;
+import urt.mem.allocator : defaultAllocator;
+import urt.time;
+
+import manager.base;
+
+import router.iface;
+import router.iface.ethernet;
+import router.iface.mac;
+import router.iface.packet;
+
+nothrow @nogc:
+
+
+// Transport segments carried directly over the segment: the OW header supplies the fields the
+// IP header would have (addressing and protocol number); the payload is a regular transport
+// header + data, so TCP/UDP machinery is unaware the network layer beneath it is not IP.
+enum TransportProto : ubyte
+{
+    tcp = 6,    // IP protocol numbers
+    udp = 17,
+}
+
+struct EtherTransport
+{
+    enum Type = PacketType.ether_transport;
+nothrow @nogc:
+
+    MACAddress dst;
+    MACAddress src;
+    ubyte protocol;
+
+    static ulong extract_src(ref const Packet p) pure
+        => ulong(Type) << 60 | ulong(p.vlan & 0xFFF) << 48 | p.hdr!EtherTransport().src.ul;
+
+    static ulong extract_dst(ref const Packet p) pure
+        => ulong(Type) << 60 | ulong(p.vlan & 0xFFF) << 48 | p.hdr!EtherTransport().dst.ul;
+
+    alias is_multicast = Ethernet.is_multicast;
+
+    // [dst:6][src:6][protocol:u8]
+    static ptrdiff_t encode_ow_header(ref const Packet p, ubyte[] buffer)
+    {
+        if (buffer.length < 13)
+            return -1;
+        ref const h = p.hdr!EtherTransport;
+        buffer[0 .. 6] = h.dst.b[];
+        buffer[6 .. 12] = h.src.b[];
+        buffer[12] = h.protocol;
+        return 13;
+    }
+
+    static ptrdiff_t decode_ow_header(ref Packet p, const(ubyte)[] header)
+    {
+        if (header.length < 13)
+            return -1;
+        p.type = Type;
+        ref h = p.hdr!EtherTransport;
+        h.dst.b[] = header[0 .. 6];
+        h.src.b[] = header[6 .. 12];
+        h.protocol = header[12];
+        return 13;
+    }
+}
+
+
+alias EtherRecvHandler = void delegate(EtherEndpoint* ep, const(void)[] data, MACAddress src, ushort src_port, MonoTime rx_time) nothrow @nogc;
+
+
+// Open an ether-UDP datagram endpoint on an ethernet-framed interface, bound to a local port
+// (0 = ephemeral). Datagrams to the station MAC and broadcast are delivered; multicast
+// groups via join(). A remote restricts delivery to that peer and enables send().
+// The endpoint tracks its interface by reference; it rides out restarts, and re-attaches
+// if the interface is destroyed and later recreated with the same name.
+// The station whose mac is `mac`, if any: ether local addresses name their interface.
+EthernetStation find_ether_station(MACAddress mac)
+{
+    import manager.collection : Collection;
+    foreach (i; Collection!BaseInterface().values)
+    {
+        if (!(i.caps & InterfaceCaps.ethernet))
+            continue;
+        EthernetStation s = cast(EthernetStation)i;
+        if (s && s.mac == mac)
+            return s;
+    }
+    return null;
+}
+
+EtherEndpoint* ether_open(EthernetStation iface, ushort port, EtherRecvHandler on_recv,
+                          MACAddress remote = MACAddress(), ushort remote_port = 0)
+{
+    if (iface is null || on_recv is null)
+        return null;
+    if (cast(bool)remote != (remote_port != 0))
+        return null;
+
+    EtherEndpoint* ep = defaultAllocator().allocT!EtherEndpoint();
+    ep._iface = iface;
+    ep._local_port = port ? port : allocate_ephemeral();
+    ep._remote = remote;
+    ep._remote_port = remote_port;
+    ep._on_recv = on_recv;
+    ep.try_subscribe();
+    _ether_eps ~= ep;
+    return ep;
+}
+
+
+struct EtherEndpoint
+{
+nothrow @nogc:
+
+    inout(EthernetStation) iface() inout pure
+        => _iface.get;
+
+    ushort local_port() const pure
+        => _local_port;
+
+    MACAddress remote() const pure
+        => _remote;
+
+    ushort remote_port() const pure
+        => _remote_port;
+
+    MACAddress local()
+    {
+        EthernetStation i = _iface.get;
+        return i ? i.mac : MACAddress();
+    }
+
+    // TODO: interfaces that filter multicast in hardware need an add-address hook
+    bool join(MACAddress group)
+    {
+        if (!group.is_multicast || group.is_broadcast)
+            return false;
+        if (!_groups[].contains(group))
+            _groups ~= group;
+        return true;
+    }
+
+    void leave(MACAddress group)
+    {
+        _groups.removeFirstSwapLast(group);
+    }
+
+    // Send to the remote given at open. Returns bytes sent, or 0.
+    ptrdiff_t send(scope const(void)[] data)
+        => _remote ? sendto(_remote, _remote_port, data) : 0;
+
+    ptrdiff_t sendto(MACAddress dst, ushort dst_port, scope const(void)[] data)
+    {
+        if (_closing || !dst || dst_port == 0)
+            return 0;
+        EthernetStation i = _iface.get;
+        if (!i || !i.running)
+            return 0;
+        ushort mtu = i.actual_mtu;
+        if (mtu && data.length + encap_overhead > mtu)
+            return 0;
+
+        ubyte[1518] buf = void;
+        if (UdpSegHeader.sizeof + data.length > buf.length)
+            return 0;
+        auto u = cast(UdpSegHeader*)buf.ptr;
+        u.src_port = _local_port.nativeToBigEndian;
+        u.dst_port = dst_port.nativeToBigEndian;
+        u.length = nativeToBigEndian(cast(ushort)(UdpSegHeader.sizeof + data.length));
+        u.checksum[] = 0;    // link CRC covers integrity
+        buf[UdpSegHeader.sizeof .. UdpSegHeader.sizeof + data.length] = (cast(const(ubyte)[])data)[];
+
+        Packet p;
+        ref h = p.init!EtherTransport(buf[0 .. UdpSegHeader.sizeof + data.length]);
+        h.dst = dst;
+        h.src = i.mac;
+        h.protocol = TransportProto.udp;
+        if (i.forward(p) < 0)
+            return 0;
+        return data.length;
+    }
+
+    // Teardown is deferred to the module sweep; safe to call from the recv handler.
+    void close()
+    {
+        _closing = true;
+    }
+
+private:
+    ObjectRef!EthernetStation _iface;
+    EtherRecvHandler _on_recv;
+    Array!MACAddress _groups;
+    MACAddress _remote;
+    ushort _remote_port;
+    ushort _local_port;
+    bool _subscribed;
+    bool _closing;
+
+    void try_subscribe()
+    {
+        EthernetStation i = _iface.get;
+        if (!i || !i.running)
+            return;
+        PacketFilter filter;
+        filter.type = PacketType.ether_transport;
+        i.subscribe(&on_packet, filter);
+        i.subscribe(&on_iface_state);
+        _subscribed = true;
+    }
+
+    void on_packet(ref const Packet p, BaseInterface, PacketDirection dir, void*)
+    {
+        if (_closing || dir != PacketDirection.incoming)
+            return;
+        EthernetStation i = _iface.get;
+        if (!i)
+            return;
+        ref const h = p.hdr!EtherTransport;
+        if (h.protocol != TransportProto.udp)
+            return;
+
+        const(ubyte)[] seg = cast(const(ubyte)[])p.data;
+        if (seg.length < UdpSegHeader.sizeof)
+            return;
+        const u = cast(const(UdpSegHeader)*)seg.ptr;
+        if (u.dst_port.bigEndianToNative!ushort != _local_port)
+            return;
+        ushort len = u.length.bigEndianToNative!ushort;
+        if (len < UdpSegHeader.sizeof || len > seg.length)
+            return;
+
+        if (h.dst != i.mac && !h.dst.is_broadcast && !(h.dst.is_multicast && _groups[].contains(h.dst)))
+            return;
+        ushort src_port = u.src_port.bigEndianToNative!ushort;
+        if (_remote && (h.src != _remote || src_port != _remote_port))
+            return;
+
+        _on_recv(&this, seg[UdpSegHeader.sizeof .. len], h.src, src_port, p.creation_time);
+    }
+
+    void on_iface_state(ActiveObject, StateSignal signal)
+    {
+        // Subscriptions on the dying object vanish with it; the module sweep
+        // re-subscribes if an interface with the same name reappears.
+        if (signal == StateSignal.destroyed)
+            _subscribed = false;
+    }
+}
+
+
+package:
+
+void update_ether_endpoints()
+{
+    for (size_t i = _ether_eps.length; i-- > 0; )
+    {
+        EtherEndpoint* ep = _ether_eps[i];
+        if (ep._closing)
+        {
+            if (ep._subscribed)
+            {
+                if (EthernetStation iface = ep._iface.get)
+                {
+                    iface.unsubscribe(&ep.on_packet);
+                    iface.unsubscribe(&ep.on_iface_state);
+                }
+            }
+            defaultAllocator().freeT(ep);
+            _ether_eps.removeSwapLast(i);
+        }
+        else if (!ep._subscribed)
+            ep.try_subscribe();
+    }
+}
+
+
+private:
+
+enum encap_overhead = 5 + 13 + UdpSegHeader.sizeof;     // ow framing + mac-transport header + udp header
+
+// standard UDP header; over MAC the checksum is unused (transmitted zero, ignored on receive)
+struct UdpSegHeader
+{
+    ubyte[2] src_port;      // big-endian
+    ubyte[2] dst_port;      // big-endian
+    ubyte[2] length;        // big-endian; header + data
+    ubyte[2] checksum;
+}
+static assert(UdpSegHeader.sizeof == 8);
+
+__gshared Array!(EtherEndpoint*) _ether_eps;
+__gshared ushort _next_ephemeral = 49_152;
+
+ushort allocate_ephemeral()
+{
+    ushort port = _next_ephemeral;
+    _next_ephemeral = port == 0xFFFF ? 49_152 : cast(ushort)(port + 1);
+    return port;
+}
+
+
+unittest
+{
+    ubyte[12] payload = [ 0xC0, 0x00, 0x01, 0xF4, 0x00, 0x0C, 0x00, 0x00, 1, 2, 3, 4 ];
+    Packet packet;
+    ref EtherTransport t = packet.init!EtherTransport(payload[]);
+    t.dst = MACAddress(0x02, 0x13, 0x37, 0xAA, 0xBB, 0x64);
+    t.src = MACAddress(0x02, 0x13, 0x37, 0xCC, 0xDD, 0x65);
+    t.protocol = TransportProto.udp;
+
+    ubyte[13] header;
+    assert(EtherTransport.encode_ow_header(packet, header[]) == 13);
+    assert(EtherTransport.encode_ow_header(packet, header[0 .. 12]) == -1);
+
+    Packet decoded;
+    assert(EtherTransport.decode_ow_header(decoded, header[0 .. 12]) == -1);
+    assert(EtherTransport.decode_ow_header(decoded, header[]) == 13);
+    ref result = decoded.hdr!EtherTransport;
+    assert(result.dst == t.dst && result.src == t.src && result.protocol == TransportProto.udp);
+    assert(EtherTransport.extract_dst(packet) == EtherTransport.extract_dst(decoded));
+    assert(EtherTransport.extract_dst(packet) >> 60 == ulong(PacketType.ether_transport));
+    assert(MACAddress.from_ul(EtherTransport.extract_dst(packet)) == t.dst);
+}

--- a/src/router/iface/endpoint.d
+++ b/src/router/iface/endpoint.d
@@ -2,6 +2,7 @@ module router.iface.endpoint;
 
 import urt.array;
 import urt.endian;
+import urt.map;
 import urt.mem.allocator : defaultAllocator;
 import urt.time;
 
@@ -93,6 +94,41 @@ EthernetStation find_ether_station(MACAddress mac)
     return null;
 }
 
+void foreach_ether_station(scope void delegate(EthernetStation) nothrow @nogc sink)
+{
+    import manager.collection : Collection;
+    foreach (i; Collection!BaseInterface().values)
+    {
+        if (!(i.caps & InterfaceCaps.ethernet))
+            continue;
+        if (EthernetStation s = cast(EthernetStation)i)
+            sink(s);
+    }
+}
+
+// Egress cache for unbound sources: (peer mac -> station) learned passively from tap
+// ingress, the arp-cache analogue. A miss means the caller floods every segment
+// (unknown-unicast flooding, self-limiting); the peer's reply populates the entry.
+EthernetStation ether_neighbour_lookup(MACAddress mac)
+{
+    if (EtherNeighbour* e = mac.ul in _neighbours)
+    {
+        if (EthernetStation s = e.station.get)
+        {
+            if (s.running && getTime() - e.seen < ether_neighbour_ttl)
+                return s;
+        }
+    }
+    return null;
+}
+
+// Wildcard consumers (bind-any endpoints, unbound connects, any-listeners) need every
+// segment tapped; once requested, the module sweep keeps taps on all stations.
+void ether_request_tap_all()
+{
+    _tap_all = true;
+}
+
 // One ether_transport subscription per station, demuxing to endpoints and the tcp hook.
 // Endpoints and pcbs bound to the station share it; the module sweep re-subscribes if
 // the station is destroyed and recreated with the same name.
@@ -110,26 +146,36 @@ void ensure_ether_tap(EthernetStation station)
 }
 
 
-// Open an ether-UDP datagram endpoint on an ethernet-framed interface, bound to a local port
-// (0 = ephemeral). Datagrams to the station MAC and broadcast are delivered; multicast
-// groups via join(). A remote restricts delivery to that peer and enables send().
-// The endpoint tracks its interface by reference; it rides out restarts, and re-attaches
-// if the interface is destroyed and later recreated with the same name.
+// Open an ether-UDP datagram endpoint bound to a local port (0 = ephemeral). A non-null
+// iface binds the endpoint to that station; a null iface is a wildcard bind: datagrams
+// are accepted on every ethernet segment, and egress uses the learned neighbour (or
+// floods unknown unicast). Datagrams to the receiving station's MAC and broadcast are
+// delivered; multicast groups via join(). A remote restricts delivery to that peer and
+// enables send(). Bound endpoints track their interface by reference; they ride out
+// restarts and re-attach if the interface is destroyed and recreated with the same name.
 EtherEndpoint* ether_open(EthernetStation iface, ushort port, EtherRecvHandler on_recv,
                           MACAddress remote = MACAddress(), ushort remote_port = 0)
 {
-    if (iface is null || on_recv is null)
+    if (on_recv is null)
         return null;
     if (cast(bool)remote != (remote_port != 0))
         return null;
 
     EtherEndpoint* ep = defaultAllocator().allocT!EtherEndpoint();
-    ep._iface = iface;
     ep._local_port = port ? port : allocate_ephemeral();
     ep._remote = remote;
     ep._remote_port = remote_port;
     ep._on_recv = on_recv;
-    ensure_ether_tap(iface);
+    if (iface)
+    {
+        ep._iface = iface;
+        ensure_ether_tap(iface);
+    }
+    else
+    {
+        ep._wildcard = true;
+        ether_request_tap_all();
+    }
     _ether_eps ~= ep;
     return ep;
 }
@@ -180,12 +226,6 @@ nothrow @nogc:
     {
         if (_closing || !dst || dst_port == 0)
             return 0;
-        EthernetStation i = _iface.get;
-        if (!i || !i.running)
-            return 0;
-        ushort mtu = i.actual_mtu;
-        if (mtu && data.length + encap_overhead > mtu)
-            return 0;
 
         ubyte[1518] buf = void;
         if (UdpSegHeader.sizeof + data.length > buf.length)
@@ -196,15 +236,25 @@ nothrow @nogc:
         u.length = nativeToBigEndian(cast(ushort)(UdpSegHeader.sizeof + data.length));
         u.checksum[] = 0;    // link CRC covers integrity
         buf[UdpSegHeader.sizeof .. UdpSegHeader.sizeof + data.length] = (cast(const(ubyte)[])data)[];
+        const(ubyte)[] frame = buf[0 .. UdpSegHeader.sizeof + data.length];
 
-        Packet p;
-        ref h = p.init!EtherTransport(buf[0 .. UdpSegHeader.sizeof + data.length]);
-        h.dst = dst;
-        h.src = i.mac;
-        h.protocol = TransportProto.udp;
-        if (i.forward(p) < 0)
-            return 0;
-        return data.length;
+        if (!_wildcard)
+        {
+            EthernetStation i = _iface.get;
+            if (!i || !i.running)
+                return 0;
+            return emit(i, dst, frame) ? data.length : 0;
+        }
+
+        // wildcard: learned neighbour picks the segment; unknown (or multicast) floods them all
+        if (EthernetStation i = ether_neighbour_lookup(dst))
+            return emit(i, dst, frame) ? data.length : 0;
+        bool sent = false;
+        foreach_ether_station((EthernetStation s) {
+            if (s.running && emit(s, dst, frame))
+                sent = true;
+        });
+        return sent ? data.length : 0;
     }
 
     // Teardown is deferred to the module sweep; safe to call from the recv handler.
@@ -220,11 +270,27 @@ private:
     MACAddress _remote;
     ushort _remote_port;
     ushort _local_port;
+    bool _wildcard;
     bool _closing;
+
+    bool emit(EthernetStation station, MACAddress dst, const(ubyte)[] frame)
+    {
+        ushort mtu = station.actual_mtu;
+        if (mtu && frame.length + encap_overhead - UdpSegHeader.sizeof > mtu)
+            return false;
+        Packet p;
+        ref h = p.init!EtherTransport(frame);
+        h.dst = dst;
+        h.src = station.mac;
+        h.protocol = TransportProto.udp;
+        return station.forward(p) >= 0;
+    }
 
     void deliver(ref const Packet p, ref const EtherTransport h, EthernetStation station)
     {
         if (_closing)
+            return;
+        if (!_wildcard && _iface.get !is station)
             return;
 
         const(ubyte)[] seg = cast(const(ubyte)[])p.data;
@@ -261,6 +327,8 @@ void update_ether_endpoints()
             _ether_eps.removeSwapLast(i);
         }
     }
+    if (_tap_all)
+        foreach_ether_station((EthernetStation s) { ensure_ether_tap(s); });
     foreach (tap; _taps[])
     {
         if (!tap._subscribed)
@@ -311,14 +379,12 @@ nothrow @nogc:
         if (!station)
             return;
         ref const h = p.hdr!EtherTransport;
+        ether_neighbour_learn(h.src, station);
         switch (h.protocol)
         {
             case TransportProto.udp:
                 foreach (ep; _ether_eps[])
-                {
-                    if (ep._iface.get is station)
-                        ep.deliver(p, h, station);
-                }
+                    ep.deliver(p, h, station);
                 break;
 
             case TransportProto.tcp:
@@ -341,9 +407,32 @@ nothrow @nogc:
     }
 }
 
+enum ether_neighbour_ttl = 300.seconds;
+
+struct EtherNeighbour
+{
+    ObjectRef!EthernetStation station;
+    MonoTime seen;
+}
+
+void ether_neighbour_learn(MACAddress mac, EthernetStation station)
+{
+    if (mac.is_multicast)
+        return;
+    if (EtherNeighbour* e = mac.ul in _neighbours)
+    {
+        e.station = station;
+        e.seen = getTime();
+    }
+    else
+        _neighbours[mac.ul] = EtherNeighbour(ObjectRef!EthernetStation(station), getTime());
+}
+
 __gshared Array!(EtherEndpoint*) _ether_eps;
 __gshared Array!(EtherTap*) _taps;
+__gshared Map!(ulong, EtherNeighbour) _neighbours;
 __gshared EtherTcpInput g_ether_tcp_input;
+__gshared bool _tap_all;
 __gshared ushort _next_ephemeral = 49_152;
 
 ushort allocate_ephemeral()

--- a/src/router/iface/ethernet.d
+++ b/src/router/iface/ethernet.d
@@ -1,5 +1,6 @@
 module router.iface.ethernet;
 
+import urt.array;
 import urt.endian;
 import urt.log;
 import urt.map;
@@ -31,6 +32,20 @@ nothrow @nogc:
         eth.dst = dest;
         eth.ether_type = type;
         return forward(p, callback);
+    }
+
+    // OW mac-ping: time an echo round-trip to dst (broadcast for discovery sweeps).
+    // Each reply invokes handler; identify asks responders to name themselves.
+    // The pending entry expires quietly after 10s unless cancelled earlier.
+    final uint ping(MACAddress dst, bool identify, MacPingHandler handler)
+    {
+        uint cookie = _next_ping_cookie++;
+        ubyte[5] req = void;
+        storeBigEndian(cast(uint*)req.ptr, cookie);
+        req[4] = identify ? OWEchoFlag.identify : 0;
+        _pending_pings ~= PendingPing(cookie, getTime(), handler);
+        station_send_control(OWControl.echo_req, dst, req);
+        return cookie;
     }
 
 protected:
@@ -86,6 +101,12 @@ protected:
             if (!station_ingress(packet))
                 add_rx_drop();
             return;
+        }
+        if (packet.type == PacketType.ethernet && packet.eth.ether_type == EtherType.cfm && packet.eth.src != mac)
+        {
+            if (packet.eth.dst == mac || packet.eth.dst.is_multicast)
+                cfm_ingress(packet);
+            // fall through: cfm frames stay visible to subscribers/bridging either way
         }
         dispatch(packet);
     }
@@ -339,6 +360,29 @@ private:
         return MACAddress.broadcast;
     }
 
+    // 802.1ag / Y.1731 loopback responder: an LBM (opcode 3) addressed to this station
+    // is answered with an LBR (opcode 2) echoing the whole PDU, so standard L2 OAM gear
+    // can mac-ping us. We answer at any MD level; a full MEP would filter by configured
+    // level, which we don't model.
+    void cfm_ingress(ref const Packet packet)
+    {
+        enum ubyte opcode_lbr = 2, opcode_lbm = 3;
+
+        const(ubyte)[] pdu = cast(const(ubyte)[])packet.data;
+        if (pdu.length < 8)
+            return;
+        if ((pdu[0] & 0x1F) != 0)
+            return;     // CFM version != 0
+        if (pdu[1] != opcode_lbm)
+            return;     // only the loopback responder is implemented
+
+        ubyte[1500] reply = void;
+        size_t len = min(pdu.length, reply.length);
+        reply[0 .. len] = pdu[0 .. len];
+        reply[1] = opcode_lbr;
+        send(packet.eth.src, reply[0 .. len], EtherType.cfm);
+    }
+
     void station_send_control(OWControl msg, MACAddress dst, scope const(ubyte)[] content)
     {
         ubyte[512] buffer = void;
@@ -399,11 +443,95 @@ private:
                 }
                 return;
 
+            case OWControl.echo_req:
+            {
+                if (content.length < 5)
+                    return;
+                ubyte[288] reply = void;
+                reply[0 .. 5] = content[0 .. 5];
+                size_t len = 5;
+                if (content[4] & OWEchoFlag.identify)
+                {
+                    // TODO: identity should become the system name once one exists;
+                    //       the internal socket backend's hostname is a placeholder
+                    import urt.socket : get_hostname;
+                    char[64] name = void;
+                    if (!get_hostname(name.ptr, name.length).failed)
+                    {
+                        size_t n = 0;
+                        while (n < name.length && name[n])
+                            ++n;
+                        reply[5 .. 5 + n] = cast(ubyte[])name[0 .. n];
+                        len += n;
+                    }
+                }
+                else
+                {
+                    size_t copy = min(content.length, reply.length) - 5;
+                    reply[5 .. 5 + copy] = content[5 .. 5 + copy];
+                    len += copy;
+                }
+                station_send_control(OWControl.echo_reply, src, reply[0 .. len]);
+                return;
+            }
+
+            case OWControl.echo_reply:
+            {
+                if (content.length < 5)
+                    return;
+                uint cookie = loadBigEndian(cast(const(uint)*)content.ptr);
+                foreach (ref p; _pending_pings[])
+                {
+                    if (p.cookie != cookie)
+                        continue;
+                    Duration rtt = getTime() - p.sent;
+                    const(char)[] identity = (content[4] & OWEchoFlag.identify) ? cast(const(char)[])content[5 .. $] : null;
+                    p.handler(src, rtt, identity);
+                    return;    // the entry stays; broadcast pings collect further replies
+                }
+                return;
+            }
+
             default:
                 return;
         }
     }
 }
+
+
+alias MacPingHandler = void delegate(MACAddress from, Duration rtt, scope const(char)[] identity) nothrow @nogc;
+
+void mac_ping_cancel(uint cookie)
+{
+    foreach (i, ref p; _pending_pings[])
+    {
+        if (p.cookie == cookie)
+        {
+            _pending_pings.removeSwapLast(i);
+            return;
+        }
+    }
+}
+
+package void expire_mac_pings()
+{
+    MonoTime now = getTime();
+    for (size_t i = _pending_pings.length; i-- > 0; )
+    {
+        if (now - _pending_pings[i].sent >= 10.seconds)
+            _pending_pings.removeSwapLast(i);
+    }
+}
+
+private struct PendingPing
+{
+    uint cookie;
+    MonoTime sent;
+    MacPingHandler handler;
+}
+
+private __gshared Array!PendingPing _pending_pings;
+private __gshared uint _next_ping_cookie = 1;
 
 
 abstract class EthernetInterface : EthernetStation

--- a/src/router/iface/ethernet.d
+++ b/src/router/iface/ethernet.d
@@ -317,6 +317,9 @@ private:
     // an unknown unicast also fires who_has; the frame still floods, so delivery never waits on the reply
     MACAddress resolve(ulong address)
     {
+        // mac-transport addresses ARE wire addresses; identity, no resolution needed
+        if (address >> 60 == ulong(PacketType.ether_transport))
+            return MACAddress.from_ul(address);
         if (is_network_multicast_address(address))
             return MACAddress.broadcast;
         if (auto r = address in _neighbours)

--- a/src/router/iface/mac.d
+++ b/src/router/iface/mac.d
@@ -43,6 +43,15 @@ nothrow @nogc:
             bool is_link_local() const pure
                 => *cast(uint*)b.ptr == 0x00C28001 && ((*cast(ushort*)(b.ptr + 4) & 0xF0FF) == 0x0000);
         }
+
+        // inverse of ul; bits above 47 are ignored
+        static MACAddress from_ul(ulong v) pure
+        {
+            version (BigEndian)
+                return MACAddress(cast(ubyte)(v >> 40), cast(ubyte)(v >> 32), cast(ubyte)(v >> 24), cast(ubyte)(v >> 16), cast(ubyte)(v >> 8), cast(ubyte)v);
+            else
+                return MACAddress(cast(ubyte)v, cast(ubyte)(v >> 8), cast(ubyte)(v >> 16), cast(ubyte)(v >> 24), cast(ubyte)(v >> 32), cast(ubyte)(v >> 40));
+        }
     }
     else
     {
@@ -231,6 +240,8 @@ unittest
     assert(mac.b == kMac);
     assert(cast(bool)mac);
     assert(!cast(bool)MACAddress.init);
+    assert(MACAddress.from_ul(mac.ul) == mac);
+    assert(MACAddress.from_ul(mac.ul | 0xF000_0000_0000_0000) == mac);
 
     // bit-flag predicates
     assert(!mac.is_multicast);

--- a/src/router/iface/package.d
+++ b/src/router/iface/package.d
@@ -4,6 +4,7 @@ import urt.array;
 import urt.conv;
 import urt.map;
 import urt.lifetime;
+import urt.meta.nullable;
 import urt.mem.ring;
 import urt.mem.string;
 import urt.meta.enuminfo : bitfield;
@@ -19,6 +20,7 @@ import manager.console;
 import manager.plugin;
 
 import router.iface.endpoint;
+import router.iface.ethernet;
 import router.iface.group;
 import router.iface.vlan;
 
@@ -740,10 +742,111 @@ nothrow @nogc:
         g_app.console.register_collection!VLANInterface();
     }
 
+    override void post_init()
+    {
+        // after init: the platform ethernet collections own /interface/ethernet by now,
+        // so this lands as an extension command on that scope
+        g_app.console.register_command!mac_ping("/interface/ethernet", this, "ping");
+    }
+
     override void update()
     {
         Collection!BaseInterface().update_all();
         update_ether_endpoints();
+        expire_mac_pings();
+    }
+
+    // OW mac-ping: `/interface/ethernet/ping address=<mac> [count=] [identify=]`.
+    // Pings go out every running station; broadcast address makes it a discovery sweep.
+    MacPingState mac_ping(Session session, MACAddress address, Nullable!uint count, Nullable!bool identify)
+    {
+        if (!address)
+        {
+            session.write_line("ping requires a destination mac address");
+            return null;
+        }
+        return g_app.allocator.allocT!MacPingState(session, address,
+                                                   identify ? identify.value : true,
+                                                   count ? count.value : 4);
+    }
+
+    static class MacPingState : CommandState
+    {
+    nothrow @nogc:
+
+        CommandCompletionState state = CommandCompletionState.in_progress;
+
+        MACAddress dst;
+        bool identify;
+        uint count;
+        uint sent;
+        uint replies;
+        MonoTime last_send;
+        Array!uint cookies;
+
+        this(Session session, MACAddress dst, bool identify, uint count)
+        {
+            super(session, null);
+            this.dst = dst;
+            this.identify = identify;
+            this.count = count ? count : 1;
+            send_round();
+        }
+
+        override CommandCompletionState update()
+        {
+            if (state == CommandCompletionState.cancel_requested)
+            {
+                cancel_round();
+                state = CommandCompletionState.cancelled;
+                return state;
+            }
+            if (getTime() - last_send >= 1.seconds)
+            {
+                cancel_round();
+                if (sent >= count)
+                {
+                    session.write_line(replies, " replies for ", sent, " requests");
+                    state = CommandCompletionState.finished;
+                }
+                else
+                    send_round();
+            }
+            return state;
+        }
+
+        override void request_cancel()
+        {
+            if (state == CommandCompletionState.in_progress)
+                state = CommandCompletionState.cancel_requested;
+        }
+
+    private:
+        void send_round()
+        {
+            ++sent;
+            last_send = getTime();
+            foreach_ether_station((EthernetStation s) {
+                if (s.running)
+                    cookies ~= s.ping(dst, identify, &on_reply);
+            });
+        }
+
+        void cancel_round()
+        {
+            foreach (c; cookies[])
+                mac_ping_cancel(c);
+            cookies.clear();
+        }
+
+        void on_reply(MACAddress from, Duration rtt, scope const(char)[] identity)
+        {
+            ++replies;
+            if (identity.length)
+                session.write_line("reply from ", from, ": time=", rtt, " \"", identity, "\"");
+            else
+                session.write_line("reply from ", from, ": time=", rtt);
+        }
     }
 
     final String add_interface_name(Session session, const(char)[] name, const(char)[] default_name_prefix)

--- a/src/router/iface/package.d
+++ b/src/router/iface/package.d
@@ -18,6 +18,7 @@ import manager.collection;
 import manager.console;
 import manager.plugin;
 
+import router.iface.endpoint;
 import router.iface.group;
 import router.iface.vlan;
 
@@ -26,6 +27,7 @@ public import router.status;
 
 // package modules...
 public static import router.iface.bridge;
+public static import router.iface.endpoint;
 public static import router.iface.ethernet;
 public static import router.iface.group;
 public static import router.iface.i2c;
@@ -732,6 +734,8 @@ nothrow @nogc:
 
     override void init()
     {
+        register_packet_codec!EtherTransport();
+
         g_app.console.register_collection!InterfaceGroup();
         g_app.console.register_collection!VLANInterface();
     }
@@ -739,6 +743,7 @@ nothrow @nogc:
     override void update()
     {
         Collection!BaseInterface().update_all();
+        update_ether_endpoints();
     }
 
     final String add_interface_name(Session session, const(char)[] name, const(char)[] default_name_prefix)

--- a/src/router/iface/packet.d
+++ b/src/router/iface/packet.d
@@ -46,6 +46,7 @@ enum EtherType : ushort
     mtik    = 0x88BF,   // MikroTik RoMON
     lldp    = 0x88CC,   // Link Layer Discovery Protocol (LLDP)
     hpgp    = 0x88E1,   // HomePlug Green PHY (HPGP)
+    cfm     = 0x8902,   // IEEE 802.1ag / ITU-T Y.1731 Connectivity Fault Management
 }
 
 // Bit 15 of the OW encapsulation type field marks control-plane messages;
@@ -58,6 +59,13 @@ enum OWControl : ushort
     who_has     = ow_control_flag | 0x0001,  // body: universal address (u64 BE) -- which station carries this?
     addr_query  = ow_control_flag | 0x0002,  // body: PacketType (u16 BE, unknown = all) -- report your addresses
     addr_report = ow_control_flag | 0x0003,  // body: N x universal address (u64 BE) -- response to either of the above
+    echo_req    = ow_control_flag | 0x0004,  // body: [cookie:u32 BE][flags:u8][payload] -- mac ping / discovery probe
+    echo_reply  = ow_control_flag | 0x0005,  // body: cookie+flags echoed, then payload echo (or identity when requested)
+}
+
+enum OWEchoFlag : ubyte
+{
+    identify = 1 << 0,  // reply carries the responder's identity instead of echoing the payload
 }
 
 // 802.1p PCP traffic classes

--- a/src/router/iface/packet.d
+++ b/src/router/iface/packet.d
@@ -26,6 +26,8 @@ enum PacketType : ushort
     ble         = 10,
     cpc         = 11,
     i2c         = 12,
+    // 13 is reserved for the udp packet interface (PR #460)
+    ether_transport = 14,
     count
 }
 static assert(PacketType.count <= 16, "PacketType must fit in 4 bits");


### PR DESCRIPTION
MAC-addressed transport as part of the normal stack, not a parallel API: `udp_open()`, `tcp_connect()` and `tcp_listen()` accept `AddressFamily.ether` addresses, so endpoints bind to a station MAC and talk to `(mac, port)` exactly like an IP endpoint. Plus the L2 control plane that lets OpenWatt peers self-assemble on a cold ethernet segment with no DHCP and no IP assignment.

```d
udp_open(null, &peer, &on_recv);                      // wildcard: all segments
tcp_connect(peer, &on_data, &on_event);               // unbound connect: flood SYN, reply pins source
tcp_listen(InetAddress(zero_mac, 7000), &on_accept);  // any-listener across all segments
station.ping(MACAddress.broadcast, true, &on_reply);  // discovery sweep: who's an OW node?
```

```
/interface/ethernet/ping address=FF:FF:FF:FF:FF:FF               # discovery sweep
/interface/ethernet/ping address=02:13:37:AA:BB:64 count=10      # timed mac-ping
```

## Layering

The ethernet-level OW datagram service (`ether_open`, UDP segment framing, ports, wildcard bind, neighbour table, flooding, mac-ping, CFM) lives in `router/iface/endpoint.d` with **zero `protocol/ip` dependency**, so it is present on `FEATURES=switch`. `protocol/ip` supplies the family-dispatching front door (`udp_open`) and all of TCP, reaching down through a hook that ip-less builds simply never install. #460 stacks on this to give `/interface/udp` an ether backend, at which point the UDP interface needs no IP stack at all.

## Addressing model

Weak/strong host pair mirroring IP: a bound station MAC is strong interface binding; the zero mac (or null local) is the weak wildcard. Egress for unbound sources is **flood + learn**, matching what the station layer already does for exotic addresses ("the frame still floods, so delivery never waits on the reply"):

- a passive **neighbour table** (peer mac -> station, the arp-cache analogue) learned from tap ingress; entries age (5 min), die with their station, heal on next ingress
- unknown unicast floods every running station (self-limiting); the peer's reply pins the entry and everything after is single-path
- an unbound TCP connect floods its SYN with each station's own source mac; the peer's reply pins `pcb.local` -- deferred source binding, the L2 analogue of `select_source_v4`
- no probe protocol: who_has/ICMP-style discovery would buy a round trip for what flooding gives free

## Wire formats

```
transport:  [ow: type=ether_transport] [dst:6][src:6][proto:u8] [real UDP/TCP header + data]
mac-ping:   [ow: control echo_req/echo_reply] [cookie:u32][flags:u8][payload | identity]
cfm:        802.1ag LBM in, LBR out (0x8902); responder only, any MD level
```

`PacketType.ether_transport = 14` (13 is reserved for #460's udp interface). `proto` uses IP protocol numbers and the payload is an unmodified transport segment, so TCP rides with no format change; TCP checksum uses an ether pseudo-header `[src:6][dst:6][0][proto][len:2]`, recomputed per emission on the flood path. `echo_req`/`echo_reply` join `who_has`/`addr_query`/`addr_report` in the OW control plane.

## Structure (v6-shaped seams)

The TCP machinery is untouched; only the network layer beneath it became pluggable, with every seam shaped so ipv6 drops in beside v4 and ether (marked `TODO: ipv6` at each site): `TcpPcb`'s 4-tuple is two `InetAddress`es (urt gains family-generic `port`/`addr_any`/`same_addr`); `tcp_input` (v4) and the ether tap both feed the family-generic `tcp_segment_input`; `send_segment_raw` family-switches on emit; `transport_pseudo_checksum` dispatches per family; `refresh_route`'s ether arm resolves egress from the bound mac or the neighbour table and derives MSS from the station MTU. One per-station tap learns neighbours and demuxes udp -> endpoints, tcp -> hook.

## Not yet

- Sync/hub discovery consumer (broadcast identify -> ether-TCP -> mesh).
- TCPStream/TCPServer ether support (`remote=[mac]:port` parses; needs the family allowed through validation).
- CFM loopback originator (responder only). RoMON deliberately skipped: undocumented proprietary L2 overlay, reverse-engineering project with poor effort/value; MNDP is the documented MikroTik-visibility play if ever wanted, and it is an IP/UDP feature anyway.
- Hardware multicast filter hook; socket backend ether support; UdpPcb InetAddress convergence.

## Testing

119/119 module unittests pass; full, switch and unittest configs all build clean. Codec roundtrips and InetAddress ether coverage are unit-tested. **No two-node runtime exercise yet** -- `/interface/ethernet/ping` on the ether1.3 rig is the intended first smoke, and it validates the OW control path before the transport paths behind it.