### PR TITLE
telnet: fix carrier ownership bookkeeping (disconnect reboots the board)

### DIFF
--- a/src/manager/console/session.d
+++ b/src/manager/console/session.d
@@ -907,6 +907,8 @@ private:
         if (signal == StateSignal.online)
             return;
         unsubscribe_stream();
+        if (_stream && (_stream.flags & ObjectFlags.temporary))
+            _stream = null;
         restart();
     }
 

--- a/src/protocol/telnet/stream.d
+++ b/src/protocol/telnet/stream.d
@@ -6,7 +6,7 @@ import urt.mem.allocator;
 import urt.string;
 
 import manager.base;
-import manager.base : Property;
+import manager.base : ObjectRef, Property;
 import manager.collection;
 import manager.console.session;
 
@@ -56,11 +56,11 @@ nothrow @nogc:
     }
 
     inout(Stream) transport() inout pure
-        => _inner;
+        => _inner.get;
 
     final void transport(Stream value)
     {
-        if (_inner is value)
+        if (_inner.get is value)
             return;
         if (_subscribed)
         {
@@ -376,7 +376,7 @@ protected:
     }
 
 private:
-    Stream _inner;
+    ObjectRef!Stream _inner;
     TerminalChannel _terminal;
     Array!char _terminal_type;
     Array!ubyte _tail;


### PR DESCRIPTION
Two ownership-bookkeeping fixes around a telnet session's carrier. Both are one layer of the same stack and were found together; they are independently revertable.

## 1. `console: release the carrier claim when a temporary stream dies`

Fixes the reported crash: **every telnet disconnect reboots the board.**

Peer closes, and the offline signal cascades up the stack:

```
TCPStream.update() sees _link < 0 -> restart() -> set_state(restarting)
  -> set_offline() -> TelnetStream.inner_state_change() -> restart() -> set_offline()
     -> Session.stream_state_change() -> restart() -> Session is temporary -> destroy()
        -> shutdown() -> _stream.destroy()            <- 1st destroy
  <- unwind to TelnetStream.set_state: _flags & temporary -> destroy()   <- 2nd destroy
```

`Session.stream_state_change` dropped its *subscription* to the dying stream but kept its *ownership claim*, so `shutdown()` destroyed a stream the state machine was already reaping as a temporary. `BaseObject.destroy()`'s `assert(!(_state & _destroyed), "destroy() called twice - bookkeeping bug")` fires; on embedded targets that aborts and reboots.

The release used to be there. 2b2a6591 wrote it; a6b98bc9 lost it when `Session` became a Collection-managed `ActiveObject` -- `unsubscribe_stream()` preserved the subscription half of the teardown but not the `_stream = null` half.

Released only for `temporary` carriers, matching what `TelnetStream.inner_state_change` already does one layer down. A named stream stays referenced so the session resumes when it comes back.

## 2. `telnet: hold the transport by ObjectRef`

Latent use-after-free on a different path, found while investigating the above.

`TelnetStream._inner` was `ObjectRef!Stream` until 2b2a6591 downgraded it to a raw pointer. `inner_state_change` only clears it for *temporary* transports, so destroying a **named** transport (client role, `transport=<named stream>`) leaves `_inner` dangling once `free_pending()` runs:

1. `TCPStream.destroy()` -> `set_offline()` -> `inner_state_change`: not temporary, clear is skipped -> `restart()`
2. `TelnetStream.shutdown()` unsubscribes, correctly skips the destroy -> lands in `validate`
3. End of frame: `free_pending()` frees the TCPStream
4. Next frame: `validate()` -> `_inner !is null` -> **true** -> `startup()` -> `_inner.running` on freed memory

`ObjectRef` tombstones the CID, so `validate()` correctly fails, and the ref rebinds if the transport returns under the same name -- the documented behaviour in AGENTS.md, and what `Session._stream` already does.

The explicit clear in `inner_state_change` stays: a *restarting* temporary is not destroyed yet, so the tombstone has not fired.

## Testing

`dmd -o-` (full semantic, no codegen) passes on all five modules touching `TelnetStream`/`Session`: `stream.d`, `session.d`, `server.d`, `client.d`, `package.d`.

**Not runtime-tested.** The tree does not currently link, on breakage unrelated to these changes (`router/iface/i2c.d:337` against the current urt submodule, and `apps/energy/attribution.d:228`), so I could not build a binary and actually disconnect a session against it.

## Not included

`ActiveObject.set_state()` reaps a temporary *after* broadcasting `offline`, so during that broadcast `flags` reports `restarting` -- alive and restartable -- for an object that is already dead by definition. `destroy()` does the opposite and sets `_disabled|_destroyed` before it broadcasts. That inconsistency is what turned the missing release into a crash rather than a leak, and it is why the `!(s.flags & disabled)` guard in `Session.shutdown()` does not catch it. Left alone deliberately: it is a separate question, and reordering it as a way to survive missing bookkeeping would be the wrong trade.
