### PR TITLE
Split mac-ping into 802.1ag loopback and OW discovery

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -350,32 +350,45 @@ no transport properties.
 ### `/interface/ethernet`
 
 Ethernet interfaces are a managed collection, and additionally carry the
-mac-ping command. It sends an OW echo request and times the round trip, so
-only OpenWatt stations answer. Requests go out every running ethernet
-station, which makes a broadcast destination a discovery sweep across all
-segments.
+mac-ping and discovery commands. Reachability testing uses 802.1ag loopback,
+so standard L2 OAM equipment both answers `ping` and can ping an OpenWatt
+station itself. Enumerating the segment is a separate command, because
+loopback is a point-to-point test that gains no third-party responders when
+broadcast.
 
 | Command | Syntax | Description |
 | --- | --- | --- |
-| `ping` | `/interface/ethernet/ping address=<mac> [count=<count>] [identify=<bool>]` | Times echo round trips to `address`, one request per second. |
+| `ping` | `/interface/ethernet/ping address=<mac> [count=<count>]` | Times 802.1ag loopback round trips to `address`, one request per second. |
+| `discover` | `/interface/ethernet/discover` | Sweeps every segment for OpenWatt stations, listing each with its name and addresses. |
 
 | Argument | Values | Default | Description |
 | --- | --- | --- | --- |
-| `address` | mac address | required | Destination. A broadcast address sweeps for responders. |
+| `address` | mac address | required | Unicast destination. Multicast and broadcast are rejected; use `discover`. |
 | `count` | request count | `4` | Number of requests to send; `0` is treated as `1`. |
-| `identify` | `true` or `false` | `true` | Asks responders to name themselves, printing the name with each reply. |
 
-Each reply prints as `reply from <mac>: time=<rtt>`, with the responder's
-identity appended when it supplied one. A summary of
-`<replies> replies for <sent> requests` closes the command, and Ctrl+C
-cancels it early.
+Requests go out every running ethernet station, so whichever segment hosts the
+target answers. Each reply prints as `reply from <mac>: time=<rtt>`, with the
+responder's name appended when its LBR carried a Sender ID TLV. A summary of
+`<replies> replies for <sent> requests` closes the command, and Ctrl+C cancels
+it early.
 
-Ethernet stations also answer 802.1ag loopback messages, so standard L2 OAM
-equipment can mac-ping an OpenWatt station without OW support.
+`discover` broadcasts an OW address query from every running station and
+collects the reports, printing each responder's mac address and name followed
+by its universal addresses, one per line, indented and prefixed with the packet
+type. Responders jitter their replies over a short window, so the sweep runs
+for two seconds before closing with `<count> stations found`. Round-trip times
+are not reported: the jitter makes them meaningless. Only OpenWatt stations
+answer.
+
+Stations answer loopback only at the maintenance level they claim, set per
+interface by the `cfm-level` property (`0`-`7`, default `7`). Loopback messages
+at other levels belong to another maintenance domain and are ignored, so an
+OpenWatt station never corrupts diagnostics on a network with provisioned CFM.
 
 ```text
-/interface/ethernet/ping address=ff:ff:ff:ff:ff:ff count=1
-/interface/ethernet/ping address=02:13:37:aa:bb:64 count=10 identify=false
+/interface/ethernet/ping address=02:13:37:aa:bb:64 count=10
+/interface/ethernet/discover
+/interface/ethernet/set eth0 cfm-level=5
 ```
 
 ### `/interface/udp`

--- a/docs/UX_TODO.md
+++ b/docs/UX_TODO.md
@@ -20,3 +20,14 @@ through them and remove sections as they are absorbed.
   `/stream/udp` in pickers/forms must drop it.
 - Log sinks can no longer be given a UDP transport (syslog over UDP is unavailable) until
   sinks can bind a packet interface.
+
+## 2026-08-10: ethernet stations gain `cfm-level`; mac ping/discover CLI split
+
+- All ethernet-station interface collections (platform ethernet, bridge, vlan, wifi, udp)
+  gain a `cfm-level` property (0-7, default 7): the 802.1ag maintenance level the station
+  answers loopback at. Clients rendering interface detail/edit views may surface it.
+- `/interface/ethernet/ping` no longer accepts `identify=` and rejects multicast/broadcast
+  addresses; it is now a unicast 802.1ag loopback (works against third-party CFM gear).
+- New command `/interface/ethernet/discover`: broadcast sweep listing OW stations on the
+  segment with their system name and universal addresses. Anything that offered broadcast
+  ping as a discovery affordance should move to it.

--- a/src/router/iface/ethernet.d
+++ b/src/router/iface/ethernet.d
@@ -4,9 +4,11 @@ import urt.array;
 import urt.endian;
 import urt.log;
 import urt.map;
+import urt.rand : rand;
 import urt.time;
 import urt.util : min;
 
+import manager.base;
 import manager.collection;
 import manager.console;
 import manager.plugin;
@@ -20,6 +22,7 @@ nothrow @nogc:
 
 abstract class EthernetStation : BaseInterface
 {
+    alias Properties = AliasSeq!(Prop!("cfm-level", cfm_level));
 nothrow @nogc:
 
     MACAddress mac;
@@ -34,16 +37,42 @@ nothrow @nogc:
         return forward(p, callback);
     }
 
-    // the pending entry expires quietly after 10s unless cancelled
-    final uint ping(MACAddress dst, bool identify, MacPingHandler handler)
+    // 802.1ag loopback at our maintenance level; the pending entry expires quietly after 10s unless cancelled
+    final uint ping(MACAddress dst, MacPingHandler handler)
     {
-        uint cookie = _next_ping_cookie++;
-        ubyte[5] req = void;
-        storeBigEndian(cast(uint*)req.ptr, cookie);
-        req[4] = identify ? OWEchoFlag.identify : 0;
-        _pending_pings ~= PendingPing(cookie, getTime(), handler);
-        station_send_control(OWControl.echo_req, dst, req);
-        return cookie;
+        uint txid = _next_ping_txid++;
+        ubyte[9] lbm = void;
+        lbm[0] = cast(ubyte)(_cfm_level << 5);
+        lbm[1] = cfm_opcode_lbm;
+        lbm[2] = 0;
+        lbm[3] = 4;  // first TLV offset: past the transaction id
+        lbm[4 .. 8] = txid.nativeToBigEndian;
+        lbm[8] = 0;  // End TLV
+        _pending_pings ~= PendingPing(txid, getTime(), handler);
+        send(dst, lbm, EtherType.cfm);
+        return txid;
+    }
+
+    // txid comes from mac_discover_begin(); 0 sweeps for neighbour state with no reply correlation
+    final void discover(uint txid, PacketType type = PacketType.unknown)
+    {
+        ubyte[6] query = void;
+        query[0 .. 4] = txid.nativeToBigEndian;
+        query[4 .. 6] = ushort(type).nativeToBigEndian;
+        station_send_control(OWControl.addr_query, MACAddress.broadcast, query);
+    }
+
+    // Properties...
+
+    ubyte cfm_level() const
+        => _cfm_level;
+    const(char)[] cfm_level(ubyte value)
+    {
+        if (value > 7)
+            return "cfm level must be 0-7";
+        _cfm_level = value;
+        mark_set!(typeof(this), "cfm-level")();
+        return null;
     }
 
 protected:
@@ -123,7 +152,26 @@ protected:
         _neighbours.clear();
         _local_addresses.clear();
         _who_has_sent.clear();
+        _pending_reports.clear();
         return super.shutdown();
+    }
+
+    override void update()
+    {
+        super.update();
+
+        if (!_pending_reports.empty)
+        {
+            MonoTime now = getTime();
+            for (size_t i = _pending_reports.length; i-- > 0; )
+            {
+                if (now >= _pending_reports[i].due)
+                {
+                    send_addr_report(_pending_reports[i].dst, _pending_reports[i].txid, _pending_reports[i].type);
+                    _pending_reports.removeSwapLast(i);
+                }
+            }
+        }
     }
 
     // Local-address knowledge for answering who_has/addr_query. The default is the
@@ -155,8 +203,8 @@ protected:
 
     final void station_link_up()
     {
-        ubyte[2] query = ushort(PacketType.unknown).nativeToBigEndian;
-        station_send_control(OWControl.addr_query, MACAddress.broadcast, query);
+        // txid 0: prime the neighbour table only, not part of any discovery sweep
+        discover(0);
     }
 
     // Encapsulate an exotic packet and transmit it across the segment.
@@ -204,7 +252,7 @@ protected:
             if (content.length < 5 + data_len)
                 return false;
             add_rx_frame(packet.length);
-            station_control(cast(OWControl)wire_type, content[5 .. 5 + data_len], packet.eth.src);
+            station_control(cast(OWControl)wire_type, content[5 .. 5 + data_len], packet.eth.src, !packet.eth.dst.is_multicast);
             return true;
         }
 
@@ -316,7 +364,18 @@ protected:
 
 private:
     enum resolve_interval = 5.seconds;
-    enum max_report_entries = 180; // TODO: segment larger reports
+    enum report_capacity = 432;     // address bytes per report; head + addresses must fit the control frame
+    enum report_jitter_ms = 250;
+
+    struct PendingReport
+    {
+        MACAddress dst;
+        uint txid;
+        PacketType type;
+        MonoTime due;
+    }
+
+    ubyte _cfm_level = 7;   // maintenance level we claim; conventional for customer/edge equipment
 
     // exotic address -> ethernet station carrying it, learned from OW-encap ingress
     Map!(ulong, MACAddress) _neighbours;
@@ -324,6 +383,8 @@ private:
     Map!(ulong, MonoTime) _local_addresses;
     // who_has rate limiting
     Map!(ulong, MonoTime) _who_has_sent;
+    // jittered replies to broadcast addr_query
+    Array!PendingReport _pending_reports;
 
     void learn(ulong address, MACAddress station)
     {
@@ -358,26 +419,108 @@ private:
         return MACAddress.broadcast;
     }
 
-    // 802.1ag LBM (opcode 3) is answered with an LBR (opcode 2) echoing the whole PDU
-    // we answer at any MD level; a real MEP would filter by configured level
+    // 802.1ag LBM (opcode 3) is answered with an LBR (opcode 2) echoing the PDU, with a Sender ID TLV prepended
+    // LBMs at other levels belong to someone else's maintenance domain; answering them would corrupt it
     void cfm_ingress(ref const Packet packet)
     {
-        enum ubyte opcode_lbr = 2, opcode_lbm = 3;
-
         const(ubyte)[] pdu = cast(const(ubyte)[])packet.data;
         if (pdu.length < 8)
             return;
         if ((pdu[0] & 0x1F) != 0)
             return;     // CFM version != 0
-        if (pdu[1] != opcode_lbm)
-            return;     // only the loopback responder is implemented
+        ubyte level = pdu[0] >> 5;
 
-        ubyte[1500] reply = void;
-        size_t len = min(pdu.length, reply.length);
-        reply[0 .. len] = pdu[0 .. len];
-        reply[1] = opcode_lbr;
-        send(packet.eth.src, reply[0 .. len], EtherType.cfm);
+        switch (pdu[1])
+        {
+            case cfm_opcode_lbm:
+            {
+                if (level != _cfm_level)
+                    return;
+                if (packet.eth.dst != mac && packet.eth.dst != cfm_class_multicast(level))
+                    return;
+                size_t tlv_offset = 4 + pdu[3];
+                if (pdu[3] < 4 || tlv_offset > pdu.length)
+                    return;
+
+                ubyte[1500] reply = void;
+                reply[0 .. tlv_offset] = pdu[0 .. tlv_offset];
+                reply[1] = cfm_opcode_lbr;
+                size_t len = tlv_offset + write_sender_id_tlv(reply[tlv_offset .. $]);
+                size_t echo = min(pdu.length - tlv_offset, reply.length - len);
+                reply[len .. len + echo] = pdu[tlv_offset .. tlv_offset + echo];
+                len += echo;
+                if (echo == 0 && len < reply.length)
+                    reply[len++] = 0;   // LBM carried no TLVs; supply the End TLV ourselves
+                send(packet.eth.src, reply[0 .. len], EtherType.cfm);
+                return;
+            }
+
+            case cfm_opcode_lbr:
+            {
+                uint txid = pdu[4 .. 8].bigEndianToNative!uint;
+                foreach (ref p; _pending_pings[])
+                {
+                    if (p.txid != txid)
+                        continue;
+                    Duration rtt = getTime() - p.sent;
+                    p.handler(packet.eth.src, rtt, cfm_sender_identity(pdu));
+                    return;    // the entry stays; it collects further replies until it expires
+                }
+                return;
+            }
+
+            default:
+                return;
+        }
     }
+
+    // chassis id subtype 7 (locally assigned): the mac is already in the frame header, so subtype 4 adds nothing
+    static size_t write_sender_id_tlv(ubyte[] buffer)
+    {
+        import manager.system : hostname;
+
+        const(char)[] name = hostname[];
+        if (name.length > 63)
+            name = name[0 .. 63];
+        if (buffer.length < 5 + name.length)
+            return 0;
+        buffer[0] = cfm_tlv_sender_id;
+        buffer[1 .. 3] = (cast(ushort)(2 + name.length)).nativeToBigEndian;
+        buffer[3] = cast(ubyte)name.length;     // chassis id length (excludes the subtype octet)
+        buffer[4] = 7;                          // chassis id subtype: locally assigned
+        buffer[5 .. 5 + name.length] = cast(const(ubyte)[])name[];
+        return 5 + name.length;
+    }
+
+    // Extract the responder's name from an LBR's Sender ID TLV, if it carries a textual chassis id.
+    static const(char)[] cfm_sender_identity(const(ubyte)[] pdu)
+    {
+        size_t offset = 4 + pdu[3];
+        if (pdu[3] < 4)
+            return null;
+        while (offset + 3 <= pdu.length)
+        {
+            const(ubyte)[] tlv = pdu[offset .. $];
+            if (tlv[0] == 0)
+                return null;    // End TLV
+            ushort len = tlv[1 .. 3].bigEndianToNative!ushort;
+            if (3 + len > tlv.length)
+                return null;
+            if (tlv[0] == cfm_tlv_sender_id && len >= 2)
+            {
+                const(ubyte)[] value = tlv[3 .. 3 + len];
+                ubyte chassis_len = value[0];
+                if (chassis_len >= 1 && 2 + chassis_len <= value.length && value[1] != 4)
+                    return cast(const(char)[])value[2 .. 2 + chassis_len];  // subtype 4 = mac address, not text
+                return null;
+            }
+            offset += 3 + len;
+        }
+        return null;
+    }
+
+    static MACAddress cfm_class_multicast(ubyte level) pure
+        => MACAddress(0x01, 0x80, 0xC2, 0x00, 0x00, cast(ubyte)(0x30 | level));
 
     void station_send_control(OWControl msg, MACAddress dst, scope const(ubyte)[] content)
     {
@@ -397,38 +540,55 @@ private:
         medium_tx(wrapped);
     }
 
-    void station_control(OWControl msg, const(ubyte)[] content, MACAddress src)
+    void station_control(OWControl msg, const(ubyte)[] content, MACAddress src, bool unicast)
     {
         switch (msg)
         {
             case OWControl.who_has:
+            {
                 if (content.length < 8)
                     return;
                 ulong address = content[0 .. 8].bigEndianToNative!ulong;
-                if (station_owns(address))
-                    station_send_control(OWControl.addr_report, src, content[0 .. 8]);
+                if (!station_owns(address))
+                    return;
+                ubyte[5 + 63 + 8] report = void;
+                size_t offset = write_report_head(report, 0);
+                report[offset .. offset + 8] = content[0 .. 8];
+                station_send_control(OWControl.addr_report, src, report[0 .. offset + 8]);
                 return;
+            }
 
             case OWControl.addr_query:
-                if (content.length < 2)
+            {
+                if (content.length < 6)
                     return;
-                ushort type = content[0 .. 2].bigEndianToNative!ushort;
+                uint txid = content[0 .. 4].bigEndianToNative!uint;
+                ushort type = content[4 .. 6].bigEndianToNative!ushort;
                 if (type != PacketType.unknown && type >= PacketType.count)
                     return;
-                ubyte[max_report_entries * 8] entries = void;
-                size_t len = 0;
-                station_list(cast(PacketType)type, (ulong address) {
-                    if (len + 8 <= entries.length)
-                    {
-                        entries[len .. len + 8] = address.nativeToBigEndian;
-                        len += 8;
-                    }
-                });
-                if (len)
-                    station_send_control(OWControl.addr_report, src, entries[0 .. len]);
+                if (unicast)
+                    send_addr_report(src, txid, cast(PacketType)type);
+                else
+                {
+                    // jitter broadcast replies so a populated segment doesn't answer in one synchronised burst
+                    _pending_reports ~= PendingReport(src, txid, cast(PacketType)type, getTime() + (rand() % report_jitter_ms).msecs);
+                }
                 return;
+            }
 
             case OWControl.addr_report:
+            {
+                if (content.length < 5)
+                    return;
+                uint txid = content[0 .. 4].bigEndianToNative!uint;
+                ubyte name_len = content[4];
+                if (content.length < 5 + name_len)
+                    return;
+                const(char)[] name = cast(const(char)[])content[5 .. 5 + name_len];
+                content = content[5 + name_len .. $];
+
+                ulong[report_capacity / 8] addresses = void;
+                size_t count = 0;
                 while (content.length >= 8)
                 {
                     ulong address = content[0 .. 8].bigEndianToNative!ulong;
@@ -436,55 +596,11 @@ private:
                     if (cast(PacketType)(address >> 60) >= PacketType.count)
                         continue;
                     learn(address, src);
+                    if (count < addresses.length)
+                        addresses[count++] = address;
                 }
-                return;
-
-            case OWControl.echo_req:
-            {
-                if (content.length < 5)
-                    return;
-                ubyte[288] reply = void;
-                reply[0 .. 5] = content[0 .. 5];
-                size_t len = 5;
-                if (content[4] & OWEchoFlag.identify)
-                {
-                    // TODO: identity should become the system name once one exists;
-                    //       the internal socket backend's hostname is a placeholder
-                    import urt.socket : get_hostname;
-                    char[64] name = void;
-                    if (!get_hostname(name.ptr, name.length).failed)
-                    {
-                        size_t n = 0;
-                        while (n < name.length && name[n])
-                            ++n;
-                        reply[5 .. 5 + n] = cast(ubyte[])name[0 .. n];
-                        len += n;
-                    }
-                }
-                else
-                {
-                    size_t copy = min(content.length, reply.length) - 5;
-                    reply[5 .. 5 + copy] = content[5 .. 5 + copy];
-                    len += copy;
-                }
-                station_send_control(OWControl.echo_reply, src, reply[0 .. len]);
-                return;
-            }
-
-            case OWControl.echo_reply:
-            {
-                if (content.length < 5)
-                    return;
-                uint cookie = loadBigEndian(cast(const(uint)*)content.ptr);
-                foreach (ref p; _pending_pings[])
-                {
-                    if (p.cookie != cookie)
-                        continue;
-                    Duration rtt = getTime() - p.sent;
-                    const(char)[] identity = (content[4] & OWEchoFlag.identify) ? cast(const(char)[])content[5 .. $] : null;
-                    p.handler(src, rtt, identity);
-                    return;    // the entry stays; broadcast pings collect further replies
-                }
+                if (txid)
+                    sweep_reply(txid, src, name, addresses[0 .. count]);
                 return;
             }
 
@@ -492,16 +608,51 @@ private:
                 return;
         }
     }
+
+    void send_addr_report(MACAddress dst, uint txid, PacketType type)
+    {
+        ubyte[5 + 63 + report_capacity] report = void;   // TODO: segment reports that exceed one frame
+        size_t offset = write_report_head(report, txid);
+        size_t len = offset;
+        station_list(type, (ulong address) {
+            if (len + 8 <= report.length)
+            {
+                report[len .. len + 8] = address.nativeToBigEndian;
+                len += 8;
+            }
+        });
+        if (len > offset || txid)
+            station_send_control(OWControl.addr_report, dst, report[0 .. len]);
+    }
+
+    // [txid:u32][name_len:u8][name]; returns the offset where addresses begin
+    static size_t write_report_head(ubyte[] buffer, uint txid)
+    {
+        import manager.system : hostname;
+
+        const(char)[] name = hostname[];
+        if (name.length > 63)
+            name = name[0 .. 63];
+        buffer[0 .. 4] = txid.nativeToBigEndian;
+        buffer[4] = cast(ubyte)name.length;
+        buffer[5 .. 5 + name.length] = cast(const(ubyte)[])name[];
+        return 5 + name.length;
+    }
 }
 
 
-alias MacPingHandler = void delegate(MACAddress from, Duration rtt, scope const(char)[] identity) nothrow @nogc;
+enum ubyte cfm_opcode_lbr = 2;
+enum ubyte cfm_opcode_lbm = 3;
+enum ubyte cfm_tlv_sender_id = 1;
 
-void mac_ping_cancel(uint cookie)
+alias MacPingHandler = void delegate(MACAddress from, Duration rtt, scope const(char)[] identity) nothrow @nogc;
+alias MacDiscoverHandler = void delegate(MACAddress from, scope const(char)[] identity, scope const(ulong)[] addresses) nothrow @nogc;
+
+void mac_ping_cancel(uint txid)
 {
     foreach (i, ref p; _pending_pings[])
     {
-        if (p.cookie == cookie)
+        if (p.txid == txid)
         {
             _pending_pings.removeSwapLast(i);
             return;
@@ -509,7 +660,29 @@ void mac_ping_cancel(uint cookie)
     }
 }
 
-package void expire_mac_pings()
+// pass the returned txid to discover() on each participating station; reports correlate back until expiry
+uint mac_discover_begin(MacDiscoverHandler handler)
+{
+    uint txid = _next_sweep_txid++;
+    if (_next_sweep_txid == 0)
+        ++_next_sweep_txid;
+    _pending_sweeps ~= PendingSweep(txid, getTime(), handler);
+    return txid;
+}
+
+void mac_discover_cancel(uint txid)
+{
+    foreach (i, ref s; _pending_sweeps[])
+    {
+        if (s.txid == txid)
+        {
+            _pending_sweeps.removeSwapLast(i);
+            return;
+        }
+    }
+}
+
+package void expire_mac_probes()
 {
     MonoTime now = getTime();
     for (size_t i = _pending_pings.length; i-- > 0; )
@@ -517,17 +690,42 @@ package void expire_mac_pings()
         if (now - _pending_pings[i].sent >= 10.seconds)
             _pending_pings.removeSwapLast(i);
     }
+    for (size_t i = _pending_sweeps.length; i-- > 0; )
+    {
+        if (now - _pending_sweeps[i].begun >= 10.seconds)
+            _pending_sweeps.removeSwapLast(i);
+    }
+}
+
+private void sweep_reply(uint txid, MACAddress from, scope const(char)[] identity, scope const(ulong)[] addresses)
+{
+    foreach (ref s; _pending_sweeps[])
+    {
+        if (s.txid != txid)
+            continue;
+        s.handler(from, identity, addresses);
+        return;
+    }
 }
 
 private struct PendingPing
 {
-    uint cookie;
+    uint txid;
     MonoTime sent;
     MacPingHandler handler;
 }
 
+private struct PendingSweep
+{
+    uint txid;
+    MonoTime begun;
+    MacDiscoverHandler handler;
+}
+
 private __gshared Array!PendingPing _pending_pings;
-private __gshared uint _next_ping_cookie = 1;
+private __gshared uint _next_ping_txid = 1;
+private __gshared Array!PendingSweep _pending_sweeps;
+private __gshared uint _next_sweep_txid = 1;
 
 
 abstract class EthernetInterface : EthernetStation
@@ -617,4 +815,32 @@ protected:
     // Subclass hook: push a fully-framed ethernet frame onto the wire.
     // Return 0 on success, non-zero on failure (already logged by the subclass).
     abstract int wire_send(const(ubyte)[] frame);
+}
+
+
+unittest
+{
+    import manager.system : hostname;
+
+    ubyte[96] pdu = void;
+    pdu[0] = 7 << 5;
+    pdu[1] = cfm_opcode_lbr;
+    pdu[2] = 0;
+    pdu[3] = 4;
+    pdu[4 .. 8] = 0;
+    size_t len = 8 + EthernetStation.write_sender_id_tlv(pdu[8 .. $]);
+    assert(len > 8);
+    pdu[len++] = 0;
+    assert(EthernetStation.cfm_sender_identity(pdu[0 .. len]) == hostname[]);
+
+    // a mac-address chassis id is not a textual identity
+    ubyte[16] mac_pdu = [7 << 5, cfm_opcode_lbr, 0, 4,  0, 0, 0, 0,  cfm_tlv_sender_id, 0, 5,  3, 4, 0xAA, 0xBB, 0];
+    assert(EthernetStation.cfm_sender_identity(mac_pdu[]) == null);
+
+    // a report head round-trips through the addr_report field layout
+    ubyte[76] report = void;
+    size_t offset = EthernetStation.write_report_head(report, 0x12345678);
+    assert(report[0 .. 4].bigEndianToNative!uint == 0x12345678);
+    assert(report[4] == hostname.length);
+    assert(cast(const(char)[])report[5 .. offset] == hostname[]);
 }

--- a/src/router/iface/package.d
+++ b/src/router/iface/package.d
@@ -748,27 +748,31 @@ nothrow @nogc:
 
     override void post_init()
     {
-        // post_init: the platform ethernet collections own the scope by now, so this extends it
+        // post_init: the platform ethernet collections own the scope by now, so these extend it
         g_app.console.register_command!mac_ping("/interface/ethernet", this, "ping");
+        g_app.console.register_command!mac_discover("/interface/ethernet", this, "discover");
     }
 
     override void update()
     {
         Collection!BaseInterface().update_all();
         update_ether_endpoints();
-        expire_mac_pings();
+        expire_mac_probes();
     }
 
-    MacPingState mac_ping(Session session, MACAddress address, Nullable!uint count, Nullable!bool identify)
+    MacPingState mac_ping(Session session, MACAddress address, Nullable!uint count)
     {
         if (!address)
         {
             session.write_line("ping requires a destination mac address");
             return null;
         }
-        return g_app.allocator.allocT!MacPingState(session, address,
-                                                   identify ? identify.value : true,
-                                                   count ? count.value : 4);
+        if (address.is_multicast)
+        {
+            session.write_line("ping is unicast; use discover to enumerate the segment");
+            return null;
+        }
+        return g_app.allocator.allocT!MacPingState(session, address, count ? count.value : 4);
     }
 
     static class MacPingState : CommandState
@@ -778,18 +782,16 @@ nothrow @nogc:
         CommandCompletionState state = CommandCompletionState.in_progress;
 
         MACAddress dst;
-        bool identify;
         uint count;
         uint sent;
         uint replies;
         MonoTime last_send;
-        Array!uint cookies;
+        Array!uint txids;
 
-        this(Session session, MACAddress dst, bool identify, uint count)
+        this(Session session, MACAddress dst, uint count)
         {
             super(session, null);
             this.dst = dst;
-            this.identify = identify;
             this.count = count ? count : 1;
             send_round();
         }
@@ -829,15 +831,15 @@ nothrow @nogc:
             last_send = getTime();
             foreach_ether_station((EthernetStation s) {
                 if (s.running)
-                    cookies ~= s.ping(dst, identify, &on_reply);
+                    txids ~= s.ping(dst, &on_reply);
             });
         }
 
         void cancel_round()
         {
-            foreach (c; cookies[])
-                mac_ping_cancel(c);
-            cookies.clear();
+            foreach (t; txids[])
+                mac_ping_cancel(t);
+            txids.clear();
         }
 
         void on_reply(MACAddress from, Duration rtt, scope const(char)[] identity)
@@ -847,6 +849,80 @@ nothrow @nogc:
                 session.write_line("reply from ", from, ": time=", rtt, " \"", identity, "\"");
             else
                 session.write_line("reply from ", from, ": time=", rtt);
+        }
+    }
+
+    MacDiscoverState mac_discover(Session session)
+    {
+        return g_app.allocator.allocT!MacDiscoverState(session);
+    }
+
+    static class MacDiscoverState : CommandState
+    {
+    nothrow @nogc:
+
+        CommandCompletionState state = CommandCompletionState.in_progress;
+
+        uint txid;
+        MonoTime begun;
+        Array!MACAddress seen;
+
+        this(Session session)
+        {
+            super(session, null);
+            begun = getTime();
+            txid = mac_discover_begin(&on_report);
+            foreach_ether_station((EthernetStation s) {
+                if (s.running)
+                    s.discover(txid);
+            });
+        }
+
+        override CommandCompletionState update()
+        {
+            if (state == CommandCompletionState.cancel_requested)
+            {
+                mac_discover_cancel(txid);
+                state = CommandCompletionState.cancelled;
+                return state;
+            }
+            if (getTime() - begun >= 2.seconds)
+            {
+                mac_discover_cancel(txid);
+                session.write_line(seen.length, " stations found");
+                state = CommandCompletionState.finished;
+            }
+            return state;
+        }
+
+        override void request_cancel()
+        {
+            if (state == CommandCompletionState.in_progress)
+                state = CommandCompletionState.cancel_requested;
+        }
+
+    private:
+        void on_report(MACAddress from, scope const(char)[] identity, scope const(ulong)[] addresses)
+        {
+            // stations answer each of our querying stations; report each responder once
+            foreach (m; seen[])
+            {
+                if (m == from)
+                    return;
+            }
+            seen ~= from;
+
+            if (identity.length)
+                session.write_line(from, " \"", identity, "\"");
+            else
+                session.write_line(from);
+            foreach (a; addresses)
+            {
+                import urt.conv : format_uint;
+                char[15] hex = void;
+                ptrdiff_t len = format_uint(a & 0x0FFF_FFFF_FFFF_FFFF, hex, 16, 15, '0');
+                session.write_line("    ", cast(PacketType)(a >> 60), ":", hex[0 .. len]);
+            }
         }
     }
 

--- a/src/router/iface/packet.d
+++ b/src/router/iface/packet.d
@@ -57,15 +57,8 @@ enum ushort ow_control_flag = 0x8000;
 enum OWControl : ushort
 {
     who_has     = ow_control_flag | 0x0001,  // body: universal address (u64 BE) -- which station carries this?
-    addr_query  = ow_control_flag | 0x0002,  // body: PacketType (u16 BE, unknown = all) -- report your addresses
-    addr_report = ow_control_flag | 0x0003,  // body: N x universal address (u64 BE) -- response to either of the above
-    echo_req    = ow_control_flag | 0x0004,  // body: [cookie:u32 BE][flags:u8][payload] -- mac ping / discovery probe
-    echo_reply  = ow_control_flag | 0x0005,  // body: cookie+flags echoed, then payload echo (or identity when requested)
-}
-
-enum OWEchoFlag : ubyte
-{
-    identify = 1 << 0,  // reply carries the responder's identity instead of echoing the payload
+    addr_query  = ow_control_flag | 0x0002,  // body: [txid:u32 BE][PacketType:u16 BE, unknown = all] -- report your addresses
+    addr_report = ow_control_flag | 0x0003,  // body: [txid:u32 BE, 0 = unsolicited][name_len:u8][name][N x universal address (u64 BE)]
 }
 
 // 802.1p PCP traffic classes


### PR DESCRIPTION
Unicast reachability moves to standard 802.1ag CFM; broadcast enumeration moves to the
existing addr_query/addr_report pair. The OW echo control messages are retired.

## Unicast: OW echo -> CFM loopback

`echo_req`/`echo_reply`/`OWEchoFlag` are gone. Every field OW echo invented has a native
CFM home, so nothing is wrapped in a TLV:

- cookie -> Loopback Transaction Identifier (the 4-byte field LBM/LBR already carry)
- identity -> Sender ID TLV (type 1), always present in our LBRs; the `identify` request
  flag disappears

Chassis ID subtype is 7 (locally assigned) carrying the `/system` hostname, resolving the
TODO in the old echo handler. The MAC is already in the frame header, so subtype 4 would
have added nothing. Third-party TLVs in an LBM are echoed through untouched.

Ping now interoperates with real CFM gear in both directions.

## Responder: no longer a rogue MIP

The old responder answered any LBM at any MD level from any source. On a network with
provisioned CFM that corrupts someone else's maintenance domain. It now answers only at
the level it claims, and only when addressed to its own MAC or that level's class
multicast (01:80:C2:00:00:3x).

New per-station `cfm-level` property (0-7, default 7, conventional for customer/edge
equipment). It sits on `EthernetStation`, so bridge/vlan/wifi/udp interfaces inherit it.

## Broadcast: discovery via addr_query/addr_report

- `addr_report` carries the system name, covering what `identify` did
- `addr_query` carries a transaction id, echoed in the report, so replies correlate to a
  sweep and stale replies from an earlier sweep are discarded (txid 0 = unsolicited:
  link-up priming and who_has answers)
- broadcast replies are jittered over 0-250ms, flushed from `update()`; unicast queries
  still answer immediately. Previously every station answered a broadcast instantly, a
  synchronised storm on a populated segment.

Wire change to `addr_report` is acceptable: the OW ethertype is ours and experimental,
with no third-party implementations.

Not CFM, deliberately: LBM is point-to-point, so a broadcast LBM gains no third-party
responders; the standard's discovery answer is CCM, which is provisioned and continuous,
far heavier than an on-demand operator sweep.

## CLI

- `/interface/ethernet/ping address=<mac> [count=]` - unicast only, drops `identify=`,
  rejects multicast with a pointer at `discover`
- `/interface/ethernet/discover` - broadcast sweep, dedupes responders, prints each
  station's MAC, name, and typed universal addresses

RTT is intentionally absent from `discover`: reply jitter makes it meaningless. `ping` is
the RTT tool.

## Incidental fix

The old report path built up to 1440 bytes of entries while the control-frame send caps
at ~507, so large reports were silently dropped. Reports are now sized to fit; the
segmentation TODO remains.

## Testing

Clean debug build; 126/126 modules pass `CONFIG=unittest`, including a new test covering
the Sender ID TLV round-trip, MAC-subtype rejection, and report head layout.

Not verified: live two-node behaviour, and interop against real CFM gear. Wants a session
on the Pi pair.
