### PR TITLE
http/static: stream GET responses above 64KB

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -425,7 +425,8 @@ server. `GET <uri>/a/b.css` reads `<root>/a/b.css`; a directory request serves
 request body to the mapped path and `DELETE` removes it. Uploads stream to a
 temporary as the body arrives, so they are not limited by the server's
 `max-request-body`, and the target is only replaced once the upload completes:
-an interrupted transfer leaves the previous file untouched.
+an interrupted transfer leaves the previous file untouched. Responses larger
+than 64KB stream from disk instead of buffering, paced by the connection.
 
 Path mapping URL-decodes the request, rejects `..` traversal, and refuses
 path separators inside a segment, for reads and writes alike.

--- a/docs/UX_TODO.md
+++ b/docs/UX_TODO.md
@@ -59,4 +59,6 @@ through them and remove sections as they are absorbed.
   `max-request-body`, and an interrupted upload leaves the previous file intact. Requests
   the mount refuses (403, 405, 409, 500) still drain the body and answer with the real
   status, so large uploads never die as opaque network errors.
+- Downloads above 64KB stream from disk with a known `Content-Length`; they skip response
+  compression, trading a little link time for bounded memory.
 - There is no ETag/If-Match yet: two editors saving the same file last-writer-wins.

--- a/src/protocol/http/staticfiles.d
+++ b/src/protocol/http/staticfiles.d
@@ -147,6 +147,14 @@ protected:
             if (s)
                 s.destroy();
         }
+        while (!_downloads.empty)
+        {
+            Download* d = _downloads[_downloads.length - 1];
+            Stream s = d.stream;
+            finish_download(d);
+            if (s)
+                s.destroy();
+        }
 
         if (_registered)
         {
@@ -160,6 +168,16 @@ protected:
         return CompletionStatus.complete;
     }
 
+    override void update()
+    {
+        for (size_t i = 0; i < _downloads.length; )
+        {
+            // on completion the entry is swap-removed; the same index then holds the next candidate
+            if (!_downloads[i].pump())
+                ++i;
+        }
+    }
+
 private:
     ObjectRef!HTTPServer _server;
     String _uri;
@@ -167,6 +185,7 @@ private:
     String _allowed_origin;
     bool _registered;
     Array!(Upload*) _uploads;
+    Array!(Download*) _downloads;
 
     void remove_handlers(HTTPServer server)
     {
@@ -292,9 +311,30 @@ private:
 
         ulong size = f.get_size();
 
-        // TODO: above some threshold, stream the response (Transfer-Encoding: chunked)
-        //       instead of buffering the whole file. The threshold should eventually be
-        //       adaptive on free memory and detected link bandwidth. For now we always buffer.
+        if (size > Download.stream_threshold)
+        {
+            // head first with the known length, then the body is pumped from update() as the
+            // stream's tx queue drains, so the file is never resident in memory at once
+            HTTPMessage response;
+            response.http_version = ver;
+            response.status_code = 200;
+            response.reason = status_text(200);
+            response.timestamp = getSysTime();
+            response.headers ~= HTTPParam(StringLit!"Content-Type", mime_type(fs_path));
+            response.headers ~= HTTPParam(StringLit!"Content-Length", tconcat(size).makeString(defaultAllocator()));
+            add_cors(response, request);
+            stream.write(format_message_head(response)[]);
+
+            Download* d = defaultAllocator().allocT!Download();
+            d.owner = this;
+            d.stream = stream;
+            d.file = f;
+            d.remaining = size;
+            stream.subscribe(&d.stream_state);
+            _downloads ~= d;
+            d.pump();
+            return true;
+        }
 
         HTTPMessage response;
         response.http_version = ver;
@@ -432,6 +472,16 @@ private:
         defaultAllocator().freeT(u);
     }
 
+    void finish_download(Download* d)
+    {
+        if (d.file.is_open)
+            d.file.close();
+        if (d.stream)
+            d.stream.unsubscribe(&d.stream_state);
+        _downloads.removeFirstSwapLast(d);
+        defaultAllocator().freeT(d);
+    }
+
     static struct Upload
     {
     nothrow @nogc:
@@ -496,6 +546,59 @@ private:
             // the connection died mid-body; the temporary is discarded, the target untouched
             if (signal != StateSignal.online)
                 owner.finish_upload(&this);
+        }
+    }
+
+    static struct Download
+    {
+    nothrow @nogc:
+        enum stream_threshold = 64 * 1024;  // buffer smaller responses (they remain compressible)
+        enum chunk_size = 16 * 1024;
+        enum backlog_high = 64 * 1024;      // stop pumping while this much is queued on the stream
+
+        StaticFileServer owner;
+        Stream stream;
+        File file;
+        ulong remaining;
+
+        // returns true when the transfer completed or died (and this context was freed)
+        bool pump()
+        {
+            while (true)
+            {
+                if (!stream.running || remaining == 0)
+                {
+                    owner.finish_download(&this);
+                    return true;
+                }
+                if (stream.tx_backlog() >= backlog_high)
+                    return false;
+
+                ubyte[chunk_size] buf = void;
+                size_t take = remaining < chunk_size ? cast(size_t)remaining : chunk_size;
+                size_t got;
+                Result r = file.read(buf[0 .. take], got);
+                if (r && got == take && stream.write(buf[0 .. got]) == cast(ptrdiff_t)got)
+                {
+                    remaining -= got;
+                    continue;
+                }
+
+                // the Content-Length is already promised; drop the connection so the client
+                // sees a broken transfer rather than a silently short file
+                writeWarning("static: transfer failed mid-body, dropping connection");
+                Stream s = stream;
+                StaticFileServer o = owner;
+                o.finish_download(&this);
+                s.destroy();
+                return true;
+            }
+        }
+
+        void stream_state(ActiveObject, StateSignal signal)
+        {
+            if (signal != StateSignal.online)
+                owner.finish_download(&this);
         }
     }
 }

--- a/src/protocol/ip/package.d
+++ b/src/protocol/ip/package.d
@@ -653,6 +653,17 @@ nothrow @nogc:
     bool connected() const pure
         => _phase == Phase.open;
 
+    // bytes accepted by send() but not yet handed to the network
+    size_t tx_backlog() const pure
+    {
+        version (UseInternalIPStack)
+            return _tx.length;
+        else version (Windows)
+            return _tx_pending;
+        else
+            return _tx.length;
+    }
+
     void recv_handler(TCPRecvHandler handler)
     {
         _on_recv = handler;
@@ -746,10 +757,12 @@ nothrow @nogc:
             WSABUF wb = WSABUF(cast(uint)op.buf.length, op.buf.ptr);
             uint sent;
             ++_outstanding;
+            _tx_pending += op.buf.length;
             if (WSASend(_handle, &wb, 1, &sent, 0, &op.io.ov, null) != 0 &&
                 ws_lasterror() != WSA_IO_PENDING)
             {
                 --_outstanding;
+                _tx_pending -= op.buf.length;
                 defaultAllocator().free(op.buf);
                 defaultAllocator().freeT(op);
                 fail(IPEvent.error);
@@ -1012,6 +1025,7 @@ private:
 
         IOCP_SOCKET _handle = INVALID_SOCKET;
         int  _outstanding;   // overlapped ops in flight; freed by the pump sweep once they drain
+        size_t _tx_pending;  // bytes owned by in-flight send ops
         IoOp _connect_op;
         RecvOp _recv;
 
@@ -1101,6 +1115,7 @@ private:
         void send_complete(IoOp* op, bool ok, uint, uint)
         {
             SendOp* sop = cast(SendOp*)op;
+            _tx_pending -= sop.buf.length;
             defaultAllocator().free(sop.buf);
             defaultAllocator().freeT(sop);
             --_outstanding;

--- a/src/protocol/ip/tcp_stream.d
+++ b/src/protocol/ip/tcp_stream.d
@@ -242,6 +242,9 @@ nothrow @nogc:
         return n;
     }
 
+    override size_t tx_backlog() const
+        => _conn ? _conn.tx_backlog : 0;
+
 private:
     TCPConnection* _conn;
     InetAddress _remote;

--- a/src/protocol/tls/stream.d
+++ b/src/protocol/tls/stream.d
@@ -603,6 +603,13 @@ nothrow @nogc:
         return result;
     }
 
+    final override size_t tx_backlog() const
+    {
+        if (auto s = _stream.get)
+            return s.tx_backlog;
+        return 0;
+    }
+
     final override ptrdiff_t pending()
         => _app_buffer.length;
 

--- a/src/router/stream/package.d
+++ b/src/router/stream/package.d
@@ -226,6 +226,11 @@ nothrow @nogc:
 
     abstract ptrdiff_t write(const(void[])[] data...);
 
+    // bytes accepted by write() but still queued locally awaiting transmission; poll to pace bulk
+    // transfers. Streams that transmit synchronously (or can't tell) report no backlog.
+    size_t tx_backlog() const
+        => 0;
+
     ptrdiff_t pending()
         => _rx_buffer.length;
 


### PR DESCRIPTION
Stacked on #488. Resolves the standing TODO in `serve_file` to stop buffering whole files.

Two commits:

1. **`stream/ip: expose tx_backlog`** — a plain read loop over `Stream.write` is not safe for bulk data: the internal stack queues unboundedly (moving the buffering problem rather than fixing it), and the socket backend short-writes at its 256KB cap with return values that can't drive a retry (it reports `total` after dropping the tail, or `0` after queueing part). `Stream.tx_backlog()` reports bytes accepted but still queued locally (TCP on all three backends; TLS forwards to its transport), so bulk senders can pace instead.

2. **`http/static: stream GET responses above 64KB`** — the head goes out with the known `Content-Length` (no chunked encoding needed), then the body is pumped from `update()` in 16KB chunks, gated on `tx_backlog` staying under a 64KB watermark, so the queue never reaches the point where writes become lossy. A read or write failure mid-body drops the connection deliberately: the length is already promised, and a silently short file is worse. Files under the threshold keep the buffered path and remain compressible; streamed responses skip content-encoding.

Tested live with curl: 200KB GET byte-identical to the file on disk.