### PR TITLE
Property projection: EID resolution, reference descriptor, state-machine elements (machinery)

### DIFF
--- a/docs/PROP_ELEMENTS.draft.md
+++ b/docs/PROP_ELEMENTS.draft.md
@@ -45,10 +45,17 @@ Prop index == element index, so `eid` is `_id.element(prop_index!(T, "baud") + 1
 an `Element*` recover its owner and index by arithmetic, which is what makes `parent`/`_eid`
 derivable rather than stored.
 
-As built, property elements mint no EID: nothing resolves an object-CID container, so a minted
-handle would deref to null. It lands with the model-surface exposure that needs it, together with
-the resolve path. The change handler recovers its index by subtracting the block base, so the
-header is not needed yet either.
+As built, property elements mint their EID at construction and `resolve_element(EID)` (manager
+package) dispatches on the container's type bits: device containers resolve through the
+DeviceTable as before, any other container resolves through `get_item(cid)` and indexes the
+object's property block (`find_prop_element`, null for the container index, legacy properties,
+and out-of-range). The sync inbound paths resolve through the dispatcher, so a property EID on
+the wire reaches its element. One known gap: a write landing directly on a property element
+(`try_set` from the model surface) enforces the constraint and access gates but bypasses the
+declared `Check!` function, which lives in the by-name path (`elem_apply`); route model-surface
+property writes through `BaseObject.set` when property elements become addressable by path. The
+change handler recovers its index by subtracting the block base, so the block header is not
+needed yet.
 
 Also as built, the block is sized by the type's TOTAL property count, not its element-backed
 count, because the prop index is the slot index. SerialStream has 22 properties of which 5 are

--- a/src/driver/linux/ethernet.d
+++ b/src/driver/linux/ethernet.d
@@ -173,7 +173,7 @@ private:
         AdapterChange c = apply_os_adapter_info(this, _l2mtu, _max_l2mtu, _status, info);
         if (c & AdapterChange.mtu)       mark_set!(typeof(this), [ "l2mtu", "actual-mtu" ])();
         if (c & AdapterChange.max_mtu)   mark_set!(typeof(this), "max-l2mtu")();
-        if (c & AdapterChange.connected) mark_set!(typeof(this), [ "connected", "status" ])();
+        if (c & AdapterChange.connected) { mark_set!(typeof(this), "connected")(); write_status(); }
         if (c & AdapterChange.tx_speed)  mark_set!(typeof(this), "tx-link-speed")();
         if (c & AdapterChange.rx_speed)  mark_set!(typeof(this), "rx-link-speed")();
     }

--- a/src/driver/linux/wifi.d
+++ b/src/driver/linux/wifi.d
@@ -1192,7 +1192,8 @@ protected:
                 ubyte ch = freq_to_channel(_sta.freq);
                 if (_sta.connected && ch != 0)
                     r.update_active_channel(ch);
-                mark_set!(typeof(this), [ "ssid", "bssid", "rssi", "signal-quality", "status" ])();
+                mark_set!(typeof(this), [ "ssid", "bssid", "rssi", "signal-quality" ])();
+                write_status();
                 if (!_sta.connected)
                 {
                     restart();
@@ -1353,7 +1354,8 @@ private:
                 if (auto r = cast(LinuxWifiRadio)radio)
                     r.update_active_channel(ch);
             }
-            mark_set!(typeof(this), [ "bssid", "rssi", "signal-quality", "status" ])();
+            mark_set!(typeof(this), [ "bssid", "rssi", "signal-quality" ])();
+            write_status();
         }
 
         void ensure_scan_started()
@@ -1371,7 +1373,7 @@ private:
             if (r.start_scan(sc, &on_scan_done))
             {
                 _scan_inflight = true;
-                mark_set!(typeof(this), "status")();
+                write_status();
             }
             else
                 schedule_scan_retry(2.seconds);
@@ -1383,7 +1385,7 @@ private:
                 return;
             _scan_retry_armed = true;
             g_app.schedule(getTime() + delay, &scan_retry_event);
-            mark_set!(typeof(this), "status")();
+            write_status();
         }
 
         void cancel_scan_retry()
@@ -1416,7 +1418,7 @@ private:
                 else if (_sta.failed)
                     set_state(State.failure);
                 else
-                    mark_set!(typeof(this), "status")();
+                    write_status();
             }
         }
 
@@ -1445,7 +1447,7 @@ private:
             }
             if (!_sta.connect(super.ssid, get_password(), best.bssid, channel_to_freq(best.channel, best.band)))
                 post_progress_event();
-            mark_set!(typeof(this), "status")();
+            write_status();
         }
     }
 }

--- a/src/driver/windows/ethernet.d
+++ b/src/driver/windows/ethernet.d
@@ -142,7 +142,7 @@ private:
         AdapterChange c = apply_os_adapter_info(this, _l2mtu, _max_l2mtu, _status, info);
         if (c & AdapterChange.mtu)       mark_set!(typeof(this), [ "l2mtu", "actual-mtu" ])();
         if (c & AdapterChange.max_mtu)   mark_set!(typeof(this), "max-l2mtu")();
-        if (c & AdapterChange.connected) mark_set!(typeof(this), [ "connected", "status" ])();
+        if (c & AdapterChange.connected) { mark_set!(typeof(this), "connected")(); write_status(); }
         if (c & AdapterChange.tx_speed)  mark_set!(typeof(this), "tx-link-speed")();
         if (c & AdapterChange.rx_speed)  mark_set!(typeof(this), "rx-link-speed")();
     }

--- a/src/driver/windows/wifi.d
+++ b/src/driver/windows/wifi.d
@@ -400,7 +400,8 @@ private:
             _current_bssid = MACAddress();
             _current_rssi = 0;
             _signal_quality = 0;
-            mark_set!(typeof(this), [ "ssid", "bssid", "rssi", "signal-quality", "status" ])();
+            mark_set!(typeof(this), [ "ssid", "bssid", "rssi", "signal-quality" ])();
+            write_status();
         }
         else
         {
@@ -419,7 +420,8 @@ private:
             if (r._wlan.query_rssi(r._guid, rssi))
                 _current_rssi = rssi;
 
-            mark_set!(typeof(this), [ "ssid", "bssid", "rssi", "signal-quality", "status" ])();
+            mark_set!(typeof(this), [ "ssid", "bssid", "rssi", "signal-quality" ])();
+            write_status();
         }
 
         OSAdapterInfo info;

--- a/src/manager/base.d
+++ b/src/manager/base.d
@@ -482,7 +482,23 @@ nothrow @nogc:
 
     final package StringResult sync_apply(scope const(char)[] property, ref const Variant value)
     {
-        return set(property, value);
+        // the authority's echo bypasses the read-only gate: a proxy cannot recompute derived state
+        foreach (i, p; properties())
+        {
+            if (p.name[] == property)
+            {
+                if (!p.set)
+                    return StringResult(tconcat("Property '", property, "' is read-only"));
+                auto r = p.set(value, this, *p);
+                if (r)
+                {
+                    _props_set |= ulong(1) << i;
+                    mark_dirty(i);
+                }
+                return r;
+            }
+        }
+        return set_unknown_property(property, value);
     }
 
     final void reset(scope const(char)[] property)
@@ -1762,6 +1778,12 @@ unittest
     assert(proxy.set("gain", echoed));
     assert(proxy.prop_read!(ElemTestObject, "gain") == 3);
     assert(proxy.changes == 0);
+
+    // read-only refuses the console but not the authority's echo
+    Variant lk = Variant(true);
+    assert(!proxy.set("link", lk));
+    assert(proxy.sync_apply("link", lk));
+    assert(proxy.prop_read!(ElemTestObject, "link") == true);
     table.remove(proxy.id);
     defaultAllocator().freeT(proxy);
 }

--- a/src/manager/base.d
+++ b/src/manager/base.d
@@ -693,8 +693,8 @@ private:
 
 class ActiveObject : BaseObject
 {
-    alias Properties = AliasSeq!(Prop!("running", running, null, "h"),
-                                 Prop!("status", status_message, null, "d"));
+    alias Properties = AliasSeq!(Elem!("running", bool, ReadOnly, PropFlags!"h"),
+                                 Elem!("status", String, ReadOnly, PropFlags!"d"));
 nothrow @nogc:
 
     this(const CollectionTypeInfo* type_info, CID id, ObjectFlags flags = ObjectFlags.none)
@@ -709,6 +709,7 @@ nothrow @nogc:
 
         _props_set |= (ulong(1) << prop_index!(typeof(this), "running")) |
                       (ulong(1) << prop_index!(typeof(this), "status"));
+        write_status();
     }
 
     ~this()
@@ -734,7 +735,7 @@ nothrow @nogc:
             _state &= ~_disabled;
         mark_set!(typeof(this), "disabled")();
         mark_set!(typeof(this), "flags")();
-        mark_set!(typeof(this), "status")();
+        write_status();
     }
 
     // TODO: PUT FINAL BACK WHEN EVERYTHING PORTED!
@@ -810,6 +811,7 @@ nothrow @nogc:
         _state &= ~(_start | _fail);
         if (was_valid)
             _state |= _stop;    // -> destroying; state machine will run shutdown then transition to destroyed
+        write_status();
 
         if (was_running)
             set_offline();
@@ -831,6 +833,7 @@ nothrow @nogc:
                 if (_state == State.running)
                     return;
                 _state = State.running;
+                write_status();
                 set_online();
                 break;
             case StateSignal.offline:
@@ -838,6 +841,7 @@ nothrow @nogc:
                     return;
                 set_offline();
                 _state = State.disabled;
+                write_status();
                 break;
             case StateSignal.destroyed:
                 if (_state & _destroyed)
@@ -845,6 +849,7 @@ nothrow @nogc:
                 if (_state == State.running)
                     set_offline();
                 _state = State.destroyed;
+                write_status();
                 signal_state_change(StateSignal.destroyed);
                 _subscribers.clear();
                 super.destroy();
@@ -900,12 +905,11 @@ protected:
 
         State old = _state;
 
-        // HACK: probably over-dirty's the property, but when changing the state there's a good chance the status changed too!
-        mark_set!(typeof(this), "status")();
-
         if (new_state == _state)
             return;
         _state = new_state;
+        // held dedup makes redundant status writes free: an unchanged message stores and notifies nothing
+        write_status();
 
         if (old == State.running)
         {
@@ -976,7 +980,7 @@ protected:
         else
             log.trace("online");
 
-        mark_set!(typeof(this), "running")();
+        write_running(true);
         mark_set!(typeof(this), "flags")();
     }
 
@@ -990,7 +994,7 @@ protected:
         signal_state_change(StateSignal.offline);
         offline();
 
-        mark_set!(typeof(this), "running")();
+        write_running(false);
         mark_set!(typeof(this), "flags")();
     }
 
@@ -1000,6 +1004,18 @@ protected:
 
     void offline()
     {
+    }
+
+    // push the derived views: state transitions (and any subclass state feeding status_message)
+    // write the elements the moment they change
+    final void write_status()
+    {
+        prop_element(prop_index!(ActiveObject, "status")).try_write(status_message());
+    }
+
+    final void write_running(bool value)
+    {
+        prop_element(prop_index!(ActiveObject, "running")).try_write(value);
     }
 
 

--- a/src/manager/base.d
+++ b/src/manager/base.d
@@ -381,6 +381,15 @@ nothrow @nogc:
         return _prop_elements[index];
     }
 
+    // element_index is EID-space: 0 is the container, properties claim 1..N
+    final inout(Element)* find_prop_element(ushort element_index) inout
+    {
+        size_t index = size_t(element_index) - 1;
+        if (!_prop_elements || index >= _typeInfo.properties.length || !_typeInfo.properties[index].elem_format)
+            return null;
+        return &_prop_elements[index];
+    }
+
     ElemType!(Type, prop) prop_read(Type, string prop)() const
         => prop_element(prop_index!(Type, prop)).read!(ElemType!(Type, prop));
 
@@ -623,10 +632,10 @@ private:
                 continue;
             ref Element e = _prop_elements[i];
             e.id = p.name;
+            e._eid = _id.element(cast(ushort)(i + 1)); // element index 0 is the container
             e.format = p.elem_format();
             e.access = p.read_only ? Access.read : Access.read_write;
             e.sampling_mode = SamplingMode.config;
-            // no EID: id.d's (object CID, prop index + 1) has no resolver, so it would deref to null
             if (p.init_val)
             {
                 Variant def = p.init_val();
@@ -1594,6 +1603,13 @@ unittest
     assert(o.prop_read!(ElemTestObject, "link") == true);
     assert(o.prop_element(link).access == Access.read);
     assert(o.prop_element(gain).access == Access.read_write);
+
+    // property EIDs are (object CID, prop index + 1); resolution indexes the property block
+    assert(o.prop_element(gain).eid == o.id.element(cast(ushort)(gain + 1)));
+    assert(o.find_prop_element(cast(ushort)(gain + 1)) is &o.prop_element(gain));
+    assert(o.find_prop_element(0) is null);                                     // the container, not a property
+    assert(o.find_prop_element(1) is null);                                     // legacy property, not element-backed
+    assert(o.find_prop_element(cast(ushort)(o.properties.length + 1)) is null); // out of range
 
     defaultAllocator().freeT(o);
 

--- a/src/manager/base.d
+++ b/src/manager/base.d
@@ -19,7 +19,7 @@ import urt.util : min;
 import manager.console.argument;
 import manager.element : Access, Element, SampleUpdate, SamplingMode;
 import manager.id;
-import manager.series : DataFormat, FormatId, register_format, valid;
+import manager.series : DataFormat, FormatId, register_format, SeriesKind, valid, ValueType;
 import manager.value;
 
 public import manager.collection : CID, Collection, CollectionType, collection_type_info, CollectionTypeInfo;
@@ -129,7 +129,7 @@ struct Property
     alias DefaultFun = Variant function() nothrow @nogc;
     alias SuggestFun = Array!String function(const(char)[] arg) nothrow @nogc;
     alias FormatFun = FormatId function() nothrow @nogc;
-    alias ChangeFun = void function(BaseObject i) nothrow @nogc;
+    alias ChangeFun = void function(BaseObject i, ref const SampleUpdate u) nothrow @nogc;
     alias CheckFun = const(char)[] function(void* value) nothrow @nogc; // value is a `ref T` of the declared type
 
     String name;
@@ -225,7 +225,19 @@ struct Property
 
         prop.index = cast(ushort)index;
         prop.get = &elem_get;
-        prop.set = &elem_set!T;
+        static if (is(T : BaseObject))
+        {
+            // reference: the boxed door already converts name <-> id at the edge, so the
+            // by-name entry forwards the variant straight through
+            static assert(FindElemOpt!("default", Decl.opts).length == 0 &&
+                          FindElemOpt!("min", Decl.opts).length == 0 &&
+                          FindElemOpt!("max", Decl.opts).length == 0 &&
+                          FindElemOpt!("check", Decl.opts).length == 0,
+                          "reference properties take no Default/Min/Max/Check");
+            prop.set = &elem_ref_set;
+        }
+        else
+            prop.set = &elem_set!T;
         prop.init_val = &ElemDefault!Decl;
         prop.elem_format = &ElemFormat!Decl;
 
@@ -391,15 +403,37 @@ nothrow @nogc:
     }
 
     ElemType!(Type, prop) prop_read(Type, string prop)() const
-        => prop_element(prop_index!(Type, prop)).read!(ElemType!(Type, prop));
+    {
+        alias T = ElemType!(Type, prop);
+        static if (is(T : BaseObject))
+        {
+            import manager.collection : get_item;
+            EID eid = EID(prop_element(prop_index!(Type, prop)).read!ulong);
+            // dynamic cast: the slot can rebind to a same-named sibling of another class
+            return eid ? cast(T)get_item(eid.container) : null;
+        }
+        else
+            return prop_element(prop_index!(Type, prop)).read!T;
+    }
 
     void prop_write(Type, string prop)(auto ref ElemType!(Type, prop) value)
     {
         enum index = prop_index!(Type, prop);
-        StringResult r = elem_apply(this, *_typeInfo.properties[index], value);
-        debug assert(r, tconcat("write to property '", prop, "' refused: ", r.message));
-        if (r)
-            _props_set |= ulong(1) << index;
+        static if (is(ElemType!(Type, prop) : BaseObject))
+        {
+            ulong eid = value ? EID(value.id).raw : 0;
+            const(char)[] error = prop_element(index).try_write(eid);
+            debug assert(error is null, tconcat("write to property '", prop, "' refused: ", error));
+            if (error is null)
+                _props_set |= ulong(1) << index;
+        }
+        else
+        {
+            StringResult r = elem_apply(this, *_typeInfo.properties[index], value);
+            debug assert(r, tconcat("write to property '", prop, "' refused: ", r.message));
+            if (r)
+                _props_set |= ulong(1) << index;
+        }
     }
 
     // get and set and reset (to default) properties
@@ -652,7 +686,7 @@ private:
         ref const Property p = *_typeInfo.properties[index];
         // a proxy's elements carry the authority's echo; reacting locally would drive absent hardware
         if (p.on_change && !_is_remote)
-            p.on_change(this);
+            p.on_change(this, update);
         mark_dirty(index);
     }
 }
@@ -1407,6 +1441,9 @@ StringResult elem_set(T)(ref const Variant value, BaseObject item, ref const Pro
     return elem_apply(item, p, arg.move);
 }
 
+StringResult elem_ref_set(ref const Variant value, BaseObject item, ref const Property p) nothrow @nogc
+    => StringResult(item._prop_elements[p.index].try_set(value));
+
 const(char)[] CheckShim(alias fn, T)(void* value) nothrow @nogc
     => fn(*cast(T*)value);
 
@@ -1415,6 +1452,8 @@ Variant ElemDefault(alias Decl)() nothrow @nogc
     alias Def = FindElemOpt!("default", Decl.opts);
     static if (Def.length)
         return to_variant(cast(Decl.T)Def[0].value);
+    else static if (is(Decl.T : BaseObject))
+        return Variant(); // references default to unset
     else static if (__traits(compiles, { Decl.T v = Decl.T.init; return to_variant(v); }))
         return to_variant(Decl.T.init);
     else
@@ -1430,7 +1469,10 @@ FormatId ElemFormat(alias Decl)() nothrow @nogc
     import manager.sample : register_constraint;
     import manager.series : Constraint, data_format_of, Scalar;
 
-    DataFormat format = data_format_of!(Decl.T)();
+    static if (is(Decl.T : BaseObject))
+        DataFormat format = DataFormat(ValueType.u64, SeriesKind.held, collection_type_info!(Decl.T)());
+    else
+        DataFormat format = data_format_of!(Decl.T)();
 
     alias Mn = FindElemOpt!("min", Decl.opts);
     alias Mx = FindElemOpt!("max", Decl.opts);
@@ -1454,11 +1496,14 @@ FormatId ElemFormat(alias Decl)() nothrow @nogc
     return cached;
 }
 
-void ElemOnChange(alias fn)(BaseObject item) nothrow @nogc
+void ElemOnChange(alias fn)(BaseObject item, ref const SampleUpdate update) nothrow @nogc
 {
     alias Type = __traits(parent, fn);
     Type instance = cast(Type)cast(void*)item; // static cast: the handler only ever binds to its own class
-    __traits(child, instance, fn)();
+    static if (is(typeof(__traits(child, instance, fn)(update))))
+        __traits(child, instance, fn)(update);  // handlers that care receive previous+new
+    else
+        __traits(child, instance, fn)();
 }
 
 Variant SynthDefault(alias Getter)() nothrow @nogc
@@ -1511,26 +1556,37 @@ version (unittest)
 
     private final class ElemTestObject : BaseObject
     {
+        enum type_name = "elem-test";
+        enum collection_id = cast(CollectionType)0;
+
         alias Properties = AliasSeq!(Elem!("gain", uint, Default!7, Min!1, Max!10, OnChange!bump),
-                                     Elem!("mode", TestMode, Default!(TestMode.idle)),
+                                     Elem!("mode", TestMode, Default!(TestMode.idle), OnChange!mode_changed),
                                      Elem!("label", String),
                                      Elem!("link", bool, ReadOnly),
                                      Elem!("offset", uint),
                                      Elem!("timeout", Duration, Default!(msecs(800))),
                                      Elem!("power", Quantity!(int, ScaledUnit(Watt))),
-                                     Elem!("delay", Quantity!(int, ScaledUnit(Second, -3))));
+                                     Elem!("delay", Quantity!(int, ScaledUnit(Second, -3))),
+                                     Elem!("peer", ElemTestObject));
     nothrow @nogc:
 
         uint changes;
+        String last_previous;
 
-        this(const CollectionTypeInfo* type_info, CID id, ObjectFlags flags = ObjectFlags.none)
+        this(CID id, ObjectFlags flags = ObjectFlags.none)
         {
-            super(type_info, id, flags);
+            super(collection_type_info!ElemTestObject(), id, flags);
         }
 
         void bump()
         {
             ++changes;
+        }
+
+        void mode_changed(ref const SampleUpdate update)
+        {
+            import urt.mem.allocator : defaultAllocator;
+            last_previous = update.previous.tstring.makeString(defaultAllocator);
         }
     }
 }
@@ -1538,12 +1594,11 @@ version (unittest)
 unittest
 {
     import urt.mem.allocator : defaultAllocator;
+    import manager.collection : item_table;
 
-    __gshared CollectionTypeInfo test_ti;
-    test_ti = CollectionTypeInfo(StringLit!"elem-test", String(), cast(CollectionType)0,
-                                 all_properties!ElemTestObject(), null, null, false);
-
-    ElemTestObject o = defaultAllocator().allocT!ElemTestObject(&test_ti, CID(1));
+    auto table = &item_table(0);
+    ElemTestObject o = defaultAllocator().allocT!ElemTestObject(table.allocate("elem-test-o", 0));
+    table.bind(o.id, o);
     enum gain = prop_index!(ElemTestObject, "gain");
 
     // declared defaults apply at construction and are not "changes"
@@ -1570,10 +1625,11 @@ unittest
     assert(o.prop_read!(ElemTestObject, "gain") == 5);
     assert(o.changes == 1);
 
-    // enums arrive as strings from the console
+    // enums arrive as strings from the console; change handlers see the previous value
     Variant mode = Variant("run");
     assert(o.set("mode", mode));
     assert(o.prop_read!(ElemTestObject, "mode") == TestMode.run);
+    assert(o.last_previous[] == "idle");
 
     // text properties store through the same path
     Variant label = Variant("charger");
@@ -1644,14 +1700,53 @@ unittest
     assert(o.prop_read!(ElemTestObject, "delay").value == 1500);
     assert(!o.set("power", dur));                           // the dimension gate still holds
 
+    // reference properties: the edge converts name <-> id, storage is an EID
+    ElemTestObject target = defaultAllocator().allocT!ElemTestObject(table.allocate("ref-target", 0));
+    table.bind(target.id, target);
+    Variant peer = Variant("ref-target");
+    assert(o.set("peer", peer));
+    assert(o.prop_read!(ElemTestObject, "peer") is target);
+    assert(o.get("peer").asString == "ref-target");
+
+    // the ref tracks the name's slot: destruction tombstones, recreation at the name rebinds
+    table.remove(target.id);
+    assert(o.prop_read!(ElemTestObject, "peer") is null);
+    ElemTestObject target2 = defaultAllocator().allocT!ElemTestObject(table.allocate("ref-target", 0));
+    table.bind(target2.id, target2);
+    assert(o.prop_read!(ElemTestObject, "peer") is target2);
+    defaultAllocator().freeT(target);
+
+    // a forward reference reserves its id: the write succeeds before the target exists
+    Variant later = Variant("ref-later");
+    assert(o.set("peer", later));
+    assert(o.prop_read!(ElemTestObject, "peer") is null);
+    ElemTestObject target3 = defaultAllocator().allocT!ElemTestObject(table.allocate("ref-later", 0));
+    table.bind(target3.id, target3);
+    assert(o.prop_read!(ElemTestObject, "peer") is target3);
+
+    // the typed door writes the id straight in; null clears
+    o.prop_write!(ElemTestObject, "peer")(target2);
+    assert(o.get("peer").asString == "ref-target");
+    o.prop_write!(ElemTestObject, "peer")(null);
+    assert(o.prop_read!(ElemTestObject, "peer") is null);
+    assert(o.get("peer").isNull);
+
+    table.remove(target2.id);
+    table.remove(target3.id);
+    defaultAllocator().freeT(target2);
+    defaultAllocator().freeT(target3);
+
+    table.remove(o.id);
     defaultAllocator().freeT(o);
 
     // a proxy (is_remote) stores echoed values but never runs on_change side effects
-    ElemTestObject proxy = defaultAllocator().allocT!ElemTestObject(&test_ti, CID(2), ObjectFlags.remote);
+    ElemTestObject proxy = defaultAllocator().allocT!ElemTestObject(table.allocate("elem-test-proxy", 0), ObjectFlags.remote);
+    table.bind(proxy.id, proxy);
     Variant echoed = Variant(3);
     assert(proxy.set("gain", echoed));
     assert(proxy.prop_read!(ElemTestObject, "gain") == 3);
     assert(proxy.changes == 0);
+    table.remove(proxy.id);
     defaultAllocator().freeT(proxy);
 }
 

--- a/src/manager/base.d
+++ b/src/manager/base.d
@@ -1504,6 +1504,9 @@ template SynthSuggest(Setters...)
 
 version (unittest)
 {
+    import urt.si.quantity : Quantity;
+    import urt.si.unit : ScaledUnit, Second, Watt;
+
     private enum TestMode : ubyte { idle, run, fault }
 
     private final class ElemTestObject : BaseObject
@@ -1512,7 +1515,10 @@ version (unittest)
                                      Elem!("mode", TestMode, Default!(TestMode.idle)),
                                      Elem!("label", String),
                                      Elem!("link", bool, ReadOnly),
-                                     Elem!("offset", uint));
+                                     Elem!("offset", uint),
+                                     Elem!("timeout", Duration, Default!(msecs(800))),
+                                     Elem!("power", Quantity!(int, ScaledUnit(Watt))),
+                                     Elem!("delay", Quantity!(int, ScaledUnit(Second, -3))));
     nothrow @nogc:
 
         uint changes;
@@ -1610,6 +1616,33 @@ unittest
     assert(o.find_prop_element(0) is null);                                     // the container, not a property
     assert(o.find_prop_element(1) is null);                                     // legacy property, not element-backed
     assert(o.find_prop_element(cast(ushort)(o.properties.length + 1)) is null); // out of range
+
+    // Duration round-trips: the declared default applies, strings parse, and the box comes back as a duration
+    assert(o.prop_read!(ElemTestObject, "timeout") == msecs(800));
+    Variant timeout = Variant("5s");
+    assert(o.set("timeout", timeout));
+    assert(o.prop_read!(ElemTestObject, "timeout") == seconds(5));
+    assert(o.get("timeout").asDuration == seconds(5));
+    o.prop_write!(ElemTestObject, "timeout")(msecs(1500));
+    assert(o.get("timeout").asDuration == msecs(1500));
+
+    // Quantity round-trips through both doors and boxes with its unit
+    o.prop_write!(ElemTestObject, "power")(Quantity!(int, ScaledUnit(Watt))(240));
+    assert(o.prop_read!(ElemTestObject, "power").value == 240);
+    assert(o.get("power").asQuantity!double().value == 240);
+    Variant power = Variant("100W");
+    assert(o.set("power", power));
+    assert(o.prop_read!(ElemTestObject, "power").value == 100);
+
+    // durations and seconds-dimension quantities interchange at every boundary: a Variant
+    // stores a Duration as Quantity!(long, Nanosecond), so the generic paths do the work
+    Variant five_s = Variant(Quantity!long(5, ScaledUnit(Second)));
+    assert(o.set("timeout", five_s));                       // quantity -> Duration element, scale-adjusted
+    assert(o.prop_read!(ElemTestObject, "timeout") == seconds(5));
+    Variant dur = Variant(msecs(1500));
+    assert(o.set("delay", dur));                            // duration -> millisecond quantity element
+    assert(o.prop_read!(ElemTestObject, "delay").value == 1500);
+    assert(!o.set("power", dur));                           // the dimension gate still holds
 
     defaultAllocator().freeT(o);
 

--- a/src/manager/console/collection_commands.d
+++ b/src/manager/console/collection_commands.d
@@ -276,14 +276,21 @@ nothrow @nogc:
             return null;
         }
 
-        foreach (ref arg; namedArgs)
         {
-            StringResult r = item.set(arg.name, arg.value);
-            if (!r)
+            // one frame for the whole command: element-backed properties coalesce their
+            // change deliveries, so `set x a=1 b=2` restarts once, not per property
+            import manager.element : open_commit;
+            auto commit = open_commit();
+
+            foreach (ref arg; namedArgs)
             {
-                session.write_line("Set '", arg.name, "\' failed: ", r.message);
-                // TODO: should we bail out at first error, or try and set the rest?
-//                return null;
+                StringResult r = item.set(arg.name, arg.value);
+                if (!r)
+                {
+                    session.write_line("Set '", arg.name, "\' failed: ", r.message);
+                    // TODO: should we bail out at first error, or try and set the rest?
+//                    return null;
+                }
             }
         }
         return null;

--- a/src/manager/element.d
+++ b/src/manager/element.d
@@ -25,6 +25,7 @@ import urt.mem.string;
 import urt.si.unit : ScaledUnit;
 import urt.string;
 import urt.time;
+import urt.traits : Unqual;
 import urt.variant;
 
 import manager.component;
@@ -287,7 +288,10 @@ nothrow @nogc:
         {
             debug assert(data_format.is_scalar, "element record does not fit the scalar register");
             debug assert(scalar_type!T == data_format.type, "element type mismatch");
-            return *cast(const(T)*)_latest.raw.ptr;
+            static if (is(Unqual!T == Duration))
+                return nsecs(*cast(const(long)*)_latest.raw.ptr);
+            else
+                return *cast(const(T)*)_latest.raw.ptr;
         }
     }
 

--- a/src/manager/id.d
+++ b/src/manager/id.d
@@ -122,6 +122,11 @@ nothrow @nogc:
         raw = container.raw | (ulong(index) << 32);
     }
 
+    this(ulong raw_value) pure
+    {
+        raw = raw_value;
+    }
+
     CID container() const pure
         => CID(cast(uint)raw);
 

--- a/src/manager/package.d
+++ b/src/manager/package.d
@@ -1659,6 +1659,15 @@ private:
         uint _heartbeats;
 }
 
+Element* resolve_element(EID eid) nothrow @nogc
+{
+    if (eid.container.type_index == CollectionType.device)
+        return g_app.devices.resolve(eid);
+    if (BaseObject o = get_item(eid.container))
+        return o.find_prop_element(eid.index);
+    return null;
+}
+
 Element* resolve_global_element(const(char)[] path) nothrow @nogc
 {
     const(char)[] rest = path;

--- a/src/manager/series.d
+++ b/src/manager/series.d
@@ -106,6 +106,13 @@ template scalar_type(T)
 {
     static if (is(Unqual!T Base == enum))
         enum scalar_type = value_type_of!Base;
+    else static if (is(Unqual!T == Duration))
+        enum scalar_type = ValueType.s64;
+    else static if (is(Unqual!T == Quantity!(N, scale), N, ScaledUnit scale))
+    {
+        static assert(scale.pack != uint.max, "dynamic quantities have no static format");
+        enum scalar_type = value_type_of!N;
+    }
     else
         enum scalar_type = value_type_of!T;
 }
@@ -377,6 +384,10 @@ nothrow @nogc:
         s.raw[] = 0;
         static if (is(immutable T == immutable bool))
             s.b = v;
+        else static if (is(Unqual!T == Duration))
+            s.i = v.as!"nsecs";
+        else static if (is(Unqual!T == Quantity!(N, scale), N, ScaledUnit scale))
+            return of(v.value);
         else static if (is(immutable T == immutable float))
             s.f32_ = v;
         else static if (is(immutable T == immutable double))

--- a/src/manager/series.d
+++ b/src/manager/series.d
@@ -148,6 +148,10 @@ DataFormat data_format_of(T)()
         return DataFormat(ValueType.s64, SeriesKind.held, Nanosecond);
     else static if (is(U == Quantity!(N, scale), N, ScaledUnit scale))
         return DataFormat(value_type_of!N, SeriesKind.held, scale);
+    else static if (is(U == DateTime) || is(U == LocalTime))
+        static assert(false, "calendar views never store; coerce to SysTime at the boundary");
+    else static if (is(U == MonoTime))
+        static assert(false, "monotonic time is process-local; store SysTime");
     else static if (ValidUserType!U)
     {
         alias registered = MakeTypeDetails!U;   // registration rides its shared static this

--- a/src/manager/series.d
+++ b/src/manager/series.d
@@ -32,6 +32,9 @@ import urt.traits : is_boolean, is_some_float, is_some_int, Unqual;
 import urt.typereg : find_type_details, TypeDetails;
 import urt.variant;
 
+import manager.base : BaseObject;
+import manager.collection : CID, CollectionTypeInfo, get_id, item_table, type_matches;
+import manager.id : EID;
 import manager.ows : SeriesContainer;
 
 nothrow @nogc:
@@ -202,6 +205,8 @@ bool value_compatible(ref const DataFormat source, ref const DataFormat destinat
             return source.unit.unit == destination.unit.unit;
         case enum_:
             return source.enum_info is destination.enum_info;
+        case reference:
+            return source.ref_type is destination.ref_type;
     }
 }
 
@@ -287,7 +292,8 @@ nothrow @nogc:
     {
         none,
         quantity,
-        enum_
+        enum_,
+        reference
     }
 
     ValueType type;
@@ -299,9 +305,10 @@ nothrow @nogc:
     const(Constraint)* constraint; // null = unconstrained; write-path validation + UI/schema metadata
     union
     {
-        ScaledUnit unit;                // desc == quantity
-        const(VoidEnumInfo)* enum_info; // desc == enum_
-        const(TypeDetails)* user_type;  // type == user
+        ScaledUnit unit;                 // desc == quantity
+        const(VoidEnumInfo)* enum_info;  // desc == enum_
+        const(TypeDetails)* user_type;   // type == user
+        const(CollectionTypeInfo)* ref_type; // desc == reference: the record is an EID naming an object of this type
     }
 
     this(ValueType t, SeriesKind kind_) pure
@@ -338,6 +345,15 @@ nothrow @nogc:
         type = t;
         kind = kind_;
         user_type = td;
+    }
+
+    this(ValueType t, SeriesKind kind_, const(CollectionTypeInfo)* rt) pure
+    {
+        assert(t == ValueType.u64, "references store EIDs; the type must be u64");
+        type = t;
+        kind = kind_;
+        ref_type = rt;
+        desc = Desc.reference;
     }
 
     bool regular() const pure => rate != 0;
@@ -1041,6 +1057,37 @@ private bool unbox_scalar_value(ref const Variant v, ref const DataFormat fmt, o
     if (!fmt.is_scalar)
         return false;
 
+    if (fmt.desc == DataFormat.Desc.reference)
+    {
+        // the edge conversion: the wire and console carry the target's name. An absent name
+        // reserves its id, so forward references bind when the target is created.
+        if (v.isNull)
+        {
+            s = Scalar.of(ulong(0));
+            return true;
+        }
+        if (!v.isString)
+            return false;
+        const(char)[] name = v.asString;
+        if (name.length == 0)
+        {
+            s = Scalar.of(ulong(0));
+            return true;
+        }
+        ref table = item_table(fmt.ref_type.collection_id);
+        CID cid = table.get_id(name, fmt.ref_type.collection_id);
+        if (cid)
+        {
+            if (BaseObject o = table.get(cid))
+                if (!type_matches(fmt.ref_type, o._typeInfo))
+                    return false;
+        }
+        else
+            cid = table.reserve(name, fmt.ref_type.collection_id);
+        s = Scalar.of(EID(cid).raw);
+        return true;
+    }
+
     if (fmt.desc == DataFormat.Desc.quantity)
     {
         // wrong dimensions never store; unitless numbers adopt the format's unit
@@ -1205,9 +1252,10 @@ bool format_equal(ref const DataFormat a, ref const DataFormat b) pure
         return a.user_type is b.user_type;
     final switch (a.desc) with (DataFormat.Desc)
     {
-        case none:     return true;
-        case quantity: return a.unit == b.unit;
-        case enum_:    return a.enum_info is b.enum_info;
+        case none:      return true;
+        case quantity:  return a.unit == b.unit;
+        case enum_:     return a.enum_info is b.enum_info;
+        case reference: return a.ref_type is b.ref_type;
     }
 }
 
@@ -1247,6 +1295,12 @@ int compare(T)(T a, T b) pure
 
 Variant box_int(long v, ref const DataFormat fmt)
 {
+    if (fmt.desc == DataFormat.Desc.reference)
+    {
+        // the id never leaves the process: references box as the target's name
+        EID eid = EID(cast(ulong)v);
+        return eid ? Variant(get_id(eid.container)) : Variant();
+    }
     if (fmt.desc == DataFormat.Desc.enum_)
         return Variant(cast(ulong)v, fmt.enum_info);
     if (fmt.desc == DataFormat.Desc.quantity)

--- a/src/manager/sync/package.d
+++ b/src/manager/sync/package.d
@@ -217,7 +217,7 @@ nothrow @nogc:
                 SyncEncoder enc = encoder_for(p._encoder);
                 foreach (node; p._pending_vals[])
                 {
-                    Element* e = g_app.devices.resolve(node);
+                    Element* e = resolve_element(node);
                     SyncHandle h = p.handle_of(node);
                     if (!e || h == SyncPeer.invalid_handle)
                         continue;
@@ -1137,7 +1137,7 @@ nothrow @nogc:
             e = g_app.find_element(a.subject);
         }
         else
-            e = g_app.devices.resolve(from.node_of(handle));
+            e = resolve_element(from.node_of(handle));
         if (!e)
         {
             enc.encode_err(from, seq, path.length ? "unknown_path" : "unknown_handle", path);
@@ -1183,7 +1183,7 @@ nothrow @nogc:
         import urt.time : from_unix_time_ns;
 
         EID node = from.node_of(handle);
-        Element* e = g_app.devices.resolve(node);
+        Element* e = resolve_element(node);
         if (!e)
         {
             log.warning("sync: val for unknown handle ", handle);


### PR DESCRIPTION
Continues the property-projection migration from #462 (design: docs/PROP_ELEMENTS.draft.md). This is the **machinery half** of the round; the class migrations that exercise it (ModbusInterface, NTPClient, the modbus stream reference, and the doc truth-up) are stacked on top in #485. Six commits, each a single movement, each walk-buildable with 128/128 unit tests passing.

## Property EIDs + container-class resolution
Property elements mint their EID at construction: (object CID, prop index + 1). A new `resolve_element(EID)` dispatches on the container's type bits: device containers resolve through the DeviceTable as before, everything else resolves through `get_item(cid)` and indexes the object's property block. The sync inbound paths use the dispatcher, so property EIDs on the wire reach their elements. This was withheld from #462 because a minted handle would have deref'd to null.

## Duration and Quantity through the typed door
`scalar_type` maps Duration to s64 and Quantity to its numeric type (dynamic quantities refuse at compile time); `Scalar.of` and the read door convert to/from nanoseconds. The boxed door needed nothing: a Variant already stores a Duration as `Quantity!(long, Nanosecond)` (`isDuration` just means "number with seconds dimension"), so durations and seconds-dimension quantities interchange at every boxed boundary through the generic quantity path - dimension-gated, scale-adjusted. Duration.ticks is platform-dependent (100ns QPC ticks on Windows, ns elsewhere) but every boundary normalises through `as!"nsecs"`, so nanoseconds is the storage and wire currency everywhere. Locked by round-trip tests: defaults, string parsing, both doors, and the interchange itself (a seconds quantity writes a Duration element, a Duration writes a millisecond quantity element, watts still refuse a duration).

## Reference properties
`DataFormat` gains a reference descriptor: a `const(CollectionTypeInfo)*` in the descriptor union, record typed u64 holding `EID(cid, 0)`. The boxed door owns the edge: unbox resolves a name against the target collection (type-checked via `type_matches` when the object exists, **reserved through the id machine when it does not**, so forward references bind when the target is created), and box returns the target's name, which is what console/config/wire all carry. Typed accessors deref per use exactly as ObjectRef does: destruction reads null, recreation at the name rebinds. Change handlers can now receive the SampleUpdate (previous+new); the no-arg shape still works. Reserve-on-absent is the mechanism the base.d startup-latency TODO asks for; the synchronous-tick HACK retires once the remaining reference props migrate off legacy `from_variant`.

## State-machine properties
running and status become ReadOnly elements pushed at every `_state` change site (set_state, disabled setter, destroy, set_remote_state). Held dedup replaces the "probably over-dirty's" HACK: redundant writes store nothing and notify nobody. `status_message()` stays the virtual compute; driver subclasses (wifi/ethernet) call `write_status()` where they used to mark_set. flags deliberately stays legacy (live pull, no write site); the state-transition point-event element is deferred.

## sync_apply accepts read-only echoes
`sync_apply` forwarded to `set()`, which refuses read-only properties, so a mirror could never receive derived state even though the encoders deliberately emit it. Inbound now bypasses the gate; the console-facing `set()` keeps refusing.

## Console commit scope (opportunistic)
The set command's named-argument loop runs in one commit frame, so `set inv baud=19200 protocol=rtu` restarts once. The add command's loop deliberately stays unscoped: deferring creation-time change handlers past the synchronous state-machine tick would bounce fresh objects through an extra restart.

## Notes
- Unit coverage lives in the base.d property test: reference resolve/reserve/rebind, Duration/Quantity round-trips and boundary interchange, ReadOnly gates, previous-value change handlers, per-type synthesis sharing.
- Known gap (documented in the draft): a write landing directly on a property element via `try_set` from the model surface enforces constraint and access gates but bypasses a declared `Check!` function.
- PROP_ELEMENTS.draft.md's full truth-up rides #485, which completes the round.