### PR TITLE
console: add /system/fs/ls

### DIFF
--- a/src/manager/package.d
+++ b/src/manager/package.d
@@ -474,6 +474,7 @@ nothrow @nogc:
             console.register_command!fs_info("/system/fs", this, "info");
             console.register_command!fs_write("/system/fs", this, "write");
             console.register_command!fs_read("/system/fs", this, "read");
+            console.register_command!fs_ls("/system/fs", this, "ls");
             console.register_command!fs_rm("/system/fs", this, "rm");
         }
 

--- a/src/manager/system.d
+++ b/src/manager/system.d
@@ -3,6 +3,7 @@ module manager.system;
 import urt.array;
 import urt.log;
 import urt.mem.allocator;
+import urt.meta.nullable;
 import urt.string;
 import urt.system;
 import urt.time;
@@ -216,6 +217,32 @@ version (HasFilesystem)
         }
         session.write_line(data.length, " bytes: ", cast(const(char)[])data);
         defaultAllocator().free(data);
+    }
+
+    void fs_ls(Session session, Nullable!(const(char)[]) path)
+    {
+        import urt.file : Directory, DirEntry, open, read, close;
+
+        const(char)[] dir_path = path ? path.value : null;
+
+        Directory dir;
+        if (!dir.open(dir_path))
+        {
+            session.write_line("cannot list '", dir_path, "'");
+            return;
+        }
+
+        uint count;
+        ulong total;
+        DirEntry entry;
+        while (dir.read(entry))
+        {
+            session.write_line(entry.is_directory ? "d " : "  ", entry.size, "\t", entry.name);
+            total += entry.size;
+            ++count;
+        }
+        dir.close();
+        session.write_line(count, " entries, ", total, " bytes");
     }
 
     void fs_rm(Session session, const(char)[] name)


### PR DESCRIPTION
`urt.file` grew directory enumeration in open-watt/urt#218; this is the first thing that uses it, and it closes a gap in the `/system/fs` surface: you could write, read and remove a file, but not find out what was there.

```
/system/fs/ls                          /system/fs/ls path=conf
  280   .telnet_history                d 0   device_profiles
  5     a.txt                            16  startup.conf.bad
d 0     conf                           2 entries, 16 bytes
3 entries, 285 bytes
```

`path` is optional, so a bare `ls` lists the root. It is spelled `Nullable!(const(char)[])` because the console treats only `Nullable` as optional and ignores a D default argument, which is worth knowing before writing the next optional parameter.

Also bumps the urt pointer to master, which is where #218 landed.

## Verified

On hardware, ESP32-S3 (Waveshare RS485-CAN), release build, driven over the board's provisioning AP. This command is what proved out the enumeration API itself: files and directories distinguished, sizes correct, two levels of nesting walked, and both error cases clean, with listing a path that does not exist and listing a regular file each failing rather than returning garbage.

The `startup.conf.bad` above is the boot guard's retired config, so the listing is also showing recovery state that was previously invisible from the console.
