### PR TITLE
http/static: serve conf, log and yaml as text

### DIFF
--- a/docs/UX_TODO.md
+++ b/docs/UX_TODO.md
@@ -61,4 +61,6 @@ through them and remove sections as they are absorbed.
   status, so large uploads never die as opaque network errors.
 - Downloads above 64KB stream from disk with a known `Content-Length`; they skip response
   compression, trading a little link time for bounded memory.
+- `.conf` and `.log` serve as `text/plain`, `.yaml`/`.yml` as `text/yaml`, so they display
+  in a browser tab instead of downloading as `application/octet-stream`.
 - There is no ETag/If-Match yet: two editors saving the same file last-writer-wins.

--- a/src/protocol/http/staticfiles.d
+++ b/src/protocol/http/staticfiles.d
@@ -646,7 +646,11 @@ String mime_type(const(char)[] path) pure
         case "json":    return StringLit!"application/json; charset=utf-8";
         case "map":     return StringLit!"application/json";
         case "xml":     return StringLit!"application/xml; charset=utf-8";
-        case "txt":     return StringLit!"text/plain; charset=utf-8";
+        case "txt":
+        case "conf":
+        case "log":     return StringLit!"text/plain; charset=utf-8";
+        case "yaml":
+        case "yml":     return StringLit!"text/yaml; charset=utf-8";
         case "csv":     return StringLit!"text/csv; charset=utf-8";
         case "md":      return StringLit!"text/markdown; charset=utf-8";
         case "svg":     return StringLit!"image/svg+xml";


### PR DESCRIPTION
Stacked on #489.

`.conf`, `.log`, `.yaml`/`.yml` served as `application/octet-stream`, so a browser downloads them instead of displaying them in a tab. `conf` and `log` join the `text/plain` group; yaml serves as `text/yaml` (the registered `application/yaml` still triggers a download, which defeats the point).