### PR TITLE
Bind SmartEVSE hardware into the Device model

### DIFF
--- a/platforms/esp32/boards/smartevse-v30/system.conf
+++ b/platforms/esp32/boards/smartevse-v30/system.conf
@@ -5,3 +5,4 @@
 
 /system/update-rate rate=100
 /driver/boards/smartevse/add name=evse current=60
+/binding/smartevse/add name=evse evse=evse device=smartevse

--- a/src/driver/boards/smartevse/binding.d
+++ b/src/driver/boards/smartevse/binding.d
@@ -1,0 +1,417 @@
+module driver.boards.smartevse.binding;
+
+version (SmartEVSE):
+
+import urt.mem.string : addString;
+import urt.meta : AliasSeq;
+import urt.si.quantity : Quantity;
+import urt.si.unit : Celsius, ScaledUnit, Volt;
+import urt.string;
+import urt.time : getSysTime;
+
+import manager : g_app;
+import manager.base : ActiveObject, CompletionStatus, ObjectFlags, ObjectRef, Prop, StateSignal;
+import manager.binding : ProtocolBinding;
+import manager.collection : CID, collection_type_info;
+import manager.component : Component, ComponentEvent;
+import manager.device : Device;
+import manager.element : Access, Element, SampleUpdate, SamplingMode;
+import manager.series : register_value_format;
+
+import driver.boards.smartevse : DeciAmps, SmartEVSE, SmartEVSEADCCalibration,
+                                SmartEVSEChange, SmartEVSEContactor2Mode,
+                                SmartEVSEPilot, SmartEVSEState;
+
+nothrow @nogc:
+
+
+alias DegreesC = Quantity!(short, Celsius);
+alias MilliVolts = Quantity!(uint, ScaledUnit(Volt, -3));
+
+class SmartEVSEBinding : ProtocolBinding
+{
+    alias Properties = AliasSeq!(Prop!("evse", evse));
+nothrow @nogc:
+
+    enum type_name = "smartevse-binding";
+    enum path = "/binding/smartevse";
+
+    this(CID id, ObjectFlags flags = ObjectFlags.none)
+    {
+        super(collection_type_info!SmartEVSEBinding, id, flags);
+    }
+
+    final inout(SmartEVSE) evse() inout pure
+        => _evse.get;
+
+    final void evse(SmartEVSE value)
+    {
+        if (_evse.get is value)
+            return;
+        unsubscribe();
+        _evse = value;
+        mark_set!(typeof(this), "evse")();
+        restart();
+    }
+
+    final override bool validate() const pure
+        => _evse.get !is null && !_device.empty;
+
+    override CompletionStatus startup()
+    {
+        if (!materialise())
+            return CompletionStatus.error;
+
+        SmartEVSE hardware = _evse.get;
+        if (!hardware)
+            return CompletionStatus.continue_;
+
+        hardware.subscribe_changes(&hardware_changed);
+        hardware.subscribe(&hardware_state_changed);
+        subscribe_elements();
+        _subscribed = true;
+
+        publish(SmartEVSEChange.all);
+        publish_online();
+        _device_instance.notify(ComponentEvent.online);
+        return CompletionStatus.complete;
+    }
+
+    override CompletionStatus shutdown()
+    {
+        unsubscribe();
+        if (_device_instance)
+            _device_instance.notify(ComponentEvent.offline);
+        return CompletionStatus.complete;
+    }
+
+protected:
+
+    override bool materialise()
+    {
+        if (_built)
+            return true;
+
+        Device* found = _device[] in g_app.devices;
+        if (!found)
+            return false;
+        _device_instance = *found;
+
+        Component info = find_or_create_component(_device_instance, "info", "DeviceInfo");
+        set_constant(info, "type", "evse");
+        set_constant(info, "name", "SmartEVSE v3.0");
+
+        Component status = find_or_create_component(_device_instance, "status", "DeviceStatus");
+        _online = add_element!bool(status, "online");
+
+        Component grid = find_or_create_component(_device_instance, "grid", "Port");
+        set_constant(grid, "role", "parent");
+        set_constant(grid, "flow", "consume");
+
+        Component control = find_or_create_component(grid, "control", "PowerControl");
+        set_constant(control, "kind", "continuous");
+        set_constant(control, "direction", "consume");
+        set_constant(control, "unit", "A");
+        set_constant(control, "min", DeciAmps(60));
+        set_constant(control, "step", DeciAmps(10));
+        set_constant(control, "can_disable", true);
+        _setpoint = add_element!DeciAmps(control, "setpoint", Access.read_write);
+        _control_max = add_element!DeciAmps(control, "max");
+        _enable = add_element!bool(control, "enable", Access.read_write);
+
+        Component car = find_or_create_component(_device_instance, "car", "Port");
+        set_constant(car, "role", "car");
+        set_constant(car, "flow", "supply");
+
+        Component evse_status = find_or_create_component(_device_instance, "evse", "EVSE");
+        _state = add_element!SmartEVSEState(evse_status, "state", Access.read_write);
+        _connected = add_element!bool(evse_status, "connected");
+        _temperature = add_element!DegreesC(evse_status, "temp");
+        _temperature_fault = add_element!bool(evse_status, "temperature_fault");
+        _rcm_fault = add_element!bool(evse_status, "rcm_fault");
+
+        Component config = find_or_create_component(_device_instance, "config", "Configuration");
+        _max_current = add_element!DeciAmps(config, "max_current", Access.read_write, SamplingMode.config);
+        _max_temperature = add_element!DegreesC(config, "max_temperature", Access.read_write, SamplingMode.config);
+        _contactor2_mode = add_element!SmartEVSEContactor2Mode(
+            config, "contactor2_mode", Access.read_write, SamplingMode.config);
+
+        Component diagnostic = find_or_create_component(
+            _device_instance, "diagnostic", "SmartEVSEDiagnostics");
+        _pilot = add_element!SmartEVSEPilot(diagnostic, "pilot");
+        _pwm = add_element!uint(diagnostic, "pwm");
+        _effective_current = add_element!DeciAmps(diagnostic, "effective_current");
+        _pp_max_current = add_element!DeciAmps(diagnostic, "pp_max_current");
+        _pilot_min = add_element!MilliVolts(diagnostic, "pilot_min");
+        _pilot_max = add_element!MilliVolts(diagnostic, "pilot_max");
+        _pp_voltage = add_element!MilliVolts(diagnostic, "pp_voltage");
+        _temperature_voltage = add_element!MilliVolts(diagnostic, "temperature_voltage");
+        _adc_calibration = add_element!SmartEVSEADCCalibration(diagnostic, "adc_calibration");
+        _rcm_input = add_element!bool(diagnostic, "rcm_input");
+        _activation_wait = add_element!ubyte(diagnostic, "activation_wait");
+        _activation_pulse = add_element!ubyte(diagnostic, "activation_pulse");
+        _contactor1 = add_element!bool(diagnostic, "contactor1");
+        _contactor2 = add_element!bool(diagnostic, "contactor2");
+
+        g_app.request_rebind();
+        _device_instance.notify(ComponentEvent.tree_changed);
+        _built = true;
+        return true;
+    }
+
+private:
+
+    ObjectRef!SmartEVSE _evse;
+    Device _device_instance;
+    bool _built;
+    bool _subscribed;
+
+    Element* _online;
+    Element* _setpoint;
+    Element* _control_max;
+    Element* _enable;
+    Element* _state;
+    Element* _connected;
+    Element* _temperature;
+    Element* _temperature_fault;
+    Element* _rcm_fault;
+    Element* _max_current;
+    Element* _max_temperature;
+    Element* _contactor2_mode;
+    Element* _pilot;
+    Element* _pwm;
+    Element* _effective_current;
+    Element* _pp_max_current;
+    Element* _pilot_min;
+    Element* _pilot_max;
+    Element* _pp_voltage;
+    Element* _temperature_voltage;
+    Element* _adc_calibration;
+    Element* _rcm_input;
+    Element* _activation_wait;
+    Element* _activation_pulse;
+    Element* _contactor1;
+    Element* _contactor2;
+
+    Component find_or_create_component(Component parent, const(char)[] id, const(char)[] template_)
+    {
+        foreach (component; parent.components)
+        {
+            if (component.id[] == id)
+                return component;
+        }
+        Component component = g_app.allocator.allocT!Component(String(id.addString()));
+        component.template_ = template_.addString();
+        component.parent = parent;
+        parent.components ~= component;
+        return component;
+    }
+
+    Element* add_element(T)(Component parent, const(char)[] id, Access access = Access.read,
+                            SamplingMode mode = SamplingMode.report)
+    {
+        Element* element = parent.find_or_create_element(id, register_value_format!T());
+        element.access = access;
+        element.sampling_mode = mode;
+        return element;
+    }
+
+    void set_constant(T)(Component parent, const(char)[] id, auto ref T value)
+    {
+        Element* element = parent.find_or_create_element(id, register_value_format(value));
+        if (element.sampling_mode != SamplingMode.constant)
+        {
+            element.value(value);
+            element.sampling_mode = SamplingMode.constant;
+        }
+    }
+
+    void subscribe_elements()
+    {
+        _setpoint.subscribe(&element_changed);
+        _enable.subscribe(&element_changed);
+        _state.subscribe(&element_changed);
+        _max_current.subscribe(&element_changed);
+        _max_temperature.subscribe(&element_changed);
+        _contactor2_mode.subscribe(&element_changed);
+    }
+
+    void unsubscribe()
+    {
+        if (!_subscribed)
+            return;
+
+        SmartEVSE hardware = _evse.get;
+        if (hardware)
+        {
+            hardware.unsubscribe_changes(&hardware_changed);
+            hardware.unsubscribe(&hardware_state_changed);
+        }
+        _setpoint.unsubscribe(&element_changed);
+        _enable.unsubscribe(&element_changed);
+        _state.unsubscribe(&element_changed);
+        _max_current.unsubscribe(&element_changed);
+        _max_temperature.unsubscribe(&element_changed);
+        _contactor2_mode.unsubscribe(&element_changed);
+        _subscribed = false;
+    }
+
+    void hardware_changed(SmartEVSE, uint changes)
+    {
+        publish(changes);
+    }
+
+    void hardware_state_changed(ActiveObject, StateSignal signal)
+    {
+        if (signal == StateSignal.destroyed)
+        {
+            restart();
+            return;
+        }
+        publish_online();
+    }
+
+    void publish(uint changes)
+    {
+        SmartEVSE hardware = _evse.get;
+        if (!hardware)
+            return;
+
+        auto timestamp = getSysTime();
+        if (changes & SmartEVSEChange.current)
+            _setpoint.value(hardware.current, timestamp, &element_changed);
+        if (changes & (SmartEVSEChange.max_current | SmartEVSEChange.pp_max_current))
+        {
+            DeciAmps maximum = hardware.max_current.value < hardware.pp_max_current.value
+                            ? hardware.max_current : hardware.pp_max_current;
+            _control_max.value(maximum, timestamp, &element_changed);
+        }
+        if (changes & SmartEVSEChange.max_current)
+            _max_current.value(hardware.max_current, timestamp, &element_changed);
+        if (changes & SmartEVSEChange.pp_max_current)
+            _pp_max_current.value(hardware.pp_max_current, timestamp, &element_changed);
+        if (changes & SmartEVSEChange.stopped)
+            _enable.value(!hardware.stopped, timestamp, &element_changed);
+        if (changes & SmartEVSEChange.state)
+        {
+            _state.value(hardware.state, timestamp, &element_changed);
+            _connected.value(connected(hardware), timestamp, &element_changed);
+        }
+        if (changes & SmartEVSEChange.pilot)
+        {
+            _pilot.value(hardware.pilot, timestamp, &element_changed);
+            _connected.value(connected(hardware), timestamp, &element_changed);
+        }
+        if (changes & SmartEVSEChange.pwm)
+            _pwm.value(hardware.pwm, timestamp, &element_changed);
+        if (changes & SmartEVSEChange.effective_current)
+            _effective_current.value(hardware.effective_current, timestamp, &element_changed);
+        if (changes & SmartEVSEChange.pilot_min_mv)
+            _pilot_min.value(MilliVolts(hardware.pilot_min_mv), timestamp, &element_changed);
+        if (changes & SmartEVSEChange.pilot_max_mv)
+            _pilot_max.value(MilliVolts(hardware.pilot_max_mv), timestamp, &element_changed);
+        if (changes & SmartEVSEChange.pp_mv)
+            _pp_voltage.value(MilliVolts(hardware.pp_mv), timestamp, &element_changed);
+        if (changes & SmartEVSEChange.temperature_mv)
+            _temperature_voltage.value(MilliVolts(hardware.temperature_mv), timestamp, &element_changed);
+        if (changes & SmartEVSEChange.temperature)
+            _temperature.value(DegreesC(hardware.temperature), timestamp, &element_changed);
+        if (changes & SmartEVSEChange.max_temperature)
+            _max_temperature.value(DegreesC(hardware.max_temperature), timestamp, &element_changed);
+        if (changes & SmartEVSEChange.temperature_fault)
+            _temperature_fault.value(hardware.temperature_fault, timestamp, &element_changed);
+        if (changes & SmartEVSEChange.rcm_input)
+            _rcm_input.value(hardware.rcm_input, timestamp, &element_changed);
+        if (changes & SmartEVSEChange.rcm_fault)
+            _rcm_fault.value(hardware.rcm_fault, timestamp, &element_changed);
+        if (changes & SmartEVSEChange.activation_wait)
+            _activation_wait.value(hardware.activation_wait, timestamp, &element_changed);
+        if (changes & SmartEVSEChange.activation_pulse)
+            _activation_pulse.value(hardware.activation_pulse, timestamp, &element_changed);
+        if (changes & SmartEVSEChange.contactor2_mode)
+            _contactor2_mode.value(hardware.contactor2_mode, timestamp, &element_changed);
+        if (changes & SmartEVSEChange.contactor1)
+            _contactor1.value(hardware.contactor1, timestamp, &element_changed);
+        if (changes & SmartEVSEChange.contactor2)
+            _contactor2.value(hardware.contactor2, timestamp, &element_changed);
+        if (changes == SmartEVSEChange.all)
+            _adc_calibration.value(hardware.adc_calibration, timestamp, &element_changed);
+    }
+
+    void publish_online()
+    {
+        SmartEVSE hardware = _evse.get;
+        bool online = hardware && hardware.running;
+        auto timestamp = getSysTime();
+        _online.value(online, timestamp, &element_changed);
+        _enable.value(online && !hardware.stopped, timestamp, &element_changed);
+    }
+
+    bool connected(SmartEVSE hardware) const pure
+    {
+        final switch (hardware.pilot)
+        {
+            case SmartEVSEPilot.v3:
+            case SmartEVSEPilot.v6:
+            case SmartEVSEPilot.v9:
+                return true;
+            case SmartEVSEPilot.invalid:
+            case SmartEVSEPilot.diode:
+            case SmartEVSEPilot.v12:
+            case SmartEVSEPilot.short_:
+                return false;
+        }
+    }
+
+    void element_changed(ref const SampleUpdate update)
+    {
+        if (!update.value_ready)
+            return;
+        SmartEVSE hardware = _evse.get;
+        if (!hardware)
+            return;
+
+        const(char)[] error;
+        uint restore;
+        if (update.element is _setpoint)
+        {
+            hardware.current(cast(DeciAmps)update.value.asQuantity());
+            restore = SmartEVSEChange.current;
+        }
+        else if (update.element is _enable)
+        {
+            error = update.value.asBool ? hardware.start_charging()
+                                        : hardware.stop_charging();
+            restore = SmartEVSEChange.stopped;
+        }
+        else if (update.element is _state)
+        {
+            error = hardware.state(cast(SmartEVSEState)update.value.asLong);
+            restore = SmartEVSEChange.state | SmartEVSEChange.rcm_fault;
+        }
+        else if (update.element is _max_current)
+        {
+            hardware.max_current(cast(DeciAmps)update.value.asQuantity());
+            restore = SmartEVSEChange.max_current | SmartEVSEChange.pp_max_current;
+        }
+        else if (update.element is _max_temperature)
+        {
+            hardware.max_temperature((cast(DegreesC)update.value.asQuantity()).value);
+            restore = SmartEVSEChange.max_temperature;
+        }
+        else if (update.element is _contactor2_mode)
+        {
+            error = hardware.contactor2_mode(
+                cast(SmartEVSEContactor2Mode)update.value.asLong);
+            restore = SmartEVSEChange.contactor2_mode;
+        }
+
+        if (error)
+        {
+            log.warning("SmartEVSE command rejected: ", error);
+            publish(restore);
+            if (update.element is _enable)
+                publish_online();
+        }
+    }
+}

--- a/src/driver/boards/smartevse/package.d
+++ b/src/driver/boards/smartevse/package.d
@@ -39,6 +39,8 @@
  * - Module-owned hardware lifetime and safe offline electrical outputs.
  * - Exclusive ActiveObject ownership, automatic charging on connection and
  *   explicit start/stop control.
+ * - Event-driven Device binding for charge current, start/stop, installation
+ *   limits, EVSE state, protection state and board diagnostics.
  * - RCM input monitoring. A cache-safe rising-edge callback first clears SSR1
  *   and SSR2, then latches a DRAM flag. The ActiveObject enters an error state
  *   and can acknowledge it only after the input clears.
@@ -113,8 +115,6 @@
  * - SmartEVSE v3.1 and v4 as separate explicit BOARD targets.
  *
  * TODO - OpenWatt integration:
- * - Bind EVSE state, requested/available current, faults, temperature,
- *   contactor policy and session start/stop into the Device data model.
  * - Define selective build components so the board can include IP, HTTP, TLS,
  *   API, sync and OTA without pulling unrelated modules.
  * - Build and size the actual UART-test and network/OTA feature sets
@@ -138,6 +138,7 @@ module driver.boards.smartevse;
 
 version (SmartEVSE):
 
+import urt.array : Array;
 import urt.meta : AliasSeq;
 import urt.meta.nullable : Nullable;
 import urt.atomic : MemoryOrder, atomicLoad, atomicStore;
@@ -155,6 +156,7 @@ import manager.console.session : Session;
 import manager.plugin : DeclareModule, Module;
 
 import driver.boards.smartevse.display;
+import driver.boards.smartevse.binding : SmartEVSEBinding;
 import driver.boards.smartevse.hardware;
 
 public import driver.boards.smartevse.evse;
@@ -171,6 +173,34 @@ struct SmartEVSEButton
     enum ubyte right  = 1 << 2;
 }
 
+struct SmartEVSEChange
+{
+    enum uint current             = 1 << 0;
+    enum uint max_current         = 1 << 1;
+    enum uint pp_max_current      = 1 << 2;
+    enum uint stopped             = 1 << 3;
+    enum uint state               = 1 << 4;
+    enum uint pilot               = 1 << 5;
+    enum uint pwm                 = 1 << 6;
+    enum uint effective_current   = 1 << 7;
+    enum uint pilot_min_mv        = 1 << 8;
+    enum uint pilot_max_mv        = 1 << 9;
+    enum uint pp_mv               = 1 << 10;
+    enum uint temperature_mv      = 1 << 11;
+    enum uint temperature         = 1 << 12;
+    enum uint max_temperature     = 1 << 13;
+    enum uint temperature_fault   = 1 << 14;
+    enum uint rcm_input           = 1 << 15;
+    enum uint rcm_fault           = 1 << 16;
+    enum uint activation_wait     = 1 << 17;
+    enum uint activation_pulse    = 1 << 18;
+    enum uint contactor2_mode     = 1 << 19;
+    enum uint contactor1          = 1 << 20;
+    enum uint contactor2          = 1 << 21;
+    enum uint all                 = (1 << 22) - 1;
+}
+
+alias SmartEVSEChangeHandler = void delegate(SmartEVSE evse, uint changes) nothrow @nogc;
 enum SmartEVSEState : ubyte
 {
     a = STATE_A,
@@ -245,6 +275,18 @@ nothrow @nogc:
         super(collection_type_info!SmartEVSE, id, flags);
     }
 
+    void subscribe_changes(SmartEVSEChangeHandler handler)
+    {
+        foreach (existing; _change_handlers)
+            assert(existing !is handler, "SmartEVSE change handler already subscribed");
+        _change_handlers ~= handler;
+    }
+
+    void unsubscribe_changes(SmartEVSEChangeHandler handler) pure
+    {
+        _change_handlers.removeFirstSwapLast(handler);
+    }
+
     DeciAmps current() const pure
         => _current;
 
@@ -256,7 +298,7 @@ nothrow @nogc:
         mark_set!(typeof(this), "current")();
 
         apply_current();
-        sync_status();
+        sync_status(SmartEVSEChange.current);
     }
 
     DeciAmps max_current() const pure
@@ -270,7 +312,7 @@ nothrow @nogc:
         mark_set!(typeof(this), "max-current")();
 
         apply_current();
-        sync_status();
+        sync_status(SmartEVSEChange.max_current);
     }
 
     DeciAmps pp_max_current() const pure
@@ -329,6 +371,7 @@ nothrow @nogc:
             return;
         _max_temperature = value;
         mark_set!(typeof(this), "max-temperature")();
+        notify_changes(SmartEVSEChange.max_temperature);
         restart();
     }
 
@@ -371,7 +414,7 @@ nothrow @nogc:
         _contactor2_mode = value;
         mark_set!(typeof(this), "contactor2-mode")();
         setContactor2Mode(cast(ubyte)value);
-        sync_status();
+        sync_status(SmartEVSEChange.contactor2_mode);
         return null;
     }
 
@@ -419,7 +462,7 @@ nothrow @nogc:
             mark_set!(typeof(this), "stopped")();
         }
         setAccess(1);
-        sync_status();
+        sync_status(SmartEVSEChange.stopped);
         return null;
     }
 
@@ -434,22 +477,25 @@ nothrow @nogc:
             mark_set!(typeof(this), "stopped")();
         }
         setAccess(0);
-        sync_status();
+        sync_status(SmartEVSEChange.stopped);
         return null;
     }
 
     void heartbeat(MonoTime)
     {
+        uint changes;
         Timer1S_singlerun();
-        sync_pp_max_current();
+        if (sync_pp_max_current())
+            changes |= SmartEVSEChange.pp_max_current;
         short next_temperature = TemperatureSensor();
         if (_temperature != next_temperature)
         {
             _temperature = next_temperature;
             mark_set!(typeof(this), "temperature")();
+            changes |= SmartEVSEChange.temperature;
         }
-        update_temperature_protection();
-        sync_status();
+        changes |= update_temperature_protection();
+        sync_status(changes);
     }
 
 protected:
@@ -491,22 +537,25 @@ protected:
             mark_set!(typeof(this), "rcm-fault")();
             setRCMFault(true);
             setState(STATE_ERROR);
-            sync_status();
+            sync_status(SmartEVSEChange.rcm_fault);
             log.error("RCM fault active during SmartEVSE startup");
             return CompletionStatus.error;
         }
 
         setRCMFault(false);
-        sync_pp_max_current();
+        uint changes;
+        if (sync_pp_max_current())
+            changes |= SmartEVSEChange.pp_max_current;
         if (_stopped)
         {
             _stopped = false;
             mark_set!(typeof(this), "stopped")();
+            changes |= SmartEVSEChange.stopped;
         }
         setState(STATE_A);
         setAccess(1);
         arm_control_tick(getTime() + msecs(10));
-        sync_status();
+        sync_status(changes);
         return CompletionStatus.complete;
     }
 
@@ -523,21 +572,23 @@ protected:
 
         setAccess(0);
         RCmonCtrl(DISABLE);
+        uint changes;
         if (_stopped)
         {
             _stopped = false;
             mark_set!(typeof(this), "stopped")();
+            changes |= SmartEVSEChange.stopped;
         }
         if (_rcm_fault)
         {
             setState(STATE_ERROR);
-            sync_status();
+            sync_status(changes);
         }
         _active_hardware_owner = null;
         hardware_offline();
         _hardware_owner = _hardware_module;
         if (!_rcm_fault)
-            sync_status();
+            sync_status(changes);
         return CompletionStatus.complete;
     }
 
@@ -550,6 +601,7 @@ private:
     bool _temperature_fault;
     bool _rcm_fault;
     bool _rcm_monitor;
+    bool _rcm_input;
     bool _tick_armed;
     DeciAmps _current = DeciAmps(MIN_CURRENT * 10);
     DeciAmps _max_current = DeciAmps(MAX_CURRENT);
@@ -567,6 +619,7 @@ private:
     SmartEVSEState _state = SmartEVSEState.a;
     SmartEVSEPilot _pilot = SmartEVSEPilot.invalid;
     SmartEVSEContactor2Mode _contactor2_mode = SmartEVSEContactor2Mode.always_follow;
+    Array!SmartEVSEChangeHandler _change_handlers;
 
     void arm_control_tick(MonoTime when)
     {
@@ -588,19 +641,20 @@ private:
             SetCurrent(ChargeCurrent);
     }
 
-    void sync_pp_max_current()
+    bool sync_pp_max_current()
     {
         MaxCapacity = ProximityPin();
         DeciAmps next = DeciAmps(cast(ushort)(MaxCapacity * 10));
         if (_pp_max_current == next)
-            return;
+            return false;
 
         _pp_max_current = next;
         mark_set!(typeof(this), "pp-max-current")();
         apply_current();
+        return true;
     }
 
-    void update_temperature_protection()
+    uint update_temperature_protection()
     {
         if (!_temperature_fault && _temperature > _max_temperature)
         {
@@ -609,6 +663,7 @@ private:
             setTemperatureFault(true);
             setStatePowerUnavailable();
             log.error("SmartEVSE over-temperature fault");
+            return SmartEVSEChange.temperature_fault;
         }
         else if (_temperature_fault
               && _temperature < _max_temperature - TEMPERATURE_HYSTERESIS)
@@ -617,7 +672,9 @@ private:
             mark_set!(typeof(this), "temperature-fault")();
             setTemperatureFault(false);
             log.info("SmartEVSE temperature recovered");
+            return SmartEVSEChange.temperature_fault;
         }
+        return 0;
     }
 
     const(char)[] reset_fault()
@@ -632,11 +689,14 @@ private:
         setRCMFault(false);
         _rcm_fault = false;
         mark_set!(typeof(this), "rcm-fault")();
+        uint changes = SmartEVSEChange.rcm_input | SmartEVSEChange.rcm_fault;
         if (_state != SmartEVSEState.a)
         {
             _state = SmartEVSEState.a;
             mark_set!(typeof(this), "state")();
+            changes |= SmartEVSEChange.state;
         }
+        notify_changes(changes);
         restart();
         return null;
     }
@@ -684,18 +744,19 @@ private:
         _rcm_fault = true;
         mark_set!(typeof(this), "rcm-fault")();
         setState(STATE_ERROR);
-        sync_status();
+        sync_status(SmartEVSEChange.rcm_fault);
         log.error("RCM fault latched");
         restart();
     }
 
-    void sync_status()
+    void sync_status(uint changes = 0)
     {
         SmartEVSEState next_state = cast(SmartEVSEState)CurrentState();
         if (_state != next_state)
         {
             _state = next_state;
             mark_set!(typeof(this), "state")();
+            changes |= SmartEVSEChange.state;
         }
 
         SmartEVSEPilot next_pilot = cast(SmartEVSEPilot)Pilot();
@@ -703,58 +764,91 @@ private:
         {
             _pilot = next_pilot;
             mark_set!(typeof(this), "pilot")();
+            changes |= SmartEVSEChange.pilot;
         }
 
         if (_current_pwm != CurrentPWM)
         {
             _current_pwm = CurrentPWM;
             mark_set!(typeof(this), "pwm")();
+            changes |= SmartEVSEChange.pwm;
         }
         DeciAmps next_effective_current = DeciAmps(GetCurrent());
         if (_effective_current != next_effective_current)
         {
             _effective_current = next_effective_current;
             mark_set!(typeof(this), "effective-current")();
+            changes |= SmartEVSEChange.effective_current;
         }
         if (_pilot_min_mv != PilotMinMV)
         {
             _pilot_min_mv = PilotMinMV;
             mark_set!(typeof(this), "pilot-min-mv")();
+            changes |= SmartEVSEChange.pilot_min_mv;
         }
         if (_pilot_max_mv != PilotMaxMV)
         {
             _pilot_max_mv = PilotMaxMV;
             mark_set!(typeof(this), "pilot-max-mv")();
+            changes |= SmartEVSEChange.pilot_max_mv;
         }
         if (_pp_mv != PPVoltageMV)
         {
             _pp_mv = PPVoltageMV;
             mark_set!(typeof(this), "pp-mv")();
+            changes |= SmartEVSEChange.pp_mv;
         }
         if (_temperature_mv != TemperatureVoltageMV)
         {
             _temperature_mv = TemperatureVoltageMV;
             mark_set!(typeof(this), "temperature-mv")();
+            changes |= SmartEVSEChange.temperature_mv;
+        }
+        bool next_rcm_input = gpio_input_read(RCMFAULT);
+        if (_rcm_input != next_rcm_input)
+        {
+            _rcm_input = next_rcm_input;
+            mark_set!(typeof(this), "rcm-input")();
+            changes |= SmartEVSEChange.rcm_input;
         }
         if (_activation_wait != ActivationMode)
         {
             _activation_wait = ActivationMode;
             mark_set!(typeof(this), "activation-wait")();
+            changes |= SmartEVSEChange.activation_wait;
         }
         if (_activation_pulse != ActivationTimer)
         {
             _activation_pulse = ActivationTimer;
             mark_set!(typeof(this), "activation-pulse")();
+            changes |= SmartEVSEChange.activation_pulse;
         }
         if (_contactor1 != Contactor1)
         {
             _contactor1 = Contactor1;
             mark_set!(typeof(this), "contactor1")();
+            changes |= SmartEVSEChange.contactor1;
         }
         if (_contactor2 != Contactor2)
         {
             _contactor2 = Contactor2;
             mark_set!(typeof(this), "contactor2")();
+            changes |= SmartEVSEChange.contactor2;
+        }
+
+        notify_changes(changes);
+    }
+
+    void notify_changes(uint changes)
+    {
+        if (!changes)
+            return;
+        for (size_t i = 0; i < _change_handlers.length; )
+        {
+            SmartEVSEChangeHandler handler = _change_handlers[i];
+            handler(this, changes);
+            if (i < _change_handlers.length && _change_handlers[i] is handler)
+                ++i;
         }
     }
 }
@@ -772,6 +866,7 @@ nothrow @nogc:
         g_app.register_enum!SmartEVSEContactor2Mode();
         g_app.register_enum!SmartEVSEADCCalibration();
         g_app.console.register_collection!SmartEVSE();
+        g_app.console.register_collection!SmartEVSEBinding();
         g_app.console.register_command!cmd_start(
             "/driver/boards/smartevse", this, "start");
         g_app.console.register_command!cmd_stop(
@@ -809,6 +904,7 @@ nothrow @nogc:
     override void update()
     {
         Collection!SmartEVSE().update_all();
+        Collection!SmartEVSEBinding().update_all();
         if (_hardware_ready)
             display_update(g_display);
     }


### PR DESCRIPTION
Summary:
- model the SmartEVSE charger as Device, Component, and Element state
- translate writable element changes into charger controls
- publish charger state and diagnostics back into elements

This is intentionally separate from the board controller and from the display/panel path.

Validation:
- clean BOARD=smartevse-v30 CONFIG=release D compile