### PR TITLE
rtc: recover from a cold-start oscillator, and advance urt

### DIFF
--- a/src/driver/rtc/pcf85063.d
+++ b/src/driver/rtc/pcf85063.d
@@ -126,6 +126,12 @@ protected:
 
         if (_request_failed)
         {
+            if (_last_error == PCF85063Error.oscillator_stopped)
+            {
+                log.info("RTC has never been set; waiting for a clock source");
+                reset_operation();
+                return CompletionStatus.complete;
+            }
             if (_last_error == PCF85063Error.none)
                 set_last_error(PCF85063Error.transport);
             log.error("failed to read RTC at address ", _address);
@@ -162,6 +168,8 @@ protected:
         {
             if (_request_failed)
                 log.error("failed to persist updated UTC time");
+            else
+                set_last_error(PCF85063Error.none);
             reset_operation();
         }
     }

--- a/src/driver/rtc/pcf85063.d
+++ b/src/driver/rtc/pcf85063.d
@@ -88,8 +88,16 @@ nothrow @nogc:
         _writing = false;
 
         _time = value;
+        _time_valid = true;
         mark_set!(typeof(this), "time")();
         return StringResult.success;
+    }
+
+    override const(char)[] status_message() const pure
+    {
+        if (running && !_time_valid)
+            return "Waiting for clock source";
+        return super.status_message();
     }
 
 protected:
@@ -129,6 +137,7 @@ protected:
             if (_last_error == PCF85063Error.oscillator_stopped)
             {
                 log.info("RTC has never been set; waiting for a clock source");
+                set_last_error(PCF85063Error.none);
                 reset_operation();
                 return CompletionStatus.complete;
             }
@@ -142,6 +151,7 @@ protected:
             return CompletionStatus.continue_;
 
         _time = get_sys_time(_response_time);
+        _time_valid = true;
         set_utc_time(unix_time_ns(_time));
         mark_set!(typeof(this), "time")();
         log.info("restored UTC time ", _response_time);
@@ -169,7 +179,12 @@ protected:
             if (_request_failed)
                 log.error("failed to persist updated UTC time");
             else
+            {
+                _time = get_sys_time();
+                _time_valid = true;
+                mark_set!(typeof(this), "time")();
                 set_last_error(PCF85063Error.none);
+            }
             reset_operation();
         }
     }
@@ -193,6 +208,7 @@ private:
     bool _response_received;
     bool _request_failed;
     bool _writing;
+    bool _time_valid;
     PCF85063Error _last_error;
     SysTime _time;
     DateTime _response_time;


### PR DESCRIPTION
Three commits: the urt pointer bump that unbreaks ESP32 boot, then the two RTC changes.

## 1. Advance urt (`3e71d0a2` -> `45f1dc6`)

Master currently boot-loops on any ESP32 board with an I2C peripheral configured. urt's ESP32 I2C and SPI backends both declared their completion trampoline as `extern(C) bool operation_complete(void*, int)`, which collide into a single unmangled symbol. The linker kept the `@critical` SPI one, so every I2C completion dispatched into the SPI handler and aborted:

```
*** ASSERT: Assertion failed at third_party/urt/src/urt/driver/spi.d:260
```

Fixed upstream in open-watt/urt#212 (merged). Submodule pointers do not advance on their own, so master keeps recording the broken commit until this lands. Pointer change only, no source change.

## 2. Treat a stopped oscillator as a cold start, not a failure

The PCF85063 raises its OS flag when it has never been set or has lost power, which is simply the normal state on first power-up. `startup()` treated it as a hard error, so the object cycled `Failed` -> backoff forever.

The deadlock: `shutdown()` unsubscribes the clock-change hook on the way out, so the driver could never observe a clock source arriving, and therefore could never write the time that would clear the flag. It had no way out of its own cold-start state. It also logged `failed to read RTC at address 81` roughly once a second, forever.

Complete startup when that is the only problem, leaving the time unset, so the object reaches `Running` and holds its subscription until a clock source appears. Genuine transport faults and invalid BCD are untouched and still error out.

## 3. Report the wait through `status()`, not `last-error`

A never-set RTC is not in error, it is in a particular working state: the peripheral is present and controllable, it simply holds no valid time yet. `ActiveObject` already exposes `status_message()` for exactly this, and it is what the STATUS column shows. So a running RTC without a time reads "Waiting for clock source", and `last-error` stays `none`, meaning only genuine faults.

The two conditions stay distinguishable without overloading `last-error`: a transport fault fails startup and leaves the object `Failed`; a cold start leaves it `Running` with the time unset.

## Testing

ESP32-S3, Waveshare RS485-CAN board, with a PCF85063 that had never been set.

Boot, with the urt fix in place: 0 reboots and 0 asserts over 25s, where the previous pointer gave 17 boots in 30s.

Cold start, time unknown:

```
[Info] pcf85063 'rtc': RTC has never been set; waiting for a clock source
[Notice] pcf85063 'rtc': online

NAME  TYPE      STATUS                    LAST-ERROR
rtc   pcf85063  Waiting for clock source  none
```

Previously `Failed` / `oscillator_stopped`.

After supplying a time over the console, the write-back path runs and the state reverts:

```
NAME  TYPE      STATUS   LAST-ERROR
rtc   pcf85063  Running  none
```

And it survives a power cycle, which is the whole point of the driver:

```
[Info] pcf85063 'rtc': restored UTC time 2026-08-10T12:00:59
```

So the cold-start state is recoverable, the recovery has been observed, and the recovered time persists.

CI was 16/16 green on the two RTC commits, including all three ESP targets and the four baremetal ones. Re-running now with the pointer bump included.