### PR TITLE
rtc: rename time to last-observed

### DIFF
--- a/src/driver/rtc/pcf85063.d
+++ b/src/driver/rtc/pcf85063.d
@@ -27,7 +27,7 @@ class PCF85063 : ActiveObject
 {
     alias Properties = AliasSeq!(Prop!("interface", iface),
                                  Prop!("address", address),
-                                 Prop!("time", time),
+                                 Prop!("last-observed", last_observed),
                                  Prop!("last-error", last_error, "status", "d"));
 nothrow @nogc:
 
@@ -65,13 +65,10 @@ nothrow @nogc:
         restart();
     }
 
-    SysTime time() const pure
+    SysTime last_observed() const pure
         => _time;
 
-    PCF85063Error last_error() const pure
-        => _last_error;
-
-    StringResult time(SysTime value)
+    StringResult last_observed(SysTime value)
     {
         I2CInterface interface_ = _iface.get;
         if (!interface_ || !interface_.running)
@@ -89,9 +86,12 @@ nothrow @nogc:
 
         _time = value;
         _time_valid = true;
-        mark_set!(typeof(this), "time")();
+        mark_set!(typeof(this), "last-observed")();
         return StringResult.success;
     }
+
+    PCF85063Error last_error() const pure
+        => _last_error;
 
     override const(char)[] status_message() const pure
     {
@@ -153,7 +153,7 @@ protected:
         _time = get_sys_time(_response_time);
         _time_valid = true;
         set_utc_time(unix_time_ns(_time));
-        mark_set!(typeof(this), "time")();
+        mark_set!(typeof(this), "last-observed")();
         log.info("restored UTC time ", _response_time);
         reset_operation();
         return CompletionStatus.complete;
@@ -182,7 +182,7 @@ protected:
             {
                 _time = get_sys_time();
                 _time_valid = true;
-                mark_set!(typeof(this), "time")();
+                mark_set!(typeof(this), "last-observed")();
                 set_last_error(PCF85063Error.none);
             }
             reset_operation();


### PR DESCRIPTION
`/driver/rtc/pcf85063`'s `time` property is renamed to `last-observed`.

`time` reads as the current time, which invites treating the object as a clock to poll. It is not one. The value is the moment the RTC last reported: written when it is read at startup, and when a time is set into it. It does not advance between those events.

Nor could it. Properties signal on change, and a clock changes always, so a property that tracked the passing second would be a signal storm that nothing would want to subscribe to. The RTC holds a moment; the passing of time is the system clock's job.

```
/driver/rtc/pcf85063/set name=rtc last-observed=2026-08-11T12:00:00
```

Nothing in-tree used `time=`, so no configuration changes with it. This is a breaking rename for anyone who did.

Also here: the getter and setter were sitting either side of `last_error`, and are now together.

Builds for esp32-s3 / waveshare-esp32-s3-rs485-can. Not re-flashed for the rename itself, but the behaviour it names was seen on hardware while testing other work on a fresh board, which reports it correctly before any clock source exists:

```
[Info] pcf85063 'rtc': RTC has never been set; waiting for a clock source
```

The branch is still called `ow/rtc-reference-time`, from an earlier spelling of the name.
