### PR TITLE
ether: review follow-up (comments, mac-ping docs)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -347,6 +347,37 @@ no transport properties.
 /console/session/add name=default stream=console profile=vt100 initial-command="/log/print --stream"
 ```
 
+### `/interface/ethernet`
+
+Ethernet interfaces are a managed collection, and additionally carry the
+mac-ping command. It sends an OW echo request and times the round trip, so
+only OpenWatt stations answer. Requests go out every running ethernet
+station, which makes a broadcast destination a discovery sweep across all
+segments.
+
+| Command | Syntax | Description |
+| --- | --- | --- |
+| `ping` | `/interface/ethernet/ping address=<mac> [count=<count>] [identify=<bool>]` | Times echo round trips to `address`, one request per second. |
+
+| Argument | Values | Default | Description |
+| --- | --- | --- | --- |
+| `address` | mac address | required | Destination. A broadcast address sweeps for responders. |
+| `count` | request count | `4` | Number of requests to send; `0` is treated as `1`. |
+| `identify` | `true` or `false` | `true` | Asks responders to name themselves, printing the name with each reply. |
+
+Each reply prints as `reply from <mac>: time=<rtt>`, with the responder's
+identity appended when it supplied one. A summary of
+`<replies> replies for <sent> requests` closes the command, and Ctrl+C
+cancels it early.
+
+Ethernet stations also answer 802.1ag loopback messages, so standard L2 OAM
+equipment can mac-ping an OpenWatt station without OW support.
+
+```text
+/interface/ethernet/ping address=ff:ff:ff:ff:ff:ff count=1
+/interface/ethernet/ping address=02:13:37:aa:bb:64 count=10 identify=false
+```
+
 ### `/interface/udp`
 
 A UDP interface is a raw-packet interface over UDP datagrams: one datagram is

--- a/src/protocol/ip/package.d
+++ b/src/protocol/ip/package.d
@@ -271,8 +271,7 @@ TCPConnection* tcp_connect(InetAddress remote, TCPRecvHandler on_recv, TCPEventH
             return null;     // TODO: ipv6
         if (remote.family == AddressFamily.ether)
         {
-            // a bound local names the station; unbound floods the SYN and the peer's
-            // reply pins the source, so replies must be heard on every segment
+            // unbound floods the SYN, so the reply must be heard on every segment
             if (local && local.family == AddressFamily.ether && !local.addr_any)
             {
                 EthernetStation station = find_ether_station(MACAddress(local._a.ether.addr));
@@ -591,10 +590,7 @@ UDPEndpoint* udp_open(const(InetAddress)* local, const(InetAddress)* remote, UDP
     }
 }
 
-// Datagrams addressed by (mac, port): same UDPEndpoint, backed by the ether transport
-// instead of a socket or PCB. A station's mac as the local address binds the endpoint
-// to that interface; a null local or the zero mac is a wildcard bind: receive on every
-// ethernet segment, egress by learned neighbour with unknown-unicast flooding.
+// a null local or the zero mac is a wildcard bind: every segment, egress by learned neighbour
 private UDPEndpoint* udp_open_ether(const(InetAddress)* local, const(InetAddress)* remote, UDPRecvHandler on_recv)
 {
     if (local && local.family != AddressFamily.ether)
@@ -2076,7 +2072,6 @@ version (UseInternalIPStack)
         return c;
     }
 
-    // Installed as the ether tap's tcp hook: segments addressed to a station arrive here.
     void ether_tcp_input(MACAddress src, MACAddress dst, const(void)[] segment, MonoTime rx_time)
     {
         import protocol.ip.tcp : tcp_segment_input;

--- a/src/protocol/ip/tcp.d
+++ b/src/protocol/ip/tcp.d
@@ -156,7 +156,6 @@ struct TcpPcb
     // connection's lifetime amid mixed traffic. Assigned in tcp_assign_id.
     uint id;
 
-    // 4-tuple; the address family selects the network layer beneath the connection
     InetAddress local;
     InetAddress remote;
 
@@ -390,8 +389,7 @@ bool tcp_connect(ref IPStack stack, TcpPcb* pcb)
     if (pcb.local.port == 0 || pcb.remote.port == 0)
         return false;
     refresh_route(stack, pcb);
-    // ether needs no resolved egress up front: an unbound connect floods its SYN and the
-    // peer's reply pins the source (and with it the egress)
+    // ether needs no egress up front: an unbound connect floods its SYN and the reply pins it
     if (!pcb.route_egress && !pcb.local_delivery && pcb.remote.family != AddressFamily.ether)
         return false;
     if (pcb.local.family == AddressFamily.ipv4 && pcb.local.addr_any)
@@ -572,7 +570,6 @@ private void tcp_app_deliver(TcpPcb* pcb, const(ubyte)[] bytes, MonoTime rx_time
 // -------------------------------------------------------------------------
 // Ingress
 
-// v4 ingress from the stack dispatch: strip the IP header, then the family-generic path.
 void tcp_input(ref IPStack stack, ref Packet pkt)
 {
     if (pkt.data.length < IPv4Header.sizeof + TcpHeader.sizeof)
@@ -592,9 +589,7 @@ void tcp_input(ref IPStack stack, ref Packet pkt)
     tcp_segment_input(stack, InetAddress(IPAddr(ip.src), 0), InetAddress(IPAddr(ip.dst), 0), tcp_seg, pkt.creation_time);
 }
 
-// Family-generic ingress: src/dst carry the network-layer addresses (ports zero here;
-// filled in from the TCP header), tcp_seg is the whole TCP segment. The ether tap
-// delivers here directly, and ipv6 ingress will land here too.
+// src/dst ports arrive zero here; they are filled in from the TCP header
 void tcp_segment_input(ref IPStack stack, InetAddress src, InetAddress dst, const(ubyte)[] tcp_seg, MonoTime rx_time)
 {
     if (tcp_seg.length < TcpHeader.sizeof)
@@ -630,8 +625,7 @@ void tcp_segment_input(ref IPStack stack, InetAddress src, InetAddress dst, cons
         return;
     }
 
-    // Deferred source bind: an unbound local pins to the address the peer reached us at.
-    // (For ether this also selects the egress: refresh_route resolves it from the mac.)
+    // an unbound local pins to the address the peer reached us at; for ether that also picks the egress
     if (!pcb.is_listener && pcb.local.addr_any)
         pcb.local = dst;
 
@@ -1304,8 +1298,6 @@ void send_segment_at(ref IPStack stack, TcpPcb* pcb, ubyte flags, uint seq, cons
 // Build and emit a fully-specified TCP segment. Used both via PCB and for
 // stateless RSTs to unknown 4-tuples. SYN segments include an MSS option;
 // `advertise_mss` is the value to put in the option (caller's responsibility).
-// `egress`/`next_hop` are optional pre-resolved route hints: for v4 they take the
-// fast path through output_v4_routed; for ether, egress is the station itself.
 void send_segment_raw(ref IPStack stack, ref const InetAddress src, ref const InetAddress dst,
                       uint seq, uint ack_val, ubyte flags, ushort window, const(ubyte)[] data,
                       ushort advertise_mss = 0, BaseInterface egress = null, IPAddr next_hop = IPAddr.any)
@@ -1386,8 +1378,7 @@ void send_segment_raw(ref IPStack stack, ref const InetAddress src, ref const In
             MACAddress src_mac = MACAddress(src._a.ether.addr);
             MACAddress dst_mac = MACAddress(dst._a.ether.addr);
 
-            // an unbound source stamps the egress station's own address; the checksum
-            // covers the pseudo-header, so it is computed per emission
+            // the checksum covers the pseudo-header, so it is computed per emission
             void emit(EthernetStation s)
             {
                 MACAddress use_src = src_mac ? src_mac : s.mac;
@@ -1824,8 +1815,6 @@ void refresh_route(ref IPStack stack, TcpPcb* pcb)
 {
     if (pcb.remote.family == AddressFamily.ether)
     {
-        // No routing at L2: a bound local names the station directly; an unbound local
-        // uses the learned neighbour, and until one is known the send path floods.
         if (pcb.route_egress)
             return;
         EthernetStation station;
@@ -2029,8 +2018,7 @@ ushort pseudo_header_checksum_v4(IPAddr src, IPAddr dst, ubyte protocol, ushort 
 }
 
 
-// Pseudo-header checksum for ether-carried segments. Over ether both ends are us, so
-// the pseudo-header is our own definition: [src:6][dst:6][0][protocol][length:2].
+// our own definition, not an RFC one: [src:6][dst:6][0][protocol][length:2]
 ushort pseudo_header_checksum_ether(MACAddress src, MACAddress dst, ubyte protocol, ushort transport_length) pure
 {
     ubyte[16] ph = void;
@@ -2043,7 +2031,6 @@ ushort pseudo_header_checksum_ether(MACAddress src, MACAddress dst, ubyte protoc
 }
 
 
-// Pseudo-header checksum for the segment's address family.
 // TODO: udp_output/udp_input converge on this once UdpPcb adopts InetAddress addressing.
 ushort transport_pseudo_checksum(ref const InetAddress src, ref const InetAddress dst, ubyte protocol, ushort transport_length) pure
 {

--- a/src/router/iface/endpoint.d
+++ b/src/router/iface/endpoint.d
@@ -16,9 +16,6 @@ import router.iface.packet;
 nothrow @nogc:
 
 
-// Transport segments carried directly over the segment: the OW header supplies the fields the
-// IP header would have (addressing and protocol number); the payload is a regular transport
-// header + data, so TCP/UDP machinery is unaware the network layer beneath it is not IP.
 enum TransportProto : ubyte
 {
     tcp = 6,    // IP protocol numbers
@@ -42,7 +39,6 @@ nothrow @nogc:
 
     alias is_multicast = Ethernet.is_multicast;
 
-    // [dst:6][src:6][protocol:u8]
     static ptrdiff_t encode_ow_header(ref const Packet p, ubyte[] buffer)
     {
         if (buffer.length < 13)
@@ -72,14 +68,12 @@ alias EtherRecvHandler = void delegate(EtherEndpoint* ep, const(void)[] data, MA
 alias EtherTcpInput = void function(MACAddress src, MACAddress dst, const(void)[] segment, MonoTime rx_time) nothrow @nogc;
 
 
-// TCP-over-ether segments are handed up through this hook; the IP module installs it
-// when the internal TCP machinery is present.
+// null unless the IP module installs it; switch builds carry no TCP
 void set_ether_tcp_input(EtherTcpInput handler)
 {
     g_ether_tcp_input = handler;
 }
 
-// The station whose mac is `mac`, if any: ether local addresses name their interface.
 EthernetStation find_ether_station(MACAddress mac)
 {
     import manager.collection : Collection;
@@ -106,9 +100,7 @@ void foreach_ether_station(scope void delegate(EthernetStation) nothrow @nogc si
     }
 }
 
-// Egress cache for unbound sources: (peer mac -> station) learned passively from tap
-// ingress, the arp-cache analogue. A miss means the caller floods every segment
-// (unknown-unicast flooding, self-limiting); the peer's reply populates the entry.
+// the arp-cache analogue; a miss means the caller floods, and the reply populates the entry
 EthernetStation ether_neighbour_lookup(MACAddress mac)
 {
     if (EtherNeighbour* e = mac.ul in _neighbours)
@@ -122,16 +114,11 @@ EthernetStation ether_neighbour_lookup(MACAddress mac)
     return null;
 }
 
-// Wildcard consumers (bind-any endpoints, unbound connects, any-listeners) need every
-// segment tapped; once requested, the module sweep keeps taps on all stations.
 void ether_request_tap_all()
 {
     _tap_all = true;
 }
 
-// One ether_transport subscription per station, demuxing to endpoints and the tcp hook.
-// Endpoints and pcbs bound to the station share it; the module sweep re-subscribes if
-// the station is destroyed and recreated with the same name.
 void ensure_ether_tap(EthernetStation station)
 {
     foreach (t; _taps[])
@@ -146,13 +133,7 @@ void ensure_ether_tap(EthernetStation station)
 }
 
 
-// Open an ether-UDP datagram endpoint bound to a local port (0 = ephemeral). A non-null
-// iface binds the endpoint to that station; a null iface is a wildcard bind: datagrams
-// are accepted on every ethernet segment, and egress uses the learned neighbour (or
-// floods unknown unicast). Datagrams to the receiving station's MAC and broadcast are
-// delivered; multicast groups via join(). A remote restricts delivery to that peer and
-// enables send(). Bound endpoints track their interface by reference; they ride out
-// restarts and re-attach if the interface is destroyed and recreated with the same name.
+// a null iface is a wildcard bind: every segment, egress by learned neighbour
 EtherEndpoint* ether_open(EthernetStation iface, ushort port, EtherRecvHandler on_recv,
                           MACAddress remote = MACAddress(), ushort remote_port = 0)
 {
@@ -218,7 +199,6 @@ nothrow @nogc:
         _groups.removeFirstSwapLast(group);
     }
 
-    // Send to the remote given at open. Returns bytes sent, or 0.
     ptrdiff_t send(scope const(void)[] data)
         => _remote ? sendto(_remote, _remote_port, data) : 0;
 
@@ -234,7 +214,7 @@ nothrow @nogc:
         u.src_port = _local_port.nativeToBigEndian;
         u.dst_port = dst_port.nativeToBigEndian;
         u.length = nativeToBigEndian(cast(ushort)(UdpSegHeader.sizeof + data.length));
-        u.checksum[] = 0;    // link CRC covers integrity
+        u.checksum[] = 0;
         buf[UdpSegHeader.sizeof .. UdpSegHeader.sizeof + data.length] = (cast(const(ubyte)[])data)[];
         const(ubyte)[] frame = buf[0 .. UdpSegHeader.sizeof + data.length];
 
@@ -246,7 +226,6 @@ nothrow @nogc:
             return emit(i, dst, frame) ? data.length : 0;
         }
 
-        // wildcard: learned neighbour picks the segment; unknown (or multicast) floods them all
         if (EthernetStation i = ether_neighbour_lookup(dst))
             return emit(i, dst, frame) ? data.length : 0;
         bool sent = false;
@@ -257,7 +236,7 @@ nothrow @nogc:
         return sent ? data.length : 0;
     }
 
-    // Teardown is deferred to the module sweep; safe to call from the recv handler.
+    // deferred to the module sweep; safe to call from the recv handler
     void close()
     {
         _closing = true;
@@ -341,7 +320,7 @@ private:
 
 enum encap_overhead = 5 + 13 + UdpSegHeader.sizeof;     // ow framing + ether-transport header + udp header
 
-// standard UDP header; over ether the checksum is unused (transmitted zero, ignored on receive)
+// checksum is transmitted zero and ignored on receive; the link CRC covers integrity
 struct UdpSegHeader
 {
     ubyte[2] src_port;      // big-endian
@@ -400,8 +379,7 @@ nothrow @nogc:
 
     void on_iface_state(ActiveObject, StateSignal signal)
     {
-        // Subscriptions on the dying object vanish with it; the module sweep
-        // re-subscribes if an interface with the same name reappears.
+        // subscriptions die with the object; the module sweep re-subscribes if the name reappears
         if (signal == StateSignal.destroyed)
             _subscribed = false;
     }

--- a/src/router/iface/ethernet.d
+++ b/src/router/iface/ethernet.d
@@ -34,9 +34,7 @@ nothrow @nogc:
         return forward(p, callback);
     }
 
-    // OW mac-ping: time an echo round-trip to dst (broadcast for discovery sweeps).
-    // Each reply invokes handler; identify asks responders to name themselves.
-    // The pending entry expires quietly after 10s unless cancelled earlier.
+    // the pending entry expires quietly after 10s unless cancelled
     final uint ping(MACAddress dst, bool identify, MacPingHandler handler)
     {
         uint cookie = _next_ping_cookie++;
@@ -360,10 +358,8 @@ private:
         return MACAddress.broadcast;
     }
 
-    // 802.1ag / Y.1731 loopback responder: an LBM (opcode 3) addressed to this station
-    // is answered with an LBR (opcode 2) echoing the whole PDU, so standard L2 OAM gear
-    // can mac-ping us. We answer at any MD level; a full MEP would filter by configured
-    // level, which we don't model.
+    // 802.1ag LBM (opcode 3) is answered with an LBR (opcode 2) echoing the whole PDU
+    // we answer at any MD level; a real MEP would filter by configured level
     void cfm_ingress(ref const Packet packet)
     {
         enum ubyte opcode_lbr = 2, opcode_lbm = 3;

--- a/src/router/iface/package.d
+++ b/src/router/iface/package.d
@@ -748,8 +748,7 @@ nothrow @nogc:
 
     override void post_init()
     {
-        // after init: the platform ethernet collections own /interface/ethernet by now,
-        // so this lands as an extension command on that scope
+        // post_init: the platform ethernet collections own the scope by now, so this extends it
         g_app.console.register_command!mac_ping("/interface/ethernet", this, "ping");
     }
 
@@ -760,8 +759,6 @@ nothrow @nogc:
         expire_mac_pings();
     }
 
-    // OW mac-ping: `/interface/ethernet/ping address=<mac> [count=] [identify=]`.
-    // Pings go out every running station; broadcast address makes it a discovery sweep.
     MacPingState mac_ping(Session session, MACAddress address, Nullable!uint count, Nullable!bool identify)
     {
         if (!address)

--- a/src/router/iface/udp.d
+++ b/src/router/iface/udp.d
@@ -15,6 +15,14 @@ module router.iface.udp;
 //
 // TODO: broadcast tx needs SO_BROADCAST and multicast rx needs a group join; UDPEndpoint exposes neither yet
 // TODO: l2mtu assumes a 1500-byte link MTU; query the real path MTU from the endpoint when it can report one
+// TODO: raw-frame compatibility. rx delivers UDPFrame, so PacketFilter(raw) consumers that sit happily on
+//   ASH or a CPCEndpoint see nothing here (tx already accepts raw). Reconcile along CPC's trunk/leaf split:
+//   [ ] connected mode (unicast remote) should deliver RawFrame on rx: the peer is fixed by configuration,
+//       so the UDPFrame header adds nothing, and the interface becomes a drop-in raw pipe. Multi-drop keeps
+//       UDPFrame; a consumer with no notion of peers can't sit on a multi-drop segment anyway.
+//   [ ] if a consumer ever needs per-peer sessions over one socket: peer sub-interfaces bound to a
+//       multi-drop trunk, each presenting one peer as a raw pipe (the CPCEndpoint shape), possibly spawned
+//       dynamically on first datagram from an unknown peer like the TCP server spawns streams.
 
 import urt.inet;
 import urt.lifetime;


### PR DESCRIPTION
Review fixes for #473 that missed the merge.

- strip narration comments added by the ether-transport work (78 added comment lines -> 31; what survives is surprises, gotchas and TODOs)
- document `/interface/ethernet/ping` in docs/CLI.md, placed beside `/interface/udp`

Code changes are comment-only.