### PR TITLE
Filesystem-backed configuration for embedded targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ Collections are the backbone of runtime object management. Key features:
 
 **Property type support:** The property system automatically converts CLI arguments to typed properties via `convertVariant()` functions in [src/manager/console/argument.d](src/manager/console/argument.d). Supported types include:
 - Primitives: `bool`, integers, floats, strings
-- Time types: `Duration` (with unit parsing: "5m", "30s"), `SysTime` (Unix timestamps)
+- Time types: `Duration` (with unit parsing: "5m", "30s"), `SysTime` (ISO-8601 date-times: 2026-08-10T12:00:00)
 - Complex types: enums, arrays, Collection references (BaseObject, Device, Component, Stream, Interface)
 - Custom types can be added by implementing `convertVariant()` function
 

--- a/Makefile
+++ b/Makefile
@@ -484,7 +484,8 @@ endif
 		idf.py -B "$(ESP_BUILD_DIR)" -DIDF_TARGET=$(ESP_IDF_TARGET) \
 			-DSDKCONFIG="$(ESP_SDKCONFIG)" -DSDKCONFIG_DEFAULTS="$(ESP_SDKCONFIG_DEFAULTS)" \
 			-DOPENWATT_OBJ=$(abspath $(ESP_LINK_OBJ)) \
-			-DUSE_LWIP=$(if $(filter 1,$(USE_INTERNAL_IP_STACK)),0,1) build'
+			-DUSE_LWIP=$(if $(filter 1,$(USE_INTERNAL_IP_STACK)),0,1) \
+			-DUSE_SPIFFS=$(USE_SPIFFS) -DUSE_LITTLEFS=$(USE_LITTLEFS) build'
 	cp "$(ESP_BUILD_DIR)/openwatt.bin" "$(TARGETDIR)/openwatt.bin"
 	cp "$(ESP_BUILD_DIR)/bootloader/bootloader.bin" "$(TARGETDIR)/bootloader.bin"
 	cp "$(ESP_BUILD_DIR)/partition_table/partition-table.bin" "$(TARGETDIR)/partition-table.bin"

--- a/platforms/esp32-common/main.cmake
+++ b/platforms/esp32-common/main.cmake
@@ -23,16 +23,38 @@ if(USE_LWIP)
 endif()
 list(APPEND MAIN_PRIV_REQUIRES esp_driver_uart)
 list(APPEND MAIN_PRIV_REQUIRES esp_driver_ledc esp_driver_spi esp_driver_gptimer esp_adc)
+# Unconditional: IDF collects PRIV_REQUIRES during an early expansion pass that
+# cannot see -D cache variables, so gating this on USE_SPIFFS silently drops it.
+# The component is only referenced when OW_USE_SPIFFS is defined below, so an
+# unused spiffs is discarded at link time.
+list(APPEND MAIN_PRIV_REQUIRES spiffs esp_partition)
 if(OW_EXTRA_REQUIRES)
     list(APPEND MAIN_PRIV_REQUIRES ${OW_EXTRA_REQUIRES})
 endif()
 
+set(LITTLEFS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/urt/third_party/littlefs")
+
 idf_component_register(SRCS "${ESP32_SYS_DIR}/main.c"
                             "${ESP32_SYS_DIR}/ow_shim.c"
+                            "${ESP32_SYS_DIR}/littlefs_port.c"
+                            "${LITTLEFS_DIR}/lfs.c"
+                            "${LITTLEFS_DIR}/lfs_util.c"
                             "${URT_INTERNAL_DIR}/mbedtls.c"
                        INCLUDE_DIRS ""
                        PRIV_REQUIRES ${MAIN_PRIV_REQUIRES}
                        WHOLE_ARCHIVE)
+
+if(USE_SPIFFS)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE OW_USE_SPIFFS=1)
+endif()
+
+# littlefs talks to esp_partition directly, so it needs no VFS and no newlib.
+# LFS_NO_DEBUG/_WARN keep its logging out of the image; asserts stay on.
+target_include_directories(${COMPONENT_LIB} PRIVATE "${LITTLEFS_DIR}")
+target_compile_definitions(${COMPONENT_LIB} PRIVATE LFS_NO_DEBUG LFS_NO_WARN)
+if(USE_LITTLEFS)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE OW_USE_LITTLEFS=1)
+endif()
 
 # Makefile typically passes OPENWATT_OBJ via -D; fall back to the debug path
 # under bin/<buildname>_debug/ for direct idf.py invocations.

--- a/platforms/esp32s3/boards/waveshare-esp32-s3-rs485-can/board.mk
+++ b/platforms/esp32s3/boards/waveshare-esp32-s3-rs485-can/board.mk
@@ -2,3 +2,6 @@
 BOARD_PLATFORM := esp32-s3
 BOARD_FLASH_SIZE := 16MB
 BOARD_PSRAM_SIZE := 8MB
+
+# Turns SPIFFS off, so the storage partition is littlefs alone.
+USE_LITTLEFS := 1

--- a/platforms/esp32s3/boards/waveshare-esp32-s3-rs485-can/default.conf
+++ b/platforms/esp32s3/boards/waveshare-esp32-s3-rs485-can/default.conf
@@ -1,0 +1,30 @@
+# Waveshare ESP32-S3-RS485-CAN bring-up defaults
+#
+# What the board does with nothing configured yet: offer a provisioning AP and
+# enough services to upload a startup.conf. A startup.conf on the filesystem
+# replaces this file; system.conf still applies underneath either way.
+#
+# Deliberately no station config: the site's network belongs in the uploaded
+# startup.conf, not in a firmware image in a public repository.
+
+# The provisioning credential is intentionally well-known. Replace it before
+# installing the unit on an untrusted network.
+/secret/add name=setup password=openwatt-setup services=admin,wifi,rpcap
+
+/interface/ap add name=setup radio=wifi1 ssid="OpenWatt-Waveshare" auth=wpa2 secret=setup max-clients=4
+/protocol/ip/address/add address="192.168.4.1/24" interface=setup
+/protocol/ip/route/add destination="192.168.4.0/24" out-interface=setup
+/protocol/ip/pool/add name=setup start=192.168.4.10 end=192.168.4.50
+/protocol/dhcp/server/add name=setup interface=setup pool=setup add-default-gateway=false
+
+/protocol/telnet/server/add name=console port=23
+
+/protocol/http/server/add name=webserver port=80
+/apps/api/add name=api http-server=webserver uri=/api
+/apps/ota/add name=ota http-server=webserver uri=/ota commit-time=30s
+/sync/ws-server/add name=sync http-server=webserver uri=/sync
+
+# Serves and accepts the filesystem; this is how startup.conf gets uploaded.
+/protocol/http/static/add name=files http-server=webserver uri=/files root=""
+
+/tools/pcap/server/add name=rpcap port=2002 allow-anonymous=false

--- a/platforms/esp32s3/boards/waveshare-esp32-s3-rs485-can/system.conf
+++ b/platforms/esp32s3/boards/waveshare-esp32-s3-rs485-can/system.conf
@@ -1,53 +1,31 @@
-# Waveshare ESP32-S3-RS485-CAN bring-up configuration
+# Waveshare ESP32-S3-RS485-CAN platform definition
+#
+# What the board *is*: consoles, buses, pins, radios. This layer always applies,
+# whether the board is running its bring-up defaults or a startup.conf uploaded
+# to the filesystem, so a deployment config never has to restate the hardware.
+#
+# Bring-up state (provisioning AP, servers) lives in default.conf.
 #
 # Hardware:
 #   RS485 UART1: TX=GPIO17 RX=GPIO18 DE/RE=GPIO21
 #   CAN TWAI0:   TX=GPIO15 RX=GPIO16
 #   PCF85063:    SCL=GPIO38 SDA=GPIO39 INT=GPIO40
-#
-# The setup credential is intentionally only for bench bring-up. Replace it
-# before installing the unit on an untrusted network.
 
 /stream/usb-serial/add name=console
 /console/session/add name=default stream=console profile=vt100 initial-command="/log/print --stream"
+
+/system/update-rate rate=20
+/system/log-level severity=trace
 
 /interface/i2c/add name=i2c0 device=i2c0 frequency=100000 sda-gpio=39 scl-gpio=38
 /driver/rtc/pcf85063/add name=rtc interface=i2c0 address=0x51
 :wait on="object:rtc?state=online" timeout=1s
 
-/system/update-rate rate=20
-/system/log-level severity=trace
-
-/secret/add name=setup password=openwatt-setup services=admin,wifi,rpcap
-/secret/add name=dangerzone password=ChodeChode69 services=wifi
-
-# Wi-Fi station on the main LAN, with the isolated setup AP retained for recovery.
-/interface/wifi add name=wifi1 channel=6
-/interface/wlan add name=wlan1 radio=wifi1 ssid="Danger Zone" secret=dangerzone
-/protocol/dhcp/client/add name=lan interface=wlan1 add-default-route=true
-
-/interface/ap add name=setup radio=wifi1 ssid="OpenWatt-Waveshare" auth=wpa2 secret=setup max-clients=4
-/protocol/ip/address/add address="192.168.4.1/24" interface=setup
-/protocol/ip/route/add destination="192.168.4.0/24" out-interface=setup
-/protocol/ip/pool/add name=setup start=192.168.4.10 end=192.168.4.50
-/protocol/dhcp/server/add name=setup interface=setup pool=setup add-default-gateway=false
-
-# Isolated RS485 port. The transceiver uses a shared active-high DE/RE signal.
+# The transceiver uses a shared active-high DE/RE signal. What speaks on the bus
+# is deployment configuration; the port itself is the board.
 /stream/serial/add name=rs485 device=uart1 baud-rate=9600 tx-gpio=17 rx-gpio=18 de-gpio=21
-/interface/modbus/add name=rs485 stream=rs485 protocol=rtu master=false
-/interface/modbus/remote-server/add name=pt100 interface=rs485 address=1 profile=pt100_temp
-/protocol/modbus/node/add name=pt100-client interface=rs485 snoop=true
 
-# Isolated CAN 2.0 port through the ESP32-S3 TWAI controller.
 /interface/can/add name=can0 device=twai0 baud-rate=500000 tx-gpio=15 rx-gpio=16
 
-# BLE radio ble1 is created automatically and scans while Wi-Fi remains active.
-
-/protocol/telnet/server/add name=console port=23
-
-/protocol/http/server/add name=webserver port=80
-/apps/api/add name=api http-server=webserver uri=/api
-/apps/ota/add name=ota http-server=webserver uri=/ota commit-time=30s
-/sync/ws-server/add name=sync http-server=webserver uri=/sync
-
-/tools/pcap/server/add name=rpcap port=2002 allow-anonymous=false
+# The BLE radio ble1 is created automatically.
+/interface/wifi add name=wifi1 channel=6

--- a/platforms/esp32s3/sdkconfig.defaults
+++ b/platforms/esp32s3/sdkconfig.defaults
@@ -10,9 +10,11 @@ CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
 # No ESP-IDF logging -- OpenWatt has its own log system
 CONFIG_LOG_DEFAULT_LEVEL_NONE=y
 
-# No VFS layer (virtual filesystem for stdio redirection)
-CONFIG_VFS_SUPPORT_IO=n
-CONFIG_VFS_SUPPORT_DIR=n
+# VFS: IO and DIR carry the newlib file syscalls that urt.file's SPIFFS backend
+# rides on. Without IO, open() is a stub returning ENOSYS even though a
+# filesystem is mounted. SELECT stays off; nothing selects on files.
+CONFIG_VFS_SUPPORT_IO=y
+CONFIG_VFS_SUPPORT_DIR=y
 CONFIG_VFS_SUPPORT_SELECT=n
 
 # FreeRTOS tuning

--- a/src/apps/ota/package.d
+++ b/src/apps/ota/package.d
@@ -139,6 +139,9 @@ protected:
         return CompletionStatus.complete;
     }
 
+    // TODO: move this checkpoint to the main app, ahead of config execution.
+    // Marking valid from here judges the image by "the configured system stayed
+    // up", so a bad config costs a firmware rollback.
     override void update()
     {
         if (!_committed && getAppTime() >= _commit_time)

--- a/src/main.d
+++ b/src/main.d
@@ -9,6 +9,7 @@ import urt.system;
 import urt.time;
 
 import manager;
+import manager.bootguard;
 import manager.collection;
 import manager.console.session : Session, default_console_session_name;
 import manager.log : default_log_sink_name, format_log_text,
@@ -46,6 +47,7 @@ int main(string[] args)
     // parse command line arguments
     bool interactive_mode = false;
     const(char)[] config_path = "conf/startup.conf";
+    bool config_path_explicit = false;
     const(char)[] profile_path;
     for (size_t i = 1; i < args.length; ++i)
     {
@@ -54,7 +56,10 @@ int main(string[] args)
         else if (args[i] == "--config" || args[i] == "-c")
         {
             if (i + 1 < args.length)
+            {
                 config_path = args[++i];
+                config_path_explicit = true;
+            }
         }
         else if (args[i] == "--profile-path")
         {
@@ -127,8 +132,9 @@ int main(string[] args)
 
     // Config layering:
     //   1. process defaults - generated CLI commands
-    //   2. system.conf      - platform defaults
-    //   3. startup.conf     - regular configuration (--config overrides path)
+    //   2. system.conf      - the platform itself; always applies
+    //   3. default.conf     - bring-up state, used only when there is no startup.conf
+    //      or startup.conf  - regular configuration (--config overrides path)
     //   4. user.conf        - personal overrides
     //   5. process session  - generated CLI commands
 
@@ -136,6 +142,12 @@ int main(string[] args)
         static immutable system_conf = import("system.conf");
     else
         enum system_conf = "";
+
+    // Not every platform has split its bring-up state out yet.
+    static if (__traits(compiles, import("default.conf")))
+        static immutable default_conf = import("default.conf");
+    else
+        enum default_conf = "";
 
     // combine all layers
     Array!char combined_config;
@@ -148,6 +160,18 @@ int main(string[] args)
         if (interactive_mode)
             append_interactive_session_defaults(combined_config);
     }
+
+    // An explicit --config is a human decision and is not second-guessed.
+    bool trust_config = true;
+    if (!config_path_explicit && !boot_config_trusted())
+    {
+        trust_config = false;
+        retire_config(config_path);
+    }
+    char[] conf = trust_config ? cast(char[])load_file(config_path) : null;
+
+    if (conf is null && config_path_explicit)
+        log_error("system", "config '", config_path, "' could not be loaded");
 
     static if (system_conf.length > 0)
     {
@@ -167,13 +191,23 @@ int main(string[] args)
         }
     }
 
-    char[] conf = cast(char[])load_file(config_path);
     if (conf !is null)
     {
+        static if (default_conf.length > 0)
+            log_info("system", "using startup.conf from the filesystem; bring-up defaults skipped");
         combined_config ~= conf;
         combined_config ~= '\n';
         defaultAllocator().free(conf);
         loaded_configuration = true;
+    }
+    else if (!config_path_explicit)
+    {
+        static if (default_conf.length > 0)
+        {
+            combined_config ~= default_conf;
+            combined_config ~= '\n';
+            loaded_configuration = true;
+        }
     }
 
     char[] user_conf = cast(char[])load_file("conf/user.conf");
@@ -230,6 +264,8 @@ int main(string[] args)
 
     while (keep_running)
     {
+        boot_guard_update();
+
         // handle any expired timers (heartbeat-driven update() lives in here).
         MonoTime next_deadline = g_app.process_due();
 

--- a/src/manager/bootguard.d
+++ b/src/manager/bootguard.d
@@ -1,0 +1,104 @@
+module manager.bootguard;
+
+// Counted in NVS, not on the filesystem this may have to roll back. Cutting
+// power a few times in a row is therefore also the manual factory reset.
+
+import urt.driver.nvs;
+import urt.log;
+import urt.result : SizeResult;
+import urt.time;
+
+nothrow @nogc:
+
+
+enum uint max_config_boot_failures = 3;
+enum Duration healthy_uptime = 60.seconds;
+
+
+// Call once, before loading any configuration.
+bool boot_config_trusted()
+{
+    static if (!has_nvs)
+        return true;
+    else
+    {
+        uint failures = read_counter();
+        if (failures >= max_config_boot_failures)
+        {
+            log_warning("system", "filesystem config ignored after ", failures,
+                        " failed boots; falling back to the built-in config");
+            return false;
+        }
+        write_counter(failures + 1);
+        return true;
+    }
+}
+
+// Renamed rather than deleted, so the operator can still see what broke.
+void retire_config(const(char)[] path)
+{
+    static if (has_nvs)
+    {
+        import urt.file : file_exists, rename_file;
+        import urt.mem.temp : tconcat;
+
+        if (!file_exists(path))
+            return;
+        const(char)[] retired = tconcat(path, ".bad");
+        if (rename_file(path, retired))
+            log_warning("system", "moved '", path, "' aside as '", retired, "'");
+        else
+            log_warning("system", "could not move '", path, "' aside; it will be retried");
+    }
+}
+
+// Safe to call every frame; touches NVS once.
+void boot_guard_update()
+{
+    static if (has_nvs)
+    {
+        if (_cleared || getAppTime() < healthy_uptime)
+            return;
+        _cleared = true;
+        uint failures = read_counter();
+        if (failures != 0)
+        {
+            log_info("system", "boot succeeded; clearing ", failures, " recorded boot failure(s)");
+            write_counter(0);
+        }
+    }
+}
+
+
+private:
+
+static if (has_nvs)
+{
+    __gshared bool _cleared;
+
+    enum const(char)[] nvs_namespace = "openwatt";
+    enum const(char)[] nvs_key = "boot_fail";
+
+    uint read_counter()
+    {
+        Nvs nvs;
+        if (!nvs_open(nvs, nvs_namespace, NvsOpenMode.read_only))
+            return 0;
+        scope(exit) nvs_close(nvs);
+
+        uint value = 0;
+        SizeResult r = nvs_read(nvs, nvs_key, (&value)[0 .. 1]);
+        return r ? value : 0;
+    }
+
+    void write_counter(uint value)
+    {
+        Nvs nvs;
+        if (!nvs_open(nvs, nvs_namespace, NvsOpenMode.read_write))
+            return;
+        scope(exit) nvs_close(nvs);
+
+        if (nvs_write(nvs, nvs_key, (&value)[0 .. 1]))
+            nvs_commit(nvs);
+    }
+}

--- a/src/manager/package.d
+++ b/src/manager/package.d
@@ -44,6 +44,9 @@ import manager.secret;
 import manager.signal;
 import manager.system;
 
+version (UseSpiffs)   version = HasFilesystem;
+version (UseLittleFS) version = HasFilesystem;
+
 nothrow @nogc:
 
 
@@ -464,6 +467,15 @@ nothrow @nogc:
         console.register_command!show_time("/system", this, "time");
         console.register_command!sleep("/system", this);
         console.register_command!reboot("/system", this);
+
+        version (HasFilesystem)
+        {
+            console.register_command!fs_format("/system/fs", this, "format");
+            console.register_command!fs_info("/system/fs", this, "info");
+            console.register_command!fs_write("/system/fs", this, "write");
+            console.register_command!fs_read("/system/fs", this, "read");
+            console.register_command!fs_rm("/system/fs", this, "rm");
+        }
 
         version (AllocTracking)
         {

--- a/src/manager/system.d
+++ b/src/manager/system.d
@@ -159,6 +159,117 @@ void reboot(Session session)
     system_reboot();
 }
 
+version (UseSpiffs)   version = HasFilesystem;
+version (UseLittleFS) version = HasFilesystem;
+
+version (HasFilesystem)
+{
+    import urt.file : delete_file, load_file, save_file;
+    import urt.result : Result;
+    import manager.console.command : CommandState, CommandCompletionState;
+
+    // Whichever backend is built; littlefs wins when both are.
+    version (UseLittleFS)
+    {
+        import urt.fs.littlefs;
+        private alias Fs = LittleFsBackend;
+        private alias FsFormatState = LittleFsFormatState;
+    }
+    else
+    {
+        import urt.fs.spiffs;
+        private alias Fs = SpiffsBackend;
+        private alias FsFormatState = SpiffsFormatState;
+    }
+
+    void fs_info(Session session)
+    {
+        ulong total, used;
+        if (!Fs.info(total, used))
+        {
+            session.write_line(Fs.name, ": not mounted (last error ", Fs.last_error(), ")");
+            return;
+        }
+        session.write_line(Fs.name, ": ", used, " / ", total, " bytes used, ", total - used, " free");
+        version (UseLittleFS)
+            session.write_line("open handles: ", Fs.open_handles());
+    }
+
+    void fs_write(Session session, const(char)[] name, const(char)[] text)
+    {
+        Result r = save_file(name, cast(const(void)[])text);
+        if (r)
+            session.write_line("wrote ", text.length, " bytes to '", name, "'");
+        else
+            session.write_line("write failed: ", r.system_code, " (backend error ", Fs.last_error(), ")");
+    }
+
+    void fs_read(Session session, const(char)[] name)
+    {
+        import urt.mem.allocator : defaultAllocator;
+
+        void[] data = load_file(name);
+        if (data is null)
+        {
+            session.write_line("read failed / not found: '", name, "'");
+            return;
+        }
+        session.write_line(data.length, " bytes: ", cast(const(char)[])data);
+        defaultAllocator().free(data);
+    }
+
+    void fs_rm(Session session, const(char)[] name)
+    {
+        Result r = delete_file(name);
+        session.write_line(r ? "deleted" : "delete failed");
+    }
+
+    // The format runs on its own task, because on a multi-megabyte partition it
+    // blocks for long enough to starve the watchdog.
+    class FormatCommandState : CommandState
+    {
+    nothrow @nogc:
+
+        this(Session session)
+        {
+            super(session, null);
+        }
+
+        override CommandCompletionState update()
+        {
+            final switch (format_state())
+            {
+                case FsFormatState.running:
+                    return CommandCompletionState.in_progress;
+                case FsFormatState.complete:
+                    session.write_line("format: complete");
+                    return CommandCompletionState.finished;
+                case FsFormatState.failed:
+                    session.write_line("format: failed");
+                    return CommandCompletionState.error;
+                case FsFormatState.idle:
+                    return CommandCompletionState.finished;
+            }
+        }
+
+        // A partition rewrite has no safe interruption point.
+        override void request_cancel()
+        {
+        }
+    }
+
+    CommandState fs_format(Session session)
+    {
+        if (format_state() != FsFormatState.running && !format_begin())
+        {
+            session.write_line("format: could not start");
+            return null;
+        }
+        session.write_line("format: erasing filesystem...");
+        return session.allocator.allocT!FormatCommandState(session);
+    }
+}
+
 version (AllocTracking)
 {
     import urt.mem.tracking;

--- a/src/protocol/http/staticfiles.d
+++ b/src/protocol/http/staticfiles.d
@@ -53,6 +53,8 @@ nothrow @nogc:
             if (HTTPServer old = _server.get)
             {
                 old.remove_uri_handler(HTTPMethod.GET, &handle_request);
+                old.remove_uri_handler(HTTPMethod.PUT, &handle_request);
+                old.remove_uri_handler(HTTPMethod.DELETE, &handle_request);
                 old.unsubscribe(&server_state_change);
             }
             _registered = false;
@@ -90,8 +92,10 @@ nothrow @nogc:
 
 protected:
 
+    // An empty root is the filesystem's own origin: the process working
+    // directory on a host, or no name prefix at all on a flat store.
     override bool validate() const pure
-        => _server.get !is null && !_root.empty;
+        => _server.get !is null;
 
     override CompletionStatus startup()
     {
@@ -102,6 +106,19 @@ protected:
         if (!server.add_uri_handler(HTTPMethod.GET, _uri[], &handle_request))
         {
             writeWarning("static: failed to register handler for uri '", _uri[], "' (prefix conflict?)");
+            return CompletionStatus.error;
+        }
+        if (!server.add_uri_handler(HTTPMethod.PUT, _uri[], &handle_request))
+        {
+            server.remove_uri_handler(HTTPMethod.GET, &handle_request);
+            writeWarning("static: failed to register PUT handler for uri '", _uri[], "' (prefix conflict?)");
+            return CompletionStatus.error;
+        }
+        if (!server.add_uri_handler(HTTPMethod.DELETE, _uri[], &handle_request))
+        {
+            server.remove_uri_handler(HTTPMethod.GET, &handle_request);
+            server.remove_uri_handler(HTTPMethod.PUT, &handle_request);
+            writeWarning("static: failed to register DELETE handler for uri '", _uri[], "' (prefix conflict?)");
             return CompletionStatus.error;
         }
         server.subscribe(&server_state_change);
@@ -116,6 +133,8 @@ protected:
             if (HTTPServer server = _server.get)
             {
                 server.remove_uri_handler(HTTPMethod.GET, &handle_request);
+                server.remove_uri_handler(HTTPMethod.PUT, &handle_request);
+                server.remove_uri_handler(HTTPMethod.DELETE, &handle_request);
                 server.unsubscribe(&server_state_change);
             }
             _registered = false;
@@ -180,6 +199,20 @@ private:
                 fs_path ~= '/';
         }
 
+        if (request.method == HTTPMethod.PUT)
+        {
+            if (want_index)
+                return send_status(ver, stream, 405);
+            return store_file(fs_path[], ver, request, stream);
+        }
+
+        if (request.method == HTTPMethod.DELETE)
+        {
+            if (want_index)
+                return send_status(ver, stream, 405);
+            return remove_file(fs_path[], ver, stream);
+        }
+
         if (!want_index)
         {
             if (serve_file(fs_path[], ver, request, stream))
@@ -239,6 +272,67 @@ private:
 
         send_message(stream, response, &request);
         return true;
+    }
+
+    // Bodies larger than the server's max_buffered_body never reach here.
+    //
+    // Written to a temporary and swapped in, so a write that fails partway
+    // leaves the existing file untouched rather than truncated. SPIFFS refuses
+    // to rename onto an existing name, so the swap is a delete then a rename;
+    // losing power between those two leaves the complete upload as .tmp and no
+    // target, which the boot guard survives. Truncating in place does not.
+    int store_file(const(char)[] fs_path, HTTPVersion ver, ref const HTTPMessage request, ref Stream stream)
+    {
+        const bool replaced = file_exists(fs_path);
+        const(char)[] tmp_path = tconcat(fs_path, ".tmp");
+
+        File f;
+        Result o = f.open(tmp_path, FileOpenMode.WriteTruncate);
+        if (!o)
+        {
+            writeWarning("static: open '", tmp_path, "' for write failed: ", o.system_code);
+            return send_status(ver, stream, 500);
+        }
+
+        size_t written;
+        Result r = f.write(request.content[], written);
+        f.close();
+
+        if (!r || written != request.content.length)
+        {
+            writeWarning("static: write '", tmp_path, "' failed: ", r.system_code);
+            delete_file(tmp_path);
+            return send_status(ver, stream, 500);
+        }
+
+        if (replaced)
+            delete_file(fs_path);
+
+        Result mv = rename_file(tmp_path, fs_path);
+        if (!mv)
+        {
+            writeWarning("static: could not swap '", tmp_path, "' into place: ", mv.system_code);
+            return send_status(ver, stream, 500);
+        }
+
+        writeInfo("static: stored '", fs_path, "' (", written, " bytes)");
+        return send_status(ver, stream, replaced ? 200 : 201);
+    }
+
+    int remove_file(const(char)[] fs_path, HTTPVersion ver, ref Stream stream)
+    {
+        if (!file_exists(fs_path))
+            return send_status(ver, stream, 404);
+
+        Result r = delete_file(fs_path);
+        if (!r)
+        {
+            writeWarning("static: delete '", fs_path, "' failed: ", r.system_code);
+            return send_status(ver, stream, 500);
+        }
+
+        writeInfo("static: deleted '", fs_path, "'");
+        return send_status(ver, stream, 200);
     }
 
     int send_status(HTTPVersion ver, ref Stream stream, ushort code)


### PR DESCRIPTION
Embedded targets could only be reconfigured by rebuilding: the config was compiled into the image and nothing could be written to flash. This gives them a filesystem, a way to upload a config over HTTP, and a way back when that config is bad.

Depends on open-watt/urt#216 (littlefs backend + a file-handle leak fix); the submodule points at that branch, so this lands after it.

## The filesystem

Two backends, mutually exclusive because both claim the storage partition:

- **littlefs** (`USE_LITTLEFS=1`) talks to `esp_partition_*` directly, so it needs neither IDF's VFS nor newlib. Real directories, rename-over, power-loss resilience, wear levelling, bad block detection.
- **SPIFFS** rides IDF's VFS and remains the `esp%` default.

littlefs is the one to prefer, and not on size (22.2K against ~28.9K at `-Os`, a gap that mostly closes once you count the block device littlefs needs and SPIFFS gets from `esp_spiffs.c`). It is better on merit, and it is what SmartEVSE's stock firmware formats its data partition with — `board_build.filesystem = littlefs`, with the partition merely *labelled* `spiffs` because that is IDF's generic data subtype. Matching it keeps us compatible with that partition scheme.

The Waveshare board therefore defaults to littlefs in its `board.mk`. That matters beyond preference: SPIFFS cannot read a littlefs volume, so a build without it finds no `startup.conf` on a board that has one and silently falls back to bring-up defaults, which looks like the configuration was lost rather than unreadable.

## Console

`/system/fs/` `format` | `info` | `read` | `write` | `rm`, resolving whichever backend is built. Inspecting a board's filesystem otherwise costs a build and a flash per question; these turned minutes per experiment into seconds, and the runtime test harness drives the same surface.

## Config layering

```
system.conf   - what the board is; always applies
default.conf  - bring-up state, when there is no startup.conf
startup.conf  - the deployment, read from the filesystem
user.conf     - local overrides, never committed
```

`system.conf` is a prefix rather than an alternative, so exactly one of `default.conf` and `startup.conf` extends it, and a deployment config never restates the board's own hardware. `--config` still replaces the startup layer, and now reports a path it cannot read instead of quietly falling back to bring-up defaults.

## Recovery

A filesystem config that strands the board would otherwise be unrecoverable: it outlives reflashing, and fixing it needs a console the config may have removed. `manager.bootguard` counts boots that never reach healthy uptime, in NVS so the record is independent of the filesystem being rolled back from. Past three, the config is set aside as `.bad` and the board comes up on bring-up defaults with the provisioning AP.

The counter doubles as the manual escape hatch, and that is the more useful half. A config that boots happily but leaves the board **unreachable** is never detected automatically, because from the firmware's side nothing is wrong. Cutting power a few times is the operator supplying a signal the board cannot observe for itself.

## Known-wrong: the OTA interaction

Marked `TODO` at the commit site in `apps/ota`.

The intended order is config first, firmware second. Today it is reversed: the OTA app marks an image valid after 30s of uptime, and a bad config that prevents reaching 30s fails the *image* on the first boot, long before this counter reaches three. The slot swaps, the old image runs the same bad config, and it fails too. The board recovers, but only after spending a firmware rollback on a configuration problem.

The cause is that image validity is judged by "did it survive 30s", which the config can veto. The fix is to mark the image valid on evidence about the firmware alone, before the filesystem config runs, which makes the two independent rather than racing. That means moving the checkpoint into the main app and leaving the OTA app as the surface that receives and applies an image. Not done here.

## The board config

The station config is gone from the image. A site's SSID and PSK do not belong in a firmware image in a public repository, and with the filesystem layer in place they no longer have to be. The provisioning credential stays, and stays documented as one to replace. The buses are wired but unbound: what speaks Modbus or Tesla TWC on RS485 is deployment configuration.

## Testing

ESP32-S3, Waveshare RS485-CAN, release build at `-Os`, verified on hardware throughout. All results below are on littlefs.

**Filesystem**

```
20/20 sequential writes, read back byte-exact
10 consecutive console sessions, open handles flat at 2
nested paths: conf/device_profiles/goodwe_inverter.conf   (SPIFFS cannot represent this)
explicit format, then mount and write on the fresh volume
```

**File CRUD over HTTP**, with `root=""`:

```
PUT     -> 201    GET -> 200, byte-exact ("hello=world")
PUT2    -> 200    GET -> 200, "second"
DELETE  -> 200    GET -> 404
```

**Config precedence**

| filesystem | config used | evidence |
|---|---|---|
| has `startup.conf` | filesystem | `shed_twc` and the `tesla` secret, which exist only there |
| empty | built-in | none of the above; AP, buses, rtc, http/api/ota/sync/static all up |

```
[Info] system: using startup.conf from the filesystem; bring-up defaults skipped
[Notice] tesla-twc 'shed_twc': online
```

**Deployment round-trip**: `startup.conf` and a private EC key uploaded over HTTP, both byte-identical on readback, surviving reboot. The Tesla binding **loads** the key rather than regenerating it (md5 unchanged across boots), which is the point of having a filesystem at all.

**Recovery, against a genuinely bad config** (one that boots fine but creates no HTTP or telnet server, so the board is unmanageable):

```
http: 000                                  <- unreachable
[3 power cycles]
[Warning] filesystem config ignored after 3 failed boots; falling back to the built-in config
[Notice] static 'files': online            <- recoverable

/files/conf/startup.conf      -> 404       <- no longer applied
/files/conf/startup.conf.bad  -> 200       <- preserved for inspection
```

A further reboot stays on defaults, so recovery sticks rather than lasting one boot.

## Worth knowing

- An earlier round of this branch's evidence was gathered on SPIFFS and stopped reproducing: writes began failing with `EBADF` on an empty freshly-formatted volume. The cause was not SPIFFS but `urt.file`'s `is_open()` reporting every backend-held file as closed, so the console leaked one filesystem handle per session until the descriptor table filled. Fixed in open-watt/urt#216; the results above are all post-fix.
- `USE_SPIFFS` still defaults on for all other `esp%` targets, and the sdkconfig change is **esp32s3 only**, so other ESP boards will hit the same ENOSYS until their `sdkconfig.defaults` follows. Flipping the `esp%` default to littlefs is the logical end state but would strand boards already carrying a SPIFFS volume, so it wants a migration story rather than a flag flip.
- `/files` is read-write to anyone on the provisioning AP. Appropriate for provisioning behind WPA2, worth revisiting before it faces a real network.
- Editing a board's `system.conf` does **not** trigger a D rebuild: the string import is not tracked as a dependency. This silently flashed a stale config during testing until I removed the object by hand. Not fixed here, but it will bite whoever edits a board config next.
