### PR TITLE
Select ESP-IDF logging at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -461,6 +461,22 @@ ifdef ESP_PROJECT_DIR
         ESP_FLASH_SIZE := $(BOARD_FLASH_SIZE)
         ESP_PSRAM_SIZE := $(BOARD_PSRAM_SIZE)
     endif
+
+    IDF_LOG_LEVEL ?= none
+    ifeq ($(filter $(IDF_LOG_LEVEL),none error warn),)
+        $(error Unknown IDF_LOG_LEVEL='$(IDF_LOG_LEVEL)'; valid: none | error | warn)
+    endif
+    ESP_IDF_LOG_SDKCONFIG := $(abspath platforms/esp32-common/sdkconfig.idf-log-$(IDF_LOG_LEVEL).defaults)
+    ifeq ($(wildcard $(ESP_IDF_LOG_SDKCONFIG)),)
+        $(error Missing ESP-IDF log policy $(ESP_IDF_LOG_SDKCONFIG))
+    endif
+    ESP_SDKCONFIG_DEFAULTS := $(ESP_SDKCONFIG_DEFAULTS);$(ESP_IDF_LOG_SDKCONFIG)
+    ifeq ($(IDF_LOG_LEVEL),none)
+        DFLAGS := $(DFLAGS) $(VERSION_FLAG)NoIDFLog
+        ESP_IDF_LOG_ENABLED := 0
+    else
+        ESP_IDF_LOG_ENABLED := 1
+    endif
 endif
 
 ifeq ($(XTENSA_TWO_STAGE),1)
@@ -484,6 +500,7 @@ endif
 		idf.py -B "$(ESP_BUILD_DIR)" -DIDF_TARGET=$(ESP_IDF_TARGET) \
 			-DSDKCONFIG="$(ESP_SDKCONFIG)" -DSDKCONFIG_DEFAULTS="$(ESP_SDKCONFIG_DEFAULTS)" \
 			-DOPENWATT_OBJ=$(abspath $(ESP_LINK_OBJ)) \
+			-DIDF_LOG_ENABLED=$(ESP_IDF_LOG_ENABLED) \
 			-DUSE_LWIP=$(if $(filter 1,$(USE_INTERNAL_IP_STACK)),0,1) \
 			-DUSE_SPIFFS=$(USE_SPIFFS) -DUSE_LITTLEFS=$(USE_LITTLEFS) build'
 	cp "$(ESP_BUILD_DIR)/openwatt.bin" "$(TARGETDIR)/openwatt.bin"


### PR DESCRIPTION
Summary:
- select none, error, or warn IDF logging through IDF_LOG_LEVEL
- append the matching sdkconfig defaults
- keep D and C bridge inclusion consistent

This completes the build-side half of the IDF logging changes already merged in #469. Without it, current ESP32 links can omit idf_log.c while retaining D references to its symbols.

Validation:
- clean SmartEVSE ESP-IDF release link with IDF_LOG_LEVEL=none