### PR TITLE
udp: make the connected endpoint actually filter

### DIFF
--- a/src/protocol/ip/package.d
+++ b/src/protocol/ip/package.d
@@ -533,6 +533,15 @@ UDPEndpoint* udp_open(const(InetAddress)* local, const(InetAddress)* remote, UDP
             ws_closesocket(s);
             return null;
         }
+        if (remote)
+        {
+            sockaddr_in ra = to_sockaddr_in(*remote);
+            if (ws_connect(s, &ra, cast(int)sockaddr_in.sizeof) != 0)
+            {
+                ws_closesocket(s);
+                return null;
+            }
+        }
         UDPEndpoint* ep = defaultAllocator().allocT!UDPEndpoint();
         ep._handle = s;
         ep._on_recv = on_recv;
@@ -570,10 +579,17 @@ UDPEndpoint* udp_open(const(InetAddress)* local, const(InetAddress)* remote, UDP
             return null;
         }
 
+        bool connect_peer = remote && (remote.family == AddressFamily.ipv4 || remote.family == AddressFamily.ipv6);
+        if (connect_peer && s.connect(*remote).failed)
+        {
+            s.close();
+            return null;
+        }
+
         UDPEndpoint* ep = defaultAllocator().allocT!UDPEndpoint();
         ep._socket = s;
         ep._on_recv = on_recv;
-        if (remote && (remote.family == AddressFamily.ipv4 || remote.family == AddressFamily.ipv6))
+        if (connect_peer)
         {
             ep._remote = *remote;
             ep._connected = true;
@@ -1455,6 +1471,8 @@ nothrow @nogc:
         {
             if (_closing)
                 return 0;
+            if (_connected)
+                return to == _remote ? send(data) : 0;   // connected: the peer is the only destination
             if (_ether)
             {
                 const(InetAddress.Ether)* e = to.as_ether;
@@ -1506,6 +1524,8 @@ nothrow @nogc:
         {
             if (_closing)
                 return 0;
+            if (_connected)
+                return dst == _remote ? send(data) : 0;   // connected: the peer is the only destination
             if (_ether)
             {
                 const(InetAddress.Ether)* e = dst.as_ether;
@@ -1564,6 +1584,8 @@ nothrow @nogc:
         {
             if (_closing)
                 return 0;
+            if (_connected)
+                return to == _remote ? send(data) : 0;   // connected: the peer is the only destination
             if (_ether)
             {
                 const(InetAddress.Ether)* e = to.as_ether;
@@ -2112,6 +2134,7 @@ else version (Windows)
     enum uint WSA_FLAG_OVERLAPPED = 0x01;
     pragma(mangle, "WSASocketW")  extern(Windows) IOCP_SOCKET ws_socket(int af, int type, int protocol, void* protoInfo, uint group, uint flags) nothrow @nogc;
     pragma(mangle, "bind")        extern(Windows) int ws_bind(IOCP_SOCKET, const(void)*, int) nothrow @nogc;
+    pragma(mangle, "connect")     extern(Windows) int ws_connect(IOCP_SOCKET, const(void)*, int) nothrow @nogc;
     pragma(mangle, "listen")      extern(Windows) int ws_listen(IOCP_SOCKET, int) nothrow @nogc;
     pragma(mangle, "closesocket") extern(Windows) int ws_closesocket(IOCP_SOCKET) nothrow @nogc;
     pragma(mangle, "shutdown")    extern(Windows) int ws_shutdown(IOCP_SOCKET, int) nothrow @nogc;


### PR DESCRIPTION
`udp_open` takes a remote and sets `_connected`, and `/interface/udp` documents a unicast remote as "the endpoint is opened connected, so rx is filtered to that peer" -- but on the host paths nothing ever connected the socket. Windows posted `WSARecvFrom` and posix ran `recvfrom`, both delivering datagrams from any source. Only the in-tree stack (`udp_input`) and the ether endpoint honoured the peer, so the same config filtered on an embedded target and was wide open on Windows and Linux.

Fixes it where the OS can do the work: `connect()` the datagram socket on both host paths, so the kernel drops strays before they ever reach us. The software stacks already apply their own peer check and are untouched -- no duplicated filtering.

A connected socket can't portably `sendto()` an arbitrary address, so `sendto` now routes through the connected path and refuses a destination other than the peer; per-frame addressing stays available on unconnected (multi-drop) endpoints, which is where it means something.

Verified end to end on Windows with `/interface/udp` (unicast remote 127.0.0.1:7102, local 7101), sending 3 datagrams from the peer port and 3 from a stranger:

| | peer 7102 | stranger 7999 |
|---|---|---|
| before | 3 frames delivered | 3 frames delivered (60B/6 total) |
| after | 3 frames delivered | dropped (30B/3 total) |

Both IP stack configurations build (`USE_INTERNAL_IP_STACK=0/1`) and the unit tests pass. The posix `connect()` path is compiled but not yet exercised on hardware.