### PR TITLE
Property projection: class migrations (modbus, ntp, stream reference)

### DIFF
--- a/docs/PROP_ELEMENTS.draft.md
+++ b/docs/PROP_ELEMENTS.draft.md
@@ -6,10 +6,17 @@ getter/setter pairs with hand-rolled dedup and dirty tracking, and become elemen
 data-model space.
 
 Built: the `Elem!` declaration form, the per-object element block, synthesized get/set/reset with
-Default/Min/Max/Check/OnChange, the proxy side-effect gate, and SerialStream's framing properties
-as the first migration. Not built: the descriptor split, reference properties, state-machine
-properties, and the retirement of the per-object sync delta machinery. Deviations from this
-document where it describes the built part are called out inline.
+Default/Min/Max/Check/OnChange, the proxy side-effect gate, property EIDs with container-class
+resolution, Duration/Quantity support through the typed door (the boxed door needed nothing:
+a Variant stores a Duration as Quantity!(long, Nanosecond), so durations and seconds-dimension
+quantities interchange at every boxed boundary already), reference properties (the DataFormat
+reference descriptor, name<->id edge conversion, reserve-on-absent), running/status as ReadOnly
+elements, the commit scope around the console set command, and migrations: SerialStream's framing
+properties, ModbusInterface (protocol/master/baud/estimate-baud/tls and the stream reference),
+and NTPClient (server/port/interval and the read-only offset). Not built: the descriptor split,
+the state-transition point-event element, and the retirement of the per-object sync delta
+machinery. Deviations from this document where it describes the built part are called out
+inline.
 
 ## What exists that this stands on
 
@@ -190,14 +197,13 @@ The element write path replaces, per setter, the hand-written:
 - subscriber notification         -> `SampleUpdate` delivery with previous+new value and
                                      commit-scope coherence
 
-A behavioural improvement becomes *available*, but is not free: because side effects are
-subscriber deliveries, wrapping a multi-property command in a commit scope would coalesce them,
-so `/interface/modbus/set inv baud=19200 protocol=rtu` would restart once after both apply
-rather than once per property. Nothing collects that today -- the only `open_commit()` in the
-tree is `ComponentLink.populate()`, and the console opens no scope around command execution, so
-each set still delivers immediately and restarts independently, exactly as the old setters did.
-Claim it by opening a scope around console command execution (and around the named-argument loop
-in collection create), not by anything in the property machinery.
+A behavioural improvement, now partly claimed: because side effects are subscriber deliveries,
+the commit scope around the set command's named-argument loop coalesces them, so
+`/interface/modbus/set inv baud=19200 protocol=rtu` restarts once after both apply rather than
+once per property. The add command's argument loop deliberately stays unscoped: deferring
+creation-time change handlers past the synchronous state-machine tick would bounce
+freshly-created objects through an extra restart, so scoping it waits on the startup-ordering
+test below.
 
 ### Side effects: the real migration surface
 
@@ -220,7 +226,8 @@ one, it stays on the legacy `Prop!` form until it can be decomposed.
   Never migrates.
 - **`disabled`** -- drives the state machine bits directly; stays bespoke.
 - **`type`** -- a per-type constant; schema, not state.
-- **ObjectRef properties** (`stream=`, `iface=`) -- migrate early, not late. Storage is trivial:
+- **ObjectRef properties** (`stream=`, `iface=`) -- BUILT for ModbusInterface's stream; the rest
+  of the ObjectRef properties still migrate one class at a time. Storage is trivial:
   `EID(cid, 0)` in the 8-byte Scalar; the typed accessor wraps it back into `ObjectRef!T`
   semantics (table deref, null when tombstoned) and held-dedup is a raw compare. What is missing
   is edge vocabulary only: a fourth member of the DataFormat descriptor union
@@ -239,15 +246,17 @@ views over the state-machine bits, and `mark_set` on them means "tell mirrors to
 getter". An element is a push model: something must WRITE the value at the moment it changes.
 The change sites are uneven:
 
-- **`running`** is clean: `set_online`/`set_offline` are exactly the transition points; they
-  become ordinary element writes.
-- **`status`** is nearly clean: `status_message` is a pure function of `_state` (plus
+- **`running`** is BUILT: `set_online`/`set_offline` write the element; the pull-computed
+  member function remains for internal logic and the element mirrors it.
+- **`status`** is BUILT: `status_message` is a pure function of `_state` (plus
   `_fail_reason`, which is always assigned before the transition that exposes it), so one write
-  in `set_state` after the transition covers every site. Held dedup then makes the "probably
-  over-dirty's" HACK comment precise instead of apologetic: redundant writes cost nothing and
-  notify nobody. The state-transition *event* additionally lands as a `point` element, per the
-  sync draft ("`state` becomes a built-in event node on every object"); `StateSignal`
-  subscription becomes element subscription for consumers that only want online/offline.
+  in `set_state` after the transition covers every site (plus the direct `_state` mutation
+  sites: the disabled setter, destroy, and `set_remote_state`). Held dedup made the "probably
+  over-dirty's" HACK precise instead of apologetic: redundant writes cost nothing and notify
+  nobody. Subclasses that override `status_message` with richer state (the wifi/ethernet
+  drivers) call `write_status()` at their own change sites where they used to `mark_set`. NOT
+  yet built: the state-transition *event* as a `point` element, per the sync draft ("`state`
+  becomes a built-in event node on every object"); `StateSignal` subscription stays until then.
 - **`flags` does not migrate.** It folds in `validate()`, a live pull that can flip with no
   local event at all -- a referenced dependency comes into existence and nothing on this object
   runs. Note today's mirror is ALREADY stale in that case (no `mark_set` fires when a dependency
@@ -312,13 +321,16 @@ logic branches on container class. Decide when building; the former is the struc
 5. **Migrate leaf value properties** class by class (baud, mtu, timeouts, booleans, enums,
    comment). Delete member fields, delete `mark_set` calls, declare `OnChange`/checks. Each class
    is a small, verifiable diff.
-6. **The reference descriptor** (`CollectionTypeInfo*` slot in the DataFormat union + name<->id
-   edge conversion), then ObjectRef properties; pending references via `IdAllocator.reserve`
-   retire the synchronous-tick HACK.
-7. **State machine writes `running`/`status`/state-event as elements** (see the derived-views
-   section; `flags` deliberately stays behind). Last of the migrations because the change sites
-   are lifecycle-entangled. These are the first real `ReadOnly` users: the state machine pokes,
-   the operator reads.
+6. **The reference descriptor** -- BUILT (`CollectionTypeInfo*` slot in the DataFormat union,
+   name<->id conversion in the boxed door, reserve-on-absent so forward references bind on
+   creation); ModbusInterface's stream is migrated, remaining ObjectRef properties follow one
+   class at a time. The synchronous-tick HACK retires only when the last reference property
+   leaves the legacy `from_variant` conversion (which still requires the target to exist).
+7. **State machine writes `running`/`status` as elements** -- BUILT (see the derived-views
+   section; `flags` deliberately stays behind, and the state-event `point` element is still to
+   come). These and NTPClient's offset are the first real `ReadOnly` users: the owner pokes, the
+   operator reads. The inbound sync path (`sync_apply`) now bypasses the read-only gate, since a
+   proxy cannot recompute derived state and the encoders deliberately emit it.
 8. **Retire the per-object property sync machinery**: `SyncState`, `attach_delta_slot`,
    `props_dirty`, `_props_set` dirty half; the object mirror's property verbs dissolve per the
    sync draft's convergence table.

--- a/src/protocol/modbus/iface.d
+++ b/src/protocol/modbus/iface.d
@@ -18,6 +18,7 @@ import manager;
 import manager.base;
 import manager.collection;
 import manager.console;
+import manager.element : SampleUpdate;
 import manager.features;
 import manager.plugin;
 
@@ -169,34 +170,45 @@ nothrow @nogc:
     void protocol_changed()
     {
         _support_simultaneous_requests = protocol == ModbusProtocol.tcp;
-        if (protocol == ModbusProtocol.tcp && _stream)
+        if (protocol == ModbusProtocol.tcp && stream)
         {
             import router.stream.serial : SerialStream;
-            if (cast(SerialStream)_stream)
+            if (cast(SerialStream)stream)
                 log.warning("Modbus-TCP has no CRC; using TCP framing over a serial line may cause silent data corruption");
         }
     }
 
-    inout(Stream) stream() inout pure
-        => _stream;
-    const(char)[] stream(Stream value)
-    {
-        if (!value)
-            return "stream cannot be null";
-        if (_stream is value)
-            return null;
-        unsubscribe_stream();
-        static if (has_ip)
-            _conn.clear_remote();
-        _stream = value;
-        mark_set!(typeof(this), "stream")();
+    final Stream stream() const
+        => prop_read!(ModbusInterface, "stream");
+    final void stream(Stream value)
+        => prop_write!(ModbusInterface, "stream")(value);
 
-        if (_stream)
+    void stream_changed(ref const SampleUpdate update)
+    {
+        // the element already holds the new stream; the previous arrives in the update as its name
+        if (_subscribed)
         {
+            if (update.previous.isString)
+            {
+                import manager.collection : get_item_by_name;
+                if (Stream old = get_item_by_name!Stream(update.previous.asString))
+                {
+                    old.unsubscribe(&stream_state);
+                    old.rx_handler = null;
+                }
+            }
+            _subscribed = false;
+        }
+
+        if (Stream s = stream)
+        {
+            static if (has_ip)
+                _conn.clear_remote();
+
             if (protocol == ModbusProtocol.tcp)
             {
                 import router.stream.serial : SerialStream;
-                if (cast(SerialStream)_stream)
+                if (cast(SerialStream)s)
                     log.warning("Modbus-TCP has no CRC; using TCP framing over a serial line may cause silent data corruption");
             }
 
@@ -206,15 +218,13 @@ nothrow @nogc:
             static if (has_ip)
             {
                 import protocol.ip.tcp_stream : TCPStream;
-                auto tcpStream = cast(TCPStream)_stream;
-                if (tcpStream)
+                if (auto tcpStream = cast(TCPStream)s)
                     tcpStream.enable_keep_alive(true, seconds(10), seconds(1), 10);
             }
         }
 
         // flush messages and the address mapping tables
         restart();
-        return null;
     }
 
     static if (has_ip)
@@ -226,11 +236,10 @@ nothrow @nogc:
             auto r = _conn.remote(value.move);
             if (r.succeeded)
             {
-                unsubscribe_stream();
-                _stream = null;  // remote takes ownership of the stream slot
+                stream = null;  // remote takes ownership of the stream slot
                 if (protocol == ModbusProtocol.unknown)
                     protocol = ModbusProtocol.tcp;
-                mark_set!(typeof(this), [ "remote", "stream" ])();
+                mark_set!(typeof(this), "remote")();
                 restart();
             }
             return r;
@@ -238,11 +247,10 @@ nothrow @nogc:
         void remote(InetAddress value)
         {
             _conn.remote(value);
-            unsubscribe_stream();
-            _stream = null;
+            stream = null;
             if (protocol == ModbusProtocol.unknown)
                 protocol = ModbusProtocol.tcp;
-            mark_set!(typeof(this), [ "remote", "stream" ])();
+            mark_set!(typeof(this), "remote")();
             restart();
         }
 
@@ -268,7 +276,7 @@ nothrow @nogc:
             mark_set!(typeof(this), "keepalive")();
         }
 
-        alias Properties = AliasSeq!(Prop!("stream", stream),
+        alias Properties = AliasSeq!(Elem!("stream", Stream, OnChange!stream_changed),
                                      Prop!("remote", remote),
                                      Prop!("port", port),
                                      Elem!("tls", bool, OnChange!restart),
@@ -279,7 +287,7 @@ nothrow @nogc:
                                      Elem!("estimate-baud", bool));
     }
     else
-        alias Properties = AliasSeq!(Prop!("stream", stream),
+        alias Properties = AliasSeq!(Elem!("stream", Stream, OnChange!stream_changed),
                                      Elem!("protocol", ModbusProtocol, Check!protocol_check, OnChange!protocol_changed),
                                      Elem!("master", bool, OnChange!restart),
                                      Elem!("baud", uint, OnChange!restart),
@@ -315,7 +323,7 @@ protected:
 
     override bool validate() const
     {
-        bool have_target = _stream !is null;
+        bool have_target = stream !is null;
         static if (has_ip)
             have_target = have_target || _conn.has_remote();
         return have_target && (!master || protocol != ModbusProtocol.unknown);
@@ -325,7 +333,7 @@ protected:
     {
         static if (has_ip)
         {
-            if (!_stream && _conn.has_remote())
+            if (!stream && _conn.has_remote())
             {
                 if (!_conn.start(this, tls ? 802 : 502, tls))
                     return CompletionStatus.error;
@@ -358,7 +366,7 @@ protected:
         if (!_support_simultaneous_requests)
         {
             import router.stream.serial : SerialStream;
-            if (auto serial = cast(SerialStream)_stream)
+            if (auto serial = cast(SerialStream)stream)
             {
                 compute_timing(serial.baud_rate);
                 _baud_estimated = true;
@@ -403,10 +411,7 @@ protected:
         static if (has_ip)
         {
             if (_conn.has_remote())
-            {
                 _conn.stop();
-                _stream = null;
-            }
         }
 
         return CompletionStatus.complete;
@@ -536,7 +541,6 @@ private:
         MessageCallback callback;
     }
 
-    ObjectRef!Stream _stream;
     bool _subscribed;
     static if (has_ip)
     {
@@ -566,8 +570,8 @@ private:
 
     Stream active_stream()
     {
-        if (_stream)
-            return _stream;
+        if (Stream s = stream)
+            return s;
         static if (has_ip)
             return _conn.get;
         else

--- a/src/protocol/modbus/iface.d
+++ b/src/protocol/modbus/iface.d
@@ -143,53 +143,38 @@ nothrow @nogc:
 
     // Properties...
 
-    ModbusProtocol protocol() const pure
-        => _protocol;
-    const(char)[] protocol(ModbusProtocol value)
-    {
-        if (value == ModbusProtocol.unknown)
-            return "Error: Invalid modbus protocol 'unknown'";
-        _protocol = value;
-        _support_simultaneous_requests = value == ModbusProtocol.tcp;
-        mark_set!(typeof(this), "protocol")();
+    final ModbusProtocol protocol() const
+        => prop_read!(ModbusInterface, "protocol");
+    final void protocol(ModbusProtocol value)
+        => prop_write!(ModbusInterface, "protocol")(value);
 
-        if (_protocol == ModbusProtocol.tcp && _stream)
+    final bool master() const
+        => prop_read!(ModbusInterface, "master");
+    final void master(bool value)
+        => prop_write!(ModbusInterface, "master")(value);
+
+    final uint baud() const
+        => prop_read!(ModbusInterface, "baud");
+    final void baud(uint value)
+        => prop_write!(ModbusInterface, "baud")(value);
+
+    final bool estimate_baud() const
+        => prop_read!(ModbusInterface, "estimate-baud");
+    final void estimate_baud(bool value)
+        => prop_write!(ModbusInterface, "estimate-baud")(value);
+
+    static const(char)[] protocol_check(ref ModbusProtocol value)
+        => value == ModbusProtocol.unknown ? "Invalid modbus protocol 'unknown'" : null;
+
+    void protocol_changed()
+    {
+        _support_simultaneous_requests = protocol == ModbusProtocol.tcp;
+        if (protocol == ModbusProtocol.tcp && _stream)
         {
             import router.stream.serial : SerialStream;
             if (cast(SerialStream)_stream)
                 log.warning("Modbus-TCP has no CRC; using TCP framing over a serial line may cause silent data corruption");
         }
-
-        return null;
-    }
-
-    bool master() const pure
-        => _is_bus_master;
-    void master(bool value)
-    {
-        if (_is_bus_master == value)
-            return;
-
-        _is_bus_master = value;
-        if (value)
-            _master_address = 0;
-        mark_set!(typeof(this), "master")();
-        restart();
-    }
-
-    uint baud() const pure
-        => _user_baud;
-    void baud(uint value)
-    {
-        _user_baud = value;
-        restart();
-    }
-
-    bool estimate_baud() const pure
-        => _estimate_baud;
-    void estimate_baud(bool value)
-    {
-        _estimate_baud = value;
     }
 
     inout(Stream) stream() inout pure
@@ -208,7 +193,7 @@ nothrow @nogc:
 
         if (_stream)
         {
-            if (_protocol == ModbusProtocol.tcp)
+            if (protocol == ModbusProtocol.tcp)
             {
                 import router.stream.serial : SerialStream;
                 if (cast(SerialStream)_stream)
@@ -243,9 +228,9 @@ nothrow @nogc:
             {
                 unsubscribe_stream();
                 _stream = null;  // remote takes ownership of the stream slot
-                if (_protocol == ModbusProtocol.unknown)
-                    _protocol = ModbusProtocol.tcp;
-                mark_set!(typeof(this), [ "remote", "stream", "protocol" ])();
+                if (protocol == ModbusProtocol.unknown)
+                    protocol = ModbusProtocol.tcp;
+                mark_set!(typeof(this), [ "remote", "stream" ])();
                 restart();
             }
             return r;
@@ -255,9 +240,9 @@ nothrow @nogc:
             _conn.remote(value);
             unsubscribe_stream();
             _stream = null;
-            if (_protocol == ModbusProtocol.unknown)
-                _protocol = ModbusProtocol.tcp;
-            mark_set!(typeof(this), [ "remote", "stream", "protocol" ])();
+            if (protocol == ModbusProtocol.unknown)
+                protocol = ModbusProtocol.tcp;
+            mark_set!(typeof(this), [ "remote", "stream" ])();
             restart();
         }
 
@@ -270,16 +255,10 @@ nothrow @nogc:
             restart();
         }
 
-        bool tls() const pure
-            => _tls;
-        void tls(bool value)
-        {
-            if (_tls == value)
-                return;
-            _tls = value;
-            mark_set!(typeof(this), "tls")();
-            restart();
-        }
+        final bool tls() const
+            => prop_read!(ModbusInterface, "tls");
+        final void tls(bool value)
+            => prop_write!(ModbusInterface, "tls")(value);
 
         bool keepalive() const pure
             => _conn.keepalive;
@@ -292,15 +271,19 @@ nothrow @nogc:
         alias Properties = AliasSeq!(Prop!("stream", stream),
                                      Prop!("remote", remote),
                                      Prop!("port", port),
-                                     Prop!("tls", tls),
+                                     Elem!("tls", bool, OnChange!restart),
                                      Prop!("keepalive", keepalive),
-                                     Prop!("protocol", protocol),
-                                     Prop!("master", master));
+                                     Elem!("protocol", ModbusProtocol, Check!protocol_check, OnChange!protocol_changed),
+                                     Elem!("master", bool, OnChange!restart),
+                                     Elem!("baud", uint, OnChange!restart),
+                                     Elem!("estimate-baud", bool));
     }
     else
         alias Properties = AliasSeq!(Prop!("stream", stream),
-                                     Prop!("protocol", protocol),
-                                     Prop!("master", master));
+                                     Elem!("protocol", ModbusProtocol, Check!protocol_check, OnChange!protocol_changed),
+                                     Elem!("master", bool, OnChange!restart),
+                                     Elem!("baud", uint, OnChange!restart),
+                                     Elem!("estimate-baud", bool));
 
 
     // API...
@@ -335,7 +318,7 @@ protected:
         bool have_target = _stream !is null;
         static if (has_ip)
             have_target = have_target || _conn.has_remote();
-        return have_target && (!master || _protocol != ModbusProtocol.unknown);
+        return have_target && (!master || protocol != ModbusProtocol.unknown);
     }
 
     override CompletionStatus startup()
@@ -344,10 +327,11 @@ protected:
         {
             if (!_stream && _conn.has_remote())
             {
-                if (!_conn.start(this, _tls ? 802 : 502, _tls))
+                if (!_conn.start(this, tls ? 802 : 502, tls))
                     return CompletionStatus.error;
-                if (_protocol == ModbusProtocol.unknown)
-                    _protocol = ModbusProtocol.tcp;
+                // startup's protocol inference is not user configuration: poke the element without marking
+                if (protocol == ModbusProtocol.unknown)
+                    prop_element(prop_index!(ModbusInterface, "protocol")).try_write(ModbusProtocol.tcp);
             }
         }
 
@@ -367,7 +351,7 @@ protected:
         super.online();
 
         // allocate a universal address for the remote bus master on non-master interfaces
-        if (!_is_bus_master && _master_address == 0)
+        if (!master && _master_address == 0)
             _master_address = get_module!ModbusProtocolModule().allocate_universal_address(ephemeral: true);
 
         // compute timing parameters from baud rate
@@ -381,10 +365,10 @@ protected:
             }
             else
             {
-                uint baud = _user_baud != 0 ? _user_baud : _estimated_baud != 0 ? _estimated_baud : 9_600;
-                compute_timing(baud);
+                uint remote_baud = baud != 0 ? baud : _estimated_baud != 0 ? _estimated_baud : 9_600;
+                compute_timing(remote_baud);
                 _gap_time_us = 0;
-                _baud_estimated = _user_baud != 0 || _estimated_baud != 0;
+                _baud_estimated = baud != 0 || _estimated_baud != 0;
             }
         }
 
@@ -438,7 +422,7 @@ protected:
         _queue.timeout_stale(getTime());
 
         // estimate remote baud rate for TCP bridges after collecting stats
-        if (_estimate_baud && !_baud_estimated && !_support_simultaneous_requests && _status.tx_packets >= 20)
+        if (estimate_baud && !_baud_estimated && !_support_simultaneous_requests && _status.tx_packets >= 20)
             estimate_remote_baud();
 
         send_queued_messages();
@@ -465,7 +449,7 @@ protected:
         auto mod_mb = get_module!ModbusProtocolModule();
         ref const ModbusFrame hdr = packet.hdr!ModbusFrame();
 
-        if (_is_bus_master)
+        if (master)
         {
             if (hdr.type != ModbusFrameType.request)
             {
@@ -558,18 +542,13 @@ private:
     {
         import protocol.ip.client : IPClient;
         IPClient _conn;
-        bool _tls;
     }
 
-    ModbusProtocol _protocol;
-    bool _is_bus_master;
     bool _support_simultaneous_requests = false;
     uint _request_timeout = 800;   // ms - computed from baud rate in startup()
     uint _queue_timeout = 2500;    // ms - computed from baud rate in startup()
     uint _gap_time_us = 4000;      // microseconds - computed from baud rate in startup()
-    uint _user_baud;               // explicit remote baud rate (0 = not set)
     uint _estimated_baud;          // estimated remote baud rate for TCP bridges
-    bool _estimate_baud;           // enable auto-estimation of remote baud rate
     bool _baud_estimated;
     MonoTime _last_receive_event;
 
@@ -930,7 +909,7 @@ private:
             log.debug_("packet received: (", message.length, ")[ ", message[], " ]");
 
         // if we are the bus master, then we can only receive responses...
-        ModbusFrameType type = _is_bus_master ? ModbusFrameType.response : frame_info.frame_type;
+        ModbusFrameType type = master ? ModbusFrameType.response : frame_info.frame_type;
         if (type == ModbusFrameType.unknown && _expect_message_type != ModbusFrameType.unknown)
         {
             // if we haven't seen a packet for longer than the timeout interval, then we can't trust our guess
@@ -949,7 +928,7 @@ private:
             auto mod_mb = get_module!ModbusProtocolModule();
             ServerMap* map = mod_mb.find_server_by_local_address(frame_info.address, this);
 
-            if (_is_bus_master)
+            if (master)
             {
                 // master iface: incoming = response from a slave we polled
                 if (!map)
@@ -978,7 +957,7 @@ private:
         hdr.type = type;
         hdr.function_code = cast(ubyte)frame_info.function_code;
 
-        if (_is_bus_master)
+        if (master)
         {
             if (!_support_simultaneous_requests)
             {

--- a/src/protocol/ntp/client.d
+++ b/src/protocol/ntp/client.d
@@ -16,10 +16,10 @@ nothrow @nogc:
 // SNTP (RFC 4330) unicast client
 class NTPClient : ActiveObject
 {
-    alias Properties = AliasSeq!(Prop!("server",   server),
-                                 Prop!("port",     port),
-                                 Prop!("interval", interval),
-                                 Prop!("offset",   offset));
+    alias Properties = AliasSeq!(Elem!("server",   String, OnChange!restart),
+                                 Elem!("port",     ushort, Default!123, OnChange!restart),
+                                 Elem!("interval", Duration, Default!(seconds(17 * 60))),
+                                 Elem!("offset",   Duration, ReadOnly));
 nothrow @nogc:
 
     enum type_name = "ntp-client";
@@ -29,60 +29,43 @@ nothrow @nogc:
     this(CID id, ObjectFlags flags = ObjectFlags.none)
     {
         super(collection_type_info!NTPClient, id, flags);
-        _port = 123;
-        _interval = seconds(17 * 60);
     }
 
     // Properties
 
-    final const(char)[] server() const pure
-        => _server[];
-    final void server(const(char)[] value)
-    {
-        if (_server[] == value)
-            return;
-        _server = value.makeString(g_app.allocator);
-        mark_set!(typeof(this), "server")();
-        restart();
-    }
+    final const(char)[] server() const
+        => prop_read!(NTPClient, "server")[];
+    final void server(String value)
+        => prop_write!(NTPClient, "server")(value.move);
 
-    final ushort port() const pure
-        => _port;
+    final ushort port() const
+        => prop_read!(NTPClient, "port");
     final void port(ushort value)
-    {
-        if (_port == value)
-            return;
-        _port = value;
-        mark_set!(typeof(this), "port")();
-        restart();
-    }
+        => prop_write!(NTPClient, "port")(value);
 
-    final Duration interval() const pure
-        => _interval;
+    final Duration interval() const
+        => prop_read!(NTPClient, "interval");
     final void interval(Duration value)
-    {
-        _interval = value;
-        mark_set!(typeof(this), "interval")();
-    }
+        => prop_write!(NTPClient, "interval")(value);
 
-    final Duration offset() const pure
-        => _last_offset;
+    final Duration offset() const
+        => prop_read!(NTPClient, "offset");
 
 protected:
 
-    override bool validate() const pure
-        => _server.length > 0;
+    override bool validate() const
+        => server.length > 0;
 
     override CompletionStatus startup()
     {
         IPAddr ip;
-        size_t n = ip.fromString(_server[]);
-        if (n == 0 || n != _server.length)
+        size_t n = ip.fromString(server);
+        if (n == 0 || n != server.length)
         {
-            log.warning("invalid server address '", _server[], "'");
+            log.warning("invalid server address '", server, "'");
             return CompletionStatus.error;
         }
-        _addr = InetAddress(ip, _port);
+        _addr = InetAddress(ip, port);
 
         Result r = create_socket(AddressFamily.ipv4, SocketType.datagram, Protocol.udp, _socket);
         if (r)
@@ -131,12 +114,12 @@ protected:
                 if (apply_response(buf[0 .. bytes]))
                 {
                     _pending = false;
-                    _next_poll = now + _interval;
+                    _next_poll = now + interval;
                 }
             }
             else if (now - _request_time > response_timeout)
             {
-                log.warning("no response from ", _server[], ':', _port);
+                log.warning("no response from ", server, ':', port);
                 _pending = false;
                 _next_poll = now + retry_interval;
             }
@@ -146,11 +129,6 @@ protected:
     }
 
 private:
-    String   _server;
-    ushort   _port;
-    Duration _interval;
-    Duration _last_offset;
-
     Socket      _socket = Socket.invalid;
     InetAddress _addr;
     MonoTime    _next_poll;
@@ -172,7 +150,7 @@ private:
         size_t sent;
         if (!_socket.send(pkt[], MsgFlags.none, &sent))
         {
-            log.warning("send to ", _server[], ':', _port, " failed");
+            log.warning("send to ", server, ':', port, " failed");
             _next_poll = now + retry_interval;
             return;
         }
@@ -201,11 +179,11 @@ private:
         long rtt = (t4 - _t1).as!"nsecs";
         ulong corrected = cast(ulong)(t3 + (rtt - (t3 - t2)) / 2);
 
-        _last_offset = from_unix_time_ns(corrected) - getSysTime();
-        mark_set!(typeof(this), "offset")();
+        Duration off = from_unix_time_ns(corrected) - getSysTime();
+        prop_write!(NTPClient, "offset")(off);
         set_utc_time(corrected);
 
-        log.info("synced from ", _server[], " offset ", _last_offset.as!"msecs", "ms");
+        log.info("synced from ", server, " offset ", off.as!"msecs", "ms");
         return true;
     }
 }


### PR DESCRIPTION
Stacked on #484 (the machinery half) — diff shown here is against `ow/dm-props2`; retarget to master after #484 merges. Four commits, each walk-buildable with 128/128 unit tests passing; the tip tree is byte-identical to the originally-validated 9-commit chain.

## ModbusInterface value properties
protocol, master, baud, estimate-baud, and tls become `Elem!` declarations (baud/estimate-baud were accessor pairs missing from the Properties list, so they gain console exposure). The derived `_support_simultaneous_requests` moves into protocol's change reaction, which now also covers the paths that assigned `_protocol` directly (remote setters, startup's TCP inference), fixing the case where a remote-configured interface ran TCP framing at serial queue depth 1. The master setter's address clearing is dropped: OnChange!restart cycles through shutdown, which already releases and clears the universal address (and no longer leaks it on the slave-to-master flip).

## NTPClient
server/port/interval become `Elem!` declarations with construction defaults expressed as `Default!`; interval carries the Duration element support end to end; offset is the first real ReadOnly user — the sync result pokes in through `prop_write` while the console and sync inbound refuse writes.

## ModbusInterface stream — the first migrated reference
`Elem!("stream", Stream, OnChange!stream_changed)` replaces the legacy setter and the ObjectRef field. The swap logic moves into `stream_changed`, which receives the previous stream (as its name, per reference boxing) to unsubscribe before restarting; the derived concerns (remote clearing, TCP-over-serial CRC warning, keep-alive setup) ride the same handler. The remote setters clear the stream through the property so the handler sees the transition. Because the reference edge reserves absent names, `stream=` now tolerates forward references — the ref binds when the named stream is created.

## Docs
PROP_ELEMENTS.draft.md truth-up for the whole round: what is built (EIDs+resolve, Duration/Quantity, references, running/status, the set-command commit scope, and these migrations), what deliberately is not (descriptor split, point-event state element, flags, sync-delta retirement), and the known Check!-bypass gap on the model surface.

## Notes
- Runtime validation is unit-test-level for the round; a Pi soak via the OTA supervisor is still worth doing before building further on top.